### PR TITLE
Update link to API Reference in docs/index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ page_title: "criblio Provider"
 description: |-
   Cribl Terraform Provider: The Cribl Terraform provider offers a streamlined, repeatable approach for configuring end-to-end infrastructure as code (IaC) and managing resources consistently across Cribl Organizations and Workspaces.
   This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
-  Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
+  Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/. Product documentation is available at https://docs.cribl.io.
 ---
 
 # criblio Provider


### PR DESCRIPTION
Because of the way we are publishing the API Reference in the docs, the page at https://docs.cribl.io/cribl-as-code/api-reference/ does not display any of the API reference. We are currently using https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/ as the API Reference landing page in the docs.

This PR updates the URL in the description in the front matter of /docs/index.md to https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/.