### PR TITLE
Update links to product documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ page_title: "criblio Provider"
 description: |-
   Cribl Terraform Provider: The Cribl Terraform provider offers a streamlined, repeatable approach for configuring end-to-end infrastructure as code (IaC) and managing resources consistently across Cribl Organizations and Workspaces.
   This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
-  Complementary API reference documentation is available at https://docs.cribl.io/api-reference/. Product documentation is available at https://docs.cribl.io.
+  Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
 ---
 
 # criblio Provider
@@ -13,7 +13,7 @@ Cribl Terraform Provider: The Cribl Terraform provider offers a streamlined, rep
 
 This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
 
-Complementary API reference documentation is available at https://docs.cribl.io/api-reference/. Product documentation is available at https://docs.cribl.io.
+Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
 
 ## Example Usage
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,7 +87,7 @@ func (p *CriblioProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			`` + "\n" +
 			`This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.` + "\n" +
 			`` + "\n" +
-			`Complementary API reference documentation is available at https://docs.cribl.io/api-reference/. Product documentation is available at https://docs.cribl.io.`,
+			`Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.`,
 	}
 }
 

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -55,7 +55,7 @@ func Pointer[T any](v T) *T { return &v }
 //
 // This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
 //
-// Complementary API reference documentation is available at https://docs.cribl.io/api-reference/. Product documentation is available at https://docs.cribl.io.
+// Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
 type CriblIo struct {
 	SDKVersion string
 	// Actions related to REST server health


### PR DESCRIPTION
Replaces placeholder links to the Cribl API Reference with updated links for the MVP docs for Cribl as Code.

The links to the Cribl as Code docs will not work until the docs are published (planned for 10/8/25 or 10/9/25).