### PR TITLE
improving retry logic and adding exponential backoff.

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 4.14.0
   speakeasyVersion: 1.658.2
   generationVersion: 2.755.9
-  releaseVersion: 1.20.71
-  configChecksum: f9e3c38b7bd12ddcc7fd824459bffe02
+  releaseVersion: 1.20.72
+  configChecksum: 6d6cddabdcbd64970e97dcebe2cbd0ea
   published: true
 features:
   terraform:

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 4.14.0
   speakeasyVersion: 1.658.2
   generationVersion: 2.755.9
-  releaseVersion: 1.20.70
-  configChecksum: f55c7af138303d9aca2e90bd90720664
+  releaseVersion: 1.20.71
+  configChecksum: f9e3c38b7bd12ddcc7fd824459bffe02
   published: true
 features:
   terraform:

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 4.14.0
   speakeasyVersion: 1.658.2
   generationVersion: 2.755.9
-  releaseVersion: 1.20.69
-  configChecksum: b0a00e6a3d6cbe51baca42e4f9066758
+  releaseVersion: 1.20.70
+  configChecksum: f55c7af138303d9aca2e90bd90720664
   published: true
 features:
   terraform:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.20.70
+  version: 1.20.71
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.20.71
+  version: 1.20.72
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.20.69
+  version: 1.20.70
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.70"
+      version = "1.20.71"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.71"
+      version = "1.20.72"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.69"
+      version = "1.20.70"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.71"
+      version = "1.20.72"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.70"
+      version = "1.20.71"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.69"
+      version = "1.20.70"
     }
   }
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
+	github.com/hashicorp/go-retryablehttp v0.7.7
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.22.0
 	github.com/hashicorp/terraform-plugin-framework v1.15.1
@@ -44,7 +45,6 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
-	github.com/hashicorp/go-retryablehttp v0.7.7 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hc-install v0.9.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.24.0 // indirect

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -358,9 +358,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.20.69",
+		SDKVersion: "1.20.70",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.20.69 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.20.70 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -358,9 +358,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.20.71",
+		SDKVersion: "1.20.72",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.20.71 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.20.72 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -358,9 +358,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.20.70",
+		SDKVersion: "1.20.71",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.20.70 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.20.71 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/internal/sdk/internal/hooks/cribl_terraform_hook_test.go
+++ b/internal/sdk/internal/hooks/cribl_terraform_hook_test.go
@@ -1648,8 +1648,9 @@ func TestDoRequestWithRetryMaxRetriesExhausted(t *testing.T) {
 		t.Errorf("Expected error about failed request, got: %v", err)
 	}
 
-	if attemptCount != 3 {
-		t.Errorf("Expected 3 attempts (max retries), got %d", attemptCount)
+	// go-retryablehttp with RetryMax=3 means 1 initial attempt + 3 retries = 4 total attempts
+	if attemptCount != 4 {
+		t.Errorf("Expected 4 attempts (1 initial + 3 retries), got %d", attemptCount)
 	}
 
 	// Clean up
@@ -1743,8 +1744,9 @@ func TestDoRequestWithRetryContextCancellation(t *testing.T) {
 		t.Fatalf("Expected error due to context cancellation but got success")
 	}
 
-	if !strings.Contains(err.Error(), "request cancelled") {
-		t.Errorf("Expected cancellation error, got: %v", err)
+	// go-retryablehttp returns "context canceled" in the error message
+	if !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("Expected cancellation error containing 'context canceled', got: %v", err)
 	}
 
 	// Clean up


### PR DESCRIPTION
- Retries on response body read errors: When io.ReadAll(resp.Body) fails with "unexpected EOF" (connection closed prematurely), the code now retries the entire request instead of failing immediately.
- Handles request body reuse: HTTP request bodies are single-use. The fix:
- Stores the request body bytes before the first attempt
- Restores the body for each retry (using req.GetBody() if available, or recreating it)
- Ensures retries can send the request again
- Exponential backoff: Uses exponential backoff with jitter (500ms → ~750ms → ~1.1s) to avoid overwhelming the server