### PR TITLE
updating group schema and adding monkey patching to ignore default gr…

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -14,3 +14,4 @@ internal/provider/searchdatasetprovider_resource_sdk.go
 internal/provider/searchdataset_resource_sdk.go
 internal/provider/searchdatasetprovider_resource.go
 internal/provider/searchdataset_resource.go
+internal/provider/group_resource.go

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: 7f51adc0f12f5232371b039be1d7ceea
+  docChecksum: b8c7f1f39673a27c7431f0c46a14cdfd
   docVersion: 4.14.0
   speakeasyVersion: 1.658.2
   generationVersion: 2.755.9
-  releaseVersion: 1.20.72
-  configChecksum: 6d6cddabdcbd64970e97dcebe2cbd0ea
+  releaseVersion: 1.20.75
+  configChecksum: 153b0f9b70bfb82ca77dce9f45e793b6
   published: true
 features:
   terraform:
@@ -287,7 +287,6 @@ generatedFiles:
   - internal/provider/grok_resource_sdk.go
   - internal/provider/group_data_source.go
   - internal/provider/group_data_source_sdk.go
-  - internal/provider/group_resource.go
   - internal/provider/group_resource_sdk.go
   - internal/provider/groupsystemsettings_data_source.go
   - internal/provider/groupsystemsettings_data_source_sdk.go
@@ -7240,7 +7239,7 @@ examples:
         path:
           product: "stream"
       requestBody:
-        application/json: {"cloud": {"provider": "aws", "region": "us-east-1"}, "configVersion": "v12", "deployingWorkerCount": 3, "description": "Production Edge configuration group", "estimatedIngestRate": 500000, "git": {"commit": "1a2b3c4d5e6f", "localChanges": 0, "log": [{"author_email": "dev@acme.com", "author_name": "Acme Dev", "date": "2025-10-06T12:00:00Z", "hash": "1a2b3c4d5e6f7g8h9i0j", "message": "Deploy config for prod edge group", "short": "1a2b3c4"}]}, "id": "config-group-prod-edge", "incompatibleWorkerCount": 0, "inherits": "base-config", "isFleet": false, "isSearch": false, "lookupDeployments": [{"context": "prod", "lookups": [{"deployedVersion": "v3", "file": "lookups/ip_to_region.csv", "version": "v4"}]}], "name": "Prod Edge", "onPrem": true, "provisioned": true, "streamtags": ["prod", "edge"], "tags": "environment=prod,team=platform", "type": "lake_access", "upgradeVersion": "6.0.1", "workerCount": 12, "workerRemoteAccess": true, "maxWorkerAge": "1h"}
+        application/json: {"cloud": {"provider": "aws", "region": "us-east-1"}, "configVersion": "v12", "deployingWorkerCount": 3, "description": "Production Edge configuration group", "estimatedIngestRate": 500000, "git": {"commit": "1a2b3c4d5e6f", "localChanges": 0, "log": [{"author_email": "dev@acme.com", "author_name": "Acme Dev", "date": "2025-10-06T12:00:00Z", "hash": "1a2b3c4d5e6f7g8h9i0j", "message": "Deploy config for prod edge group", "short": "1a2b3c4"}]}, "id": "config-group-prod-edge", "incompatibleWorkerCount": 0, "inherits": "base-config", "isFleet": false, "isSearch": false, "lookupDeployments": [{"context": "prod", "lookups": [{"deployedVersion": "v3", "file": "lookups/ip_to_region.csv", "version": "v4"}]}], "name": "Prod Edge", "onPrem": true, "provisioned": true, "streamtags": ["prod", "edge"], "tags": "environment=prod,team=platform", "upgradeVersion": "6.0.1", "workerCount": 12, "workerRemoteAccess": true, "maxWorkerAge": "1h"}
       responses:
         "200":
           application/json: {"items": [{"cloud": {"provider": "aws", "region": "us-east-1"}, "estimatedIngestRate": 250000, "id": "grp-prod-edge", "isFleet": false, "name": "edge-group-prod", "onPrem": false, "provisioned": true, "streamtags": ["prod", "web"], "workerRemoteAccess": true}]}
@@ -7297,7 +7296,7 @@ examples:
         path:
           id: "workers-west"
       requestBody:
-        application/json: {"cloud": {"provider": "aws", "region": "us-east-1"}, "configVersion": "v12", "deployingWorkerCount": 3, "description": "Production Edge configuration group", "estimatedIngestRate": 500000, "git": {"commit": "1a2b3c4d5e6f", "localChanges": 0, "log": [{"author_email": "dev@acme.com", "author_name": "Acme Dev", "date": "2025-10-06T12:00:00Z", "hash": "1a2b3c4d5e6f7g8h9i0j", "message": "Deploy config for prod edge group", "short": "1a2b3c4"}]}, "id": "config-group-prod-edge", "incompatibleWorkerCount": 0, "inherits": "base-config", "isFleet": false, "isSearch": false, "lookupDeployments": [{"context": "prod", "lookups": [{"deployedVersion": "v3", "file": "lookups/ip_to_region.csv", "version": "v4"}]}], "name": "Prod Edge", "onPrem": true, "provisioned": true, "streamtags": ["prod", "edge"], "tags": "environment=prod,team=platform", "type": "lake_access", "upgradeVersion": "6.0.1", "workerCount": 12, "workerRemoteAccess": true, "maxWorkerAge": "1h"}
+        application/json: {"cloud": {"provider": "aws", "region": "us-east-1"}, "configVersion": "v12", "deployingWorkerCount": 3, "description": "Production Edge configuration group", "estimatedIngestRate": 500000, "git": {"commit": "1a2b3c4d5e6f", "localChanges": 0, "log": [{"author_email": "dev@acme.com", "author_name": "Acme Dev", "date": "2025-10-06T12:00:00Z", "hash": "1a2b3c4d5e6f7g8h9i0j", "message": "Deploy config for prod edge group", "short": "1a2b3c4"}]}, "id": "config-group-prod-edge", "incompatibleWorkerCount": 0, "inherits": "base-config", "isFleet": false, "isSearch": false, "lookupDeployments": [{"context": "prod", "lookups": [{"deployedVersion": "v3", "file": "lookups/ip_to_region.csv", "version": "v4"}]}], "name": "Prod Edge", "onPrem": true, "provisioned": true, "streamtags": ["prod", "edge"], "tags": "environment=prod,team=platform", "upgradeVersion": "6.0.1", "workerCount": 12, "workerRemoteAccess": true, "maxWorkerAge": "1h"}
       responses:
         "200":
           application/json: {"items": [{"cloud": {"provider": "aws", "region": "us-east-1"}, "configVersion": "v12", "deployingWorkerCount": 3, "description": "Production Edge configuration group", "estimatedIngestRate": 500000, "git": {"commit": "1a2b3c4d5e6f", "localChanges": 0, "log": [{"author_email": "dev@acme.com", "author_name": "Acme Dev", "date": "2025-10-06T12:00:00Z", "hash": "1a2b3c4d5e6f7g8h9i0j", "message": "Deploy config for prod edge group", "short": "1a2b3c4"}]}, "id": "config-group-prod-edge", "incompatibleWorkerCount": 0, "inherits": "base-config", "isFleet": false, "isSearch": false, "lookupDeployments": [{"context": "prod", "lookups": [{"deployedVersion": "v3", "file": "lookups/ip_to_region.csv", "version": "v4"}]}], "name": "Prod Edge", "onPrem": true, "provisioned": true, "streamtags": ["prod", "edge"], "tags": "environment=prod,team=platform", "type": "lake_access", "upgradeVersion": "6.0.1", "workerCount": 12, "workerRemoteAccess": true, "maxWorkerAge": "1h"}]}

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.20.72
+  version: 1.20.75
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.658.2
 sources:
     Cribl Control Plane and Management API:
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:19016696246005e18f0f455587d5e1b23db7e101f9c686ecdaab60bc0d2872ae
-        sourceBlobDigest: sha256:f017bc43965eb33620a9d564d456d7b74c36002f929b1aa0fcbb6aadf450964b
+        sourceRevisionDigest: sha256:a8cd483773d0d437baceb1e27a34cc9cfc320c9e8e7cd9c8f8654fb79b580b7c
+        sourceBlobDigest: sha256:0848302697097ed2d32d68ed91612524204bef71542464211b4c9c7080223e3d
         tags:
             - latest
             - 4.14.0
@@ -11,8 +11,8 @@ targets:
     cribl-io:
         source: Cribl Control Plane and Management API
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:19016696246005e18f0f455587d5e1b23db7e101f9c686ecdaab60bc0d2872ae
-        sourceBlobDigest: sha256:f017bc43965eb33620a9d564d456d7b74c36002f929b1aa0fcbb6aadf450964b
+        sourceRevisionDigest: sha256:a8cd483773d0d437baceb1e27a34cc9cfc320c9e8e7cd9c8f8654fb79b580b7c
+        sourceBlobDigest: sha256:0848302697097ed2d32d68ed91612524204bef71542464211b4c9c7080223e3d
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.658.2

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.72"
+      version = "1.20.75"
     }
   }
 }

--- a/docs/resources/deploy.md
+++ b/docs/resources/deploy.md
@@ -44,7 +44,7 @@ Read-Only:
 - `is_fleet` (Boolean)
 - `max_worker_age` (String) This is only configurable for hybrid worker groups.
 - `name` (String)
-- `on_prem` (Boolean)
+- `on_prem` (Boolean) Whether this is an on-premises group. Cannot be true when cloud is set.
 - `provisioned` (Boolean)
 - `streamtags` (List of String)
 - `tags` (String)

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -33,7 +33,7 @@ resource "criblio_group" "my_group" {
     "edge",
   ]
   tags                 = "environment=prod,team=platform"
-  type                 = "lake_access"
+  type                 = "search"
   worker_remote_access = true
 }
 ```
@@ -44,7 +44,7 @@ resource "criblio_group" "my_group" {
 ### Required
 
 - `id` (String) Group id
-- `product` (String) Cribl Product. must be one of ["stream", "edge"]; Requires replacement if changed.
+- `product` (String) Cribl Product. must be one of ["stream", "edge"].
 
 ### Optional
 
@@ -59,7 +59,7 @@ resource "criblio_group" "my_group" {
 - `provisioned` (Boolean)
 - `streamtags` (List of String)
 - `tags` (String)
-- `type` (String) must be "lake_access"
+- `type` (String) must be one of ["edge", "stream", "search", "lake_access", "local_search"]
 - `worker_remote_access` (Boolean)
 
 <a id="nestedatt--cloud"></a>

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.72"
+      version = "1.20.75"
     }
   }
 }

--- a/examples/resources/criblio_group/resource.tf
+++ b/examples/resources/criblio_group/resource.tf
@@ -18,6 +18,6 @@ resource "criblio_group" "my_group" {
     "edge",
   ]
   tags                 = "environment=prod,team=platform"
-  type                 = "lake_access"
+  type                 = "search"
   worker_remote_access = true
 }

--- a/internal/planmodifiers/stringplanmodifier/no_replace_product_modifier.go
+++ b/internal/planmodifiers/stringplanmodifier/no_replace_product_modifier.go
@@ -1,0 +1,107 @@
+package stringplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ planmodifier.String = StringNoReplaceProductModifierPlanModifier{}
+
+type StringNoReplaceProductModifierPlanModifier struct{}
+
+// Description describes the plan modification in plain text formatting.
+func (v StringNoReplaceProductModifierPlanModifier) Description(_ context.Context) string {
+	return "Allows product changes without forcing resource replacement for default groups (default, defaultHybrid, default_fleet)."
+}
+
+// MarkdownDescription describes the plan modification in Markdown formatting.
+func (v StringNoReplaceProductModifierPlanModifier) MarkdownDescription(ctx context.Context) string {
+	return "Allows product changes without forcing resource replacement for default groups (default, defaultHybrid, default_fleet)."
+}
+
+// PlanModifyString performs the plan modification.
+// This modifier prevents resource replacement when:
+// - product is "stream" AND group id is "default" or "defaultHybrid"
+// - product is "edge" AND group id is "default_fleet"
+// For other cases, it allows normal behavior (which may still trigger replacement from other modifiers).
+func (v StringNoReplaceProductModifierPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
+	// Get the group id from state or plan
+	var groupID types.String
+
+	// Try to get id from state first (for existing resources)
+	stateDiags := req.State.GetAttribute(ctx, path.Root("id"), &groupID)
+	if stateDiags.HasError() || groupID.IsNull() || groupID.IsUnknown() {
+		// If not in state, try plan (for new resources)
+		planDiags := req.Plan.GetAttribute(ctx, path.Root("id"), &groupID)
+		if planDiags.HasError() || groupID.IsNull() || groupID.IsUnknown() {
+			// If we can't get the id, allow normal behavior
+			return
+		}
+	}
+
+	groupIDValue := groupID.ValueString()
+
+	// Get the product value from the plan/config (the new value)
+	var productValue string
+	if !req.ConfigValue.IsNull() && !req.ConfigValue.IsUnknown() {
+		productValue = req.ConfigValue.ValueString()
+	} else if !req.PlanValue.IsNull() && !req.PlanValue.IsUnknown() {
+		productValue = req.PlanValue.ValueString()
+	} else {
+		// If product is unknown, allow normal behavior
+		return
+	}
+
+	// Check if the value actually changed
+	stateValueChanged := false
+	if !req.StateValue.IsNull() && !req.StateValue.IsUnknown() {
+		stateProductValue := req.StateValue.ValueString()
+		if stateProductValue != productValue {
+			stateValueChanged = true
+		}
+	} else {
+		// If there's no state value, this is a new resource, so no change to prevent
+		return
+	}
+
+	// Only prevent replacement if the value actually changed
+	if !stateValueChanged {
+		return
+	}
+
+	// Check if we should prevent replacement based on the conditions
+	shouldPreventReplacement := false
+
+	switch productValue {
+	case "stream":
+		// For stream product, allow changes if group is default or defaultHybrid
+		if groupIDValue == "default" || groupIDValue == "defaultHybrid" {
+			shouldPreventReplacement = true
+		}
+	case "edge":
+		// For edge product, allow changes if group is default_fleet
+		if groupIDValue == "default_fleet" {
+			shouldPreventReplacement = true
+		}
+	}
+
+	// If we should prevent replacement, explicitly set RequiresReplace to false
+	// This ensures that replacement is not forced for these specific cases
+	if shouldPreventReplacement {
+		// Explicitly prevent replacement by not setting RequiresReplace
+		// The default behavior is to not require replacement
+		resp.RequiresReplace = false
+		return
+	}
+
+	// For other cases, force replacement (mimic RequiresReplaceIfConfigured behavior)
+	// This ensures that non-default groups still require replacement when product changes
+	resp.RequiresReplace = true
+}
+
+func NoReplaceProductModifier() planmodifier.String {
+	return StringNoReplaceProductModifierPlanModifier{}
+}

--- a/internal/provider/deploy_resource.go
+++ b/internal/provider/deploy_resource.go
@@ -89,7 +89,8 @@ func (r *DeployResource) Schema(ctx context.Context, req resource.SchemaRequest,
 							Computed: true,
 						},
 						"on_prem": schema.BoolAttribute{
-							Computed: true,
+							Computed:    true,
+							Description: `Whether this is an on-premises group. Cannot be true when cloud is set.`,
 						},
 						"provisioned": schema.BoolAttribute{
 							Computed: true,

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -358,9 +358,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.20.72",
+		SDKVersion: "1.20.75",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.20.72 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.20.75 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/internal/sdk/models/shared/configgroup.go
+++ b/internal/sdk/models/shared/configgroup.go
@@ -37,7 +37,11 @@ func (c *ConfigGroupGit) GetLog() []Commit {
 type ConfigGroupType string
 
 const (
-	ConfigGroupTypeLakeAccess ConfigGroupType = "lake_access"
+	ConfigGroupTypeEdge        ConfigGroupType = "edge"
+	ConfigGroupTypeStream      ConfigGroupType = "stream"
+	ConfigGroupTypeSearch      ConfigGroupType = "search"
+	ConfigGroupTypeLakeAccess  ConfigGroupType = "lake_access"
+	ConfigGroupTypeLocalSearch ConfigGroupType = "local_search"
 )
 
 func (e ConfigGroupType) ToPointer() *ConfigGroupType {
@@ -49,7 +53,15 @@ func (e *ConfigGroupType) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	switch v {
+	case "edge":
+		fallthrough
+	case "stream":
+		fallthrough
+	case "search":
+		fallthrough
 	case "lake_access":
+		fallthrough
+	case "local_search":
 		*e = ConfigGroupType(v)
 		return nil
 	default:
@@ -71,14 +83,15 @@ type ConfigGroup struct {
 	IsSearch                *bool                `json:"isSearch,omitempty"`
 	LookupDeployments       []ConfigGroupLookups `json:"lookupDeployments,omitempty"`
 	Name                    *string              `json:"name,omitempty"`
-	OnPrem                  *bool                `json:"onPrem,omitempty"`
-	Provisioned             *bool                `json:"provisioned,omitempty"`
-	Streamtags              []string             `json:"streamtags,omitempty"`
-	Tags                    *string              `json:"tags,omitempty"`
-	Type                    *ConfigGroupType     `json:"type,omitempty"`
-	UpgradeVersion          *string              `json:"upgradeVersion,omitempty"`
-	WorkerCount             *float64             `json:"workerCount,omitempty"`
-	WorkerRemoteAccess      *bool                `json:"workerRemoteAccess,omitempty"`
+	// Whether this is an on-premises group. Cannot be true when cloud is set.
+	OnPrem             *bool            `json:"onPrem,omitempty"`
+	Provisioned        *bool            `json:"provisioned,omitempty"`
+	Streamtags         []string         `json:"streamtags,omitempty"`
+	Tags               *string          `json:"tags,omitempty"`
+	Type               *ConfigGroupType `json:"type,omitempty"`
+	UpgradeVersion     *string          `json:"upgradeVersion,omitempty"`
+	WorkerCount        *float64         `json:"workerCount,omitempty"`
+	WorkerRemoteAccess *bool            `json:"workerRemoteAccess,omitempty"`
 	// This is only configurable for hybrid worker groups.
 	MaxWorkerAge *string `json:"maxWorkerAge,omitempty"`
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -62240,6 +62240,7 @@ components:
       properties:
         cloud:
           $ref: "#/components/schemas/ConfigGroupCloud"
+          description: Cloud configuration. Only applicable for stream product. Cannot be set when onPrem is true.
         configVersion:
           type: string
           example: "v12"
@@ -62308,10 +62309,12 @@ components:
                   version: "v4"
         name:
           type: string
+          pattern: "^[a-z0-9-]+$"
           example: "Prod Edge"
         onPrem:
           type: boolean
           example: true
+          description: Whether this is an on-premises group. Cannot be true when cloud is set.
         provisioned:
           type: boolean
           example: true
@@ -62328,8 +62331,12 @@ components:
         type:
           type: string
           enum:
+            - edge
+            - stream
+            - search
             - lake_access
-          example: "lake_access"
+            - local_search
+          x-speakeasy-unknown-values: allow
         upgradeVersion:
           type: string
           example: "6.0.1"
@@ -79952,6 +79959,7 @@ paths:
               - edge
           description: Cribl Product
           example: "stream"
+          x-speakeasy-plan-modifiers: NoReplaceProductModifier
     get:
       operationId: getProductsGroupsByProduct
       tags:

--- a/tests/acceptance/commit_and_deploy_test.go
+++ b/tests/acceptance/commit_and_deploy_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestCommitAndDeploy(t *testing.T) {
-	t.Skip("Skipping resource due to API schema change")
 
 	t.Run("plan-diff", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{

--- a/tests/acceptance/group_settings_test.go
+++ b/tests/acceptance/group_settings_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
@@ -8,6 +9,9 @@ import (
 )
 
 func TestGroupSettings(t *testing.T) {
+	if os.Getenv("DEPLOYMENT") == "onprem" {
+		t.Skip("Skipping resource for On-Prem deployments as it is 'prohibited by current license'")
+	}
 	t.Run("plan-diff", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			ProtoV6ProviderFactories: providerFactory,

--- a/tests/acceptance/group_settings_test.go
+++ b/tests/acceptance/group_settings_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestGroupSettings(t *testing.T) {
-	t.Skip("Skipping resource due to API schema change")
 	t.Run("plan-diff", func(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			ProtoV6ProviderFactories: providerFactory,


### PR DESCRIPTION
This PR implements the below things:

- Adds a monkey patching to ignore deletion of default worker groups and edge fleets
- Updates schema to validate a worker group name
- Updates schema to allow newly added enum values as group types so worker group creation, group_settings and commit and deploy resources can function, also added an option to allow unknown values
- Re-enables group_settings and commit_and_deploy tests.