### PR TITLE
remove fileNameSuffix from cribl lake output.

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,19 +1,19 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: 37ceb130a95783bb431ab956c8772b05
+  docChecksum: c61aa4935fb5b17294aca2000efc231a
   docVersion: 4.12.2-4b17c8d4
-  speakeasyVersion: 1.603.0
-  generationVersion: 2.681.1
-  releaseVersion: 1.9.2
-  configChecksum: 9d2d3205b20aa997a3acf7ad0d2dd6dc
+  speakeasyVersion: 1.605.1
+  generationVersion: 2.684.0
+  releaseVersion: 1.9.3
+  configChecksum: b41f2d1edba4283f25e82ac2900e34a3
   published: true
 features:
   terraform:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.2
     constsAndDefaults: 0.2.1
-    core: 3.44.0
+    core: 3.44.1
     deprecations: 2.82.0
     getRequestBodies: 2.81.1
     globalSecurity: 2.81.12

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -21,7 +21,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.9.2
+  version: 1.9.3
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.603.0
+speakeasyVersion: 1.605.1
 sources:
     Cribl Control Plane and Management API:
         sourceNamespace: cribl-control-plane-and-management-api

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.9.2"
+      version = "1.9.3"
     }
   }
 }

--- a/docs/resources/destination.md
+++ b/docs/resources/destination.md
@@ -624,7 +624,6 @@ resource "criblio_destination" "my_destination" {
     enable_assume_role                = false
     endpoint                          = "...my_endpoint..."
     environment                       = "...my_environment..."
-    file_name_suffix                  = "...my_file_name_suffix..."
     format                            = "json"
     header_line                       = "...my_header_line..."
     id                                = "...my_id..."
@@ -4824,7 +4823,6 @@ Optional:
 - `enable_assume_role` (Boolean) Use Assume Role credentials to access S3. Default: false
 - `endpoint` (String) S3 service endpoint. If empty, defaults to the AWS Region-specific endpoint. Otherwise, it must point to S3-compatible endpoint.
 - `environment` (String) Optionally, enable this config only on a specified Git branch. If empty, will be enabled everywhere.
-- `file_name_suffix` (String) JavaScript expression to define the output filename suffix (can be constant).  The `__format` variable refers to the value of the `Data format` field (`json` or `raw`).  The `__compression` field refers to the kind of compression being used (`none` or `gzip`). Default: "`.${C.env[\"CRIBL_WORKER_ID\"]}.${__format}${__compression === \"gzip\" ? \".gz\" : \"\"}`"
 - `format` (String) must be one of ["json", "parquet", "ddss"]
 - `header_line` (String) If set, this line will be written to the beginning of each output file. Default: ""
 - `kms_key_id` (String) ID or ARN of the KMS customer-managed key to use for encryption

--- a/docs/resources/pack_destination.md
+++ b/docs/resources/pack_destination.md
@@ -624,7 +624,6 @@ resource "criblio_pack_destination" "my_packdestination" {
     enable_assume_role                = false
     endpoint                          = "...my_endpoint..."
     environment                       = "...my_environment..."
-    file_name_suffix                  = "...my_file_name_suffix..."
     format                            = "ddss"
     header_line                       = "...my_header_line..."
     id                                = "...my_id..."
@@ -4826,7 +4825,6 @@ Optional:
 - `enable_assume_role` (Boolean) Use Assume Role credentials to access S3. Default: false
 - `endpoint` (String) S3 service endpoint. If empty, defaults to the AWS Region-specific endpoint. Otherwise, it must point to S3-compatible endpoint.
 - `environment` (String) Optionally, enable this config only on a specified Git branch. If empty, will be enabled everywhere.
-- `file_name_suffix` (String) JavaScript expression to define the output filename suffix (can be constant).  The `__format` variable refers to the value of the `Data format` field (`json` or `raw`).  The `__compression` field refers to the kind of compression being used (`none` or `gzip`). Default: "`.${C.env[\"CRIBL_WORKER_ID\"]}.${__format}${__compression === \"gzip\" ? \".gz\" : \"\"}`"
 - `format` (String) must be one of ["json", "parquet", "ddss"]
 - `header_line` (String) If set, this line will be written to the beginning of each output file. Default: ""
 - `kms_key_id` (String) ID or ARN of the KMS customer-managed key to use for encryption

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.9.2"
+      version = "1.9.3"
     }
   }
 }

--- a/examples/resources/criblio_destination/resource.tf
+++ b/examples/resources/criblio_destination/resource.tf
@@ -609,7 +609,6 @@ resource "criblio_destination" "my_destination" {
     enable_assume_role                = false
     endpoint                          = "...my_endpoint..."
     environment                       = "...my_environment..."
-    file_name_suffix                  = "...my_file_name_suffix..."
     format                            = "json"
     header_line                       = "...my_header_line..."
     id                                = "...my_id..."

--- a/examples/resources/criblio_pack_destination/resource.tf
+++ b/examples/resources/criblio_pack_destination/resource.tf
@@ -609,7 +609,6 @@ resource "criblio_pack_destination" "my_packdestination" {
     enable_assume_role                = false
     endpoint                          = "...my_endpoint..."
     environment                       = "...my_environment..."
-    file_name_suffix                  = "...my_file_name_suffix..."
     format                            = "ddss"
     header_line                       = "...my_header_line..."
     id                                = "...my_id..."

--- a/examples/stream-syslog-to-lake/main.tf
+++ b/examples/stream-syslog-to-lake/main.tf
@@ -102,7 +102,6 @@ resource "criblio_destination" "cribl_lake" {
     add_id_to_stage_path              = true
     aws_authentication_method         = "auto"
     base_file_name                    = "CriblOut"
-    file_name_suffix                  = "'.gz'"
     max_file_size_mb                  = 32
     max_open_files                    = 100
     write_high_water_mark             = 64

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-validators v0.17.0
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
-	github.com/hashicorp/terraform-plugin-testing v1.13.2
+	github.com/hashicorp/terraform-plugin-testing v1.13.3
 	golang.org/x/sync v0.15.0
 	gopkg.in/ini.v1 v1.67.0
 )

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9T
 github.com/hashicorp/terraform-plugin-log v0.9.0/go.mod h1:rKL8egZQ/eXSyDqzLUuwUYLVdlYeamldAHSxjUFADow=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0 h1:NFPMacTrY/IdcIcnUB+7hsore1ZaRWU9cnB6jFoBnIM=
 github.com/hashicorp/terraform-plugin-sdk/v2 v2.37.0/go.mod h1:QYmYnLfsosrxjCnGY1p9c7Zj6n9thnEE+7RObeYs3fA=
-github.com/hashicorp/terraform-plugin-testing v1.13.2 h1:mSotG4Odl020vRjIenA3rggwo6Kg6XCKIwtRhYgp+/M=
-github.com/hashicorp/terraform-plugin-testing v1.13.2/go.mod h1:WHQ9FDdiLoneey2/QHpGM/6SAYf4A7AZazVg7230pLE=
+github.com/hashicorp/terraform-plugin-testing v1.13.3 h1:QLi/khB8Z0a5L54AfPrHukFpnwsGL8cwwswj4RZduCo=
+github.com/hashicorp/terraform-plugin-testing v1.13.3/go.mod h1:WHQ9FDdiLoneey2/QHpGM/6SAYf4A7AZazVg7230pLE=
 github.com/hashicorp/terraform-registry-address v0.2.5 h1:2GTftHqmUhVOeuu9CW3kwDkRe4pcBDq0uuK5VJngU1M=
 github.com/hashicorp/terraform-registry-address v0.2.5/go.mod h1:PpzXWINwB5kuVS5CA7m1+eO2f1jKb5ZDIxrOPfpnGkg=
 github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S52uzrw4x0jKQ=

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -4072,12 +4072,6 @@ func (r *DestinationResource) Schema(ctx context.Context, req resource.SchemaReq
 						Optional:    true,
 						Description: `Optionally, enable this config only on a specified Git branch. If empty, will be enabled everywhere.`,
 					},
-					"file_name_suffix": schema.StringAttribute{
-						Computed:    true,
-						Optional:    true,
-						Default:     stringdefault.StaticString(`` + "`" + `.${C.env["CRIBL_WORKER_ID"]}.${__format}${__compression === "gzip" ? ".gz" : ""}` + "`" + ``),
-						Description: `JavaScript expression to define the output filename suffix (can be constant).  The ` + "`" + `__format` + "`" + ` variable refers to the value of the ` + "`" + `Data format` + "`" + ` field (` + "`" + `json` + "`" + ` or ` + "`" + `raw` + "`" + `).  The ` + "`" + `__compression` + "`" + ` field refers to the kind of compression being used (` + "`" + `none` + "`" + ` or ` + "`" + `gzip` + "`" + `). Default: "` + "`" + `.${C.env[\"CRIBL_WORKER_ID\"]}.${__format}${__compression === \"gzip\" ? \".gz\" : \"\"}` + "`" + `"`,
-					},
 					"format": schema.StringAttribute{
 						Optional:    true,
 						Description: `must be one of ["json", "parquet", "ddss"]`,

--- a/internal/provider/destination_resource_sdk.go
+++ b/internal/provider/destination_resource_sdk.go
@@ -18635,12 +18635,6 @@ func (r *DestinationResourceModel) ToSharedOutput(ctx context.Context) (*shared.
 		} else {
 			baseFileName7 = nil
 		}
-		fileNameSuffix7 := new(string)
-		if !r.OutputCriblLake.FileNameSuffix.IsUnknown() && !r.OutputCriblLake.FileNameSuffix.IsNull() {
-			*fileNameSuffix7 = r.OutputCriblLake.FileNameSuffix.ValueString()
-		} else {
-			fileNameSuffix7 = nil
-		}
 		maxFileSizeMb9 := new(float64)
 		if !r.OutputCriblLake.MaxFileSizeMB.IsUnknown() && !r.OutputCriblLake.MaxFileSizeMB.IsNull() {
 			*maxFileSizeMb9 = r.OutputCriblLake.MaxFileSizeMB.ValueFloat64()
@@ -18776,7 +18770,6 @@ func (r *DestinationResourceModel) ToSharedOutput(ctx context.Context) (*shared.
 			KmsKeyID:                      kmsKeyId3,
 			RemoveEmptyDirs:               removeEmptyDirs9,
 			BaseFileName:                  baseFileName7,
-			FileNameSuffix:                fileNameSuffix7,
 			MaxFileSizeMB:                 maxFileSizeMb9,
 			MaxOpenFiles:                  maxOpenFiles9,
 			HeaderLine:                    headerLine7,

--- a/internal/provider/packdestination_resource.go
+++ b/internal/provider/packdestination_resource.go
@@ -4073,12 +4073,6 @@ func (r *PackDestinationResource) Schema(ctx context.Context, req resource.Schem
 						Optional:    true,
 						Description: `Optionally, enable this config only on a specified Git branch. If empty, will be enabled everywhere.`,
 					},
-					"file_name_suffix": schema.StringAttribute{
-						Computed:    true,
-						Optional:    true,
-						Default:     stringdefault.StaticString(`` + "`" + `.${C.env["CRIBL_WORKER_ID"]}.${__format}${__compression === "gzip" ? ".gz" : ""}` + "`" + ``),
-						Description: `JavaScript expression to define the output filename suffix (can be constant).  The ` + "`" + `__format` + "`" + ` variable refers to the value of the ` + "`" + `Data format` + "`" + ` field (` + "`" + `json` + "`" + ` or ` + "`" + `raw` + "`" + `).  The ` + "`" + `__compression` + "`" + ` field refers to the kind of compression being used (` + "`" + `none` + "`" + ` or ` + "`" + `gzip` + "`" + `). Default: "` + "`" + `.${C.env[\"CRIBL_WORKER_ID\"]}.${__format}${__compression === \"gzip\" ? \".gz\" : \"\"}` + "`" + `"`,
-					},
 					"format": schema.StringAttribute{
 						Optional:    true,
 						Description: `must be one of ["json", "parquet", "ddss"]`,

--- a/internal/provider/packdestination_resource_sdk.go
+++ b/internal/provider/packdestination_resource_sdk.go
@@ -18651,12 +18651,6 @@ func (r *PackDestinationResourceModel) ToSharedOutput(ctx context.Context) (*sha
 		} else {
 			baseFileName7 = nil
 		}
-		fileNameSuffix7 := new(string)
-		if !r.OutputCriblLake.FileNameSuffix.IsUnknown() && !r.OutputCriblLake.FileNameSuffix.IsNull() {
-			*fileNameSuffix7 = r.OutputCriblLake.FileNameSuffix.ValueString()
-		} else {
-			fileNameSuffix7 = nil
-		}
 		maxFileSizeMb9 := new(float64)
 		if !r.OutputCriblLake.MaxFileSizeMB.IsUnknown() && !r.OutputCriblLake.MaxFileSizeMB.IsNull() {
 			*maxFileSizeMb9 = r.OutputCriblLake.MaxFileSizeMB.ValueFloat64()
@@ -18792,7 +18786,6 @@ func (r *PackDestinationResourceModel) ToSharedOutput(ctx context.Context) (*sha
 			KmsKeyID:                      kmsKeyId3,
 			RemoveEmptyDirs:               removeEmptyDirs9,
 			BaseFileName:                  baseFileName7,
-			FileNameSuffix:                fileNameSuffix7,
 			MaxFileSizeMB:                 maxFileSizeMb9,
 			MaxOpenFiles:                  maxOpenFiles9,
 			HeaderLine:                    headerLine7,

--- a/internal/provider/types/output_cribl_lake.go
+++ b/internal/provider/types/output_cribl_lake.go
@@ -23,7 +23,6 @@ type OutputCriblLake struct {
 	EnableAssumeRole              types.Bool     `tfsdk:"enable_assume_role"`
 	Endpoint                      types.String   `tfsdk:"endpoint"`
 	Environment                   types.String   `tfsdk:"environment"`
-	FileNameSuffix                types.String   `tfsdk:"file_name_suffix"`
 	Format                        types.String   `tfsdk:"format"`
 	HeaderLine                    types.String   `tfsdk:"header_line"`
 	ID                            types.String   `tfsdk:"id"`

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 4.12.2-4b17c8d4 and generator version 2.681.1
+// Generated from OpenAPI doc version 4.12.2-4b17c8d4 and generator version 2.684.0
 
 import (
 	"context"
@@ -393,9 +393,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.9.2",
+		SDKVersion: "1.9.3",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.9.2 2.681.1 4.12.2-4b17c8d4 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.9.3 2.684.0 4.12.2-4b17c8d4 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/openapi.yml
+++ b/openapi.yml
@@ -43420,6 +43420,7 @@ components:
             to the kind of compression being used (`none` or `gzip`).
           default: '`.${C.env["CRIBL_WORKER_ID"]}.${__format}${__compression === "gzip" ?
             ".gz" : ""}`'
+          x-speakeasy-terraform-ignore: true
         maxFileSizeMB:
           type: number
           title: File size limit (MB)


### PR DESCRIPTION
This PR just removes exposing fileNameSuffix from TF configuration of output_cribl_lake.