### PR TITLE
 fixing the four rest collector types and updating the documentation and testing

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: 1c2f66ea5a5fdfbaae22459911b04999
+  docChecksum: 5d2302fb754cefa5a456bbdb212d0e0b
   docVersion: 4.14.0
   speakeasyVersion: 1.658.2
   generationVersion: 2.755.9

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -494,13 +494,14 @@ resource "criblio_collector" "my_collector" {
             }
           ]
           discover_type        = "http"
-          discover_url         = "https://api.example.com/discover"
+          discover_url         = "api.example.com/discover"
           enable_discover_code = true
           format_result_code   = "200"
           item_list = [
             "item1",
             "item2",
           ]
+          manual_discover_result = "{\"result\":\"true\"}"
           pagination = {
             attribute = [
               "records",
@@ -1645,6 +1646,10 @@ Optional:
 <a id="nestedatt--input_collector_rest--collector--conf"></a>
 ### Nested Schema for `input_collector_rest.collector.conf`
 
+Required:
+
+- `discovery` (Attributes) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery))
+
 Optional:
 
 - `auth_header_expr` (String) Expression for auth header value
@@ -1661,7 +1666,6 @@ Optional:
 - `credentials_secret` (String)
 - `decode_url` (Boolean) Default: false
 - `disable_time_filter` (Boolean)
-- `discovery` (Attributes) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery))
 - `login_body` (String) Body content for login request
 - `login_url` (String) URL for authentication login
 - `pagination` (Attributes) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--pagination))
@@ -1676,6 +1680,61 @@ Optional:
 - `token_secret` (String)
 - `use_round_robin_dns` (Boolean)
 - `username` (String)
+
+<a id="nestedatt--input_collector_rest--collector--conf--discovery"></a>
+### Nested Schema for `input_collector_rest.collector.conf.discovery`
+
+Required:
+
+- `discover_type` (String) must be one of ["http", "json", "list", "none"]
+
+Optional:
+
+- `discover_body` (String)
+- `discover_data_field` (String)
+- `discover_method` (String) protocol used for http discovery, required for 'http' type. must be one of ["get", "post", "post_with_body", "other"]
+- `discover_request_headers` (Attributes List) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery--discover_request_headers))
+- `discover_request_params` (Attributes List) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery--discover_request_params))
+- `discover_url` (String) URL to hit for rest type collectors, required for 'http' discoverType
+- `enable_discover_code` (Boolean) Default: false
+- `format_result_code` (String)
+- `item_list` (List of String) comma separated list of strings to return from discovery section required for 'list' discoverType
+- `manual_discover_result` (String) json payload to return manually, required for 'json' discoverType
+- `pagination` (Attributes) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery--pagination))
+
+<a id="nestedatt--input_collector_rest--collector--conf--discovery--discover_request_headers"></a>
+### Nested Schema for `input_collector_rest.collector.conf.discovery.discover_request_headers`
+
+Optional:
+
+- `name` (String)
+- `value` (String)
+
+
+<a id="nestedatt--input_collector_rest--collector--conf--discovery--discover_request_params"></a>
+### Nested Schema for `input_collector_rest.collector.conf.discovery.discover_request_params`
+
+
+<a id="nestedatt--input_collector_rest--collector--conf--discovery--pagination"></a>
+### Nested Schema for `input_collector_rest.collector.conf.discovery.pagination`
+
+Optional:
+
+- `attribute` (List of String)
+- `last_page_expr` (String)
+- `limit` (Number) Default: 100
+- `limit_field` (String)
+- `max_pages` (Number) Default: 0
+- `offset` (Number)
+- `offset_field` (String)
+- `page_field` (String)
+- `size` (Number) Default: 50
+- `size_field` (String)
+- `total_record_field` (String)
+- `type` (String) Default: "none"; must be one of ["none", "offset", "cursor", "page"]
+- `zero_indexed` (Boolean) Default: false
+
+
 
 <a id="nestedatt--input_collector_rest--collector--conf--auth_request_headers"></a>
 ### Nested Schema for `input_collector_rest.collector.conf.auth_request_headers`
@@ -1711,57 +1770,6 @@ Optional:
 
 - `name` (String)
 - `value` (String)
-
-
-<a id="nestedatt--input_collector_rest--collector--conf--discovery"></a>
-### Nested Schema for `input_collector_rest.collector.conf.discovery`
-
-Optional:
-
-- `discover_body` (String)
-- `discover_data_field` (String)
-- `discover_method` (String) must be one of ["get", "post", "post_with_body", "other"]
-- `discover_request_headers` (Attributes List) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery--discover_request_headers))
-- `discover_request_params` (Attributes List) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery--discover_request_params))
-- `discover_type` (String) must be "http"
-- `discover_url` (String)
-- `enable_discover_code` (Boolean) Default: false
-- `format_result_code` (String)
-- `item_list` (List of String)
-- `pagination` (Attributes) (see [below for nested schema](#nestedatt--input_collector_rest--collector--conf--discovery--pagination))
-
-<a id="nestedatt--input_collector_rest--collector--conf--discovery--discover_request_headers"></a>
-### Nested Schema for `input_collector_rest.collector.conf.discovery.discover_request_headers`
-
-Optional:
-
-- `name` (String)
-- `value` (String)
-
-
-<a id="nestedatt--input_collector_rest--collector--conf--discovery--discover_request_params"></a>
-### Nested Schema for `input_collector_rest.collector.conf.discovery.discover_request_params`
-
-
-<a id="nestedatt--input_collector_rest--collector--conf--discovery--pagination"></a>
-### Nested Schema for `input_collector_rest.collector.conf.discovery.pagination`
-
-Optional:
-
-- `attribute` (List of String)
-- `last_page_expr` (String)
-- `limit` (Number) Default: 100
-- `limit_field` (String)
-- `max_pages` (Number) Default: 0
-- `offset` (Number)
-- `offset_field` (String)
-- `page_field` (String)
-- `size` (Number) Default: 50
-- `size_field` (String)
-- `total_record_field` (String)
-- `type` (String) Default: "none"; must be one of ["none", "offset", "cursor", "page"]
-- `zero_indexed` (Boolean) Default: false
-
 
 
 <a id="nestedatt--input_collector_rest--collector--conf--pagination"></a>

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -100,6 +100,10 @@ resource "criblio_collector" "rest_api_collector" {
           scope         = ""
         }
 
+        discovery = {
+          discover_type = "none"
+        }
+
         # Additional REST configuration
         authentication = "basic"
         body           = ""
@@ -178,6 +182,142 @@ resource "criblio_collector" "rest_api_collector" {
     ]
     ttl             = "2h"
     worker_affinity = false
+  }
+}
+
+resource "criblio_collector" "rest_api_collector_discovery_http" {
+  group_id = "default"
+  id       = "rest-api-demo-collector_discovery_http"
+  input_collector_rest = {
+    collector = {
+      type = "rest"
+      conf = {
+        # Mandatory REST collector parameters
+        base_url     = "https://api.demo.example.com"
+        auth_type    = "manual"
+        bearer_token = ""
+        oauth_config = {
+          client_id     = ""
+          client_secret = ""
+          token_url     = ""
+          scope         = ""
+        }
+        discovery = {
+          discover_type   = "http"
+          discover_method = "get"
+          discover_url    = "foobar.com"
+        }
+        # Additional REST configuration
+        authentication = "basic"
+        body           = ""
+        headers = {
+          "Content-Type" = "application/json"
+          "Accept"       = "application/json"
+        }
+        method              = "GET"
+        password            = "demo-password"
+        path                = "/api/v1/logs"
+        reject_unauthorized = false
+        timeout             = 30
+        url                 = "https://api.demo.example.com/api/v1/logs"
+        username            = "demo-user"
+        collect_method      = "get"
+        collect_url         = "api.demo.example.com/api/v1/logs"
+      }
+    }
+    environment             = "demo"
+    id                      = "rest-api-demo-collector_discovery_http"
+    ignore_group_jobs_limit = false
+  }
+}
+
+resource "criblio_collector" "rest_api_collector_discovery_json" {
+  group_id = "default"
+  id       = "rest-api-demo-collector_discovery_json"
+  input_collector_rest = {
+    collector = {
+      type = "rest"
+      conf = {
+        # Mandatory REST collector parameters
+        base_url     = "https://api.demo.example.com"
+        auth_type    = "manual"
+        bearer_token = ""
+        oauth_config = {
+          client_id     = ""
+          client_secret = ""
+          token_url     = ""
+          scope         = ""
+        }
+        discovery = {
+          discover_type          = "json"
+          manual_discover_result = "{\"result\":\"true\"}"
+        }
+        # Additional REST configuration
+        authentication = "basic"
+        body           = ""
+        headers = {
+          "Content-Type" = "application/json"
+          "Accept"       = "application/json"
+        }
+        method              = "GET"
+        password            = "demo-password"
+        path                = "/api/v1/logs"
+        reject_unauthorized = false
+        timeout             = 30
+        url                 = "https://api.demo.example.com/api/v1/logs"
+        username            = "demo-user"
+        collect_method      = "get"
+        collect_url         = "api.demo.example.com/api/v1/logs"
+      }
+    }
+    environment             = "demo"
+    id                      = "rest-api-demo-collector_discovery_json"
+    ignore_group_jobs_limit = false
+  }
+}
+
+resource "criblio_collector" "rest_api_collector_discovery_list" {
+  group_id = "default"
+  id       = "rest-api-demo-collector_discovery_list"
+  input_collector_rest = {
+    collector = {
+      type = "rest"
+      conf = {
+        # Mandatory REST collector parameters
+        base_url     = "https://api.demo.example.com"
+        auth_type    = "manual"
+        bearer_token = ""
+        oauth_config = {
+          client_id     = ""
+          client_secret = ""
+          token_url     = ""
+          scope         = ""
+        }
+        discovery = {
+          discover_type = "list"
+          item_list     = ["foo", "bar"]
+        }
+        # Additional REST configuration
+        authentication = "basic"
+        body           = ""
+        headers = {
+          "Content-Type" = "application/json"
+          "Accept"       = "application/json"
+        }
+        method              = "GET"
+        password            = "demo-password"
+        path                = "/api/v1/logs"
+        reject_unauthorized = false
+        timeout             = 30
+        url                 = "https://api.demo.example.com/api/v1/logs"
+        username            = "demo-user"
+        collect_method      = "get"
+        collect_url         = "api.demo.example.com/api/v1/logs"
+      }
+    }
+    environment             = "demo"
+    id                      = "rest-api-demo-collector_discovery_list"
+    ignore_group_jobs_limit = false
   }
 }
 

--- a/examples/resources/criblio_collector/resource.tf
+++ b/examples/resources/criblio_collector/resource.tf
@@ -479,13 +479,14 @@ resource "criblio_collector" "my_collector" {
             }
           ]
           discover_type        = "http"
-          discover_url         = "https://api.example.com/discover"
+          discover_url         = "api.example.com/discover"
           enable_discover_code = true
           format_result_code   = "200"
           item_list = [
             "item1",
             "item2",
           ]
+          manual_discover_result = "{\"result\":\"true\"}"
           pagination = {
             attribute = [
               "records",

--- a/internal/provider/collector_resource.go
+++ b/internal/provider/collector_resource.go
@@ -2027,7 +2027,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 										Optional: true,
 									},
 									"discovery": schema.SingleNestedAttribute{
-										Optional: true,
+										Required: true,
 										Attributes: map[string]schema.Attribute{
 											"discover_body": schema.StringAttribute{
 												Optional: true,
@@ -2037,7 +2037,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 											},
 											"discover_method": schema.StringAttribute{
 												Optional:    true,
-												Description: `must be one of ["get", "post", "post_with_body", "other"]`,
+												Description: `protocol used for http discovery, required for 'http' type. must be one of ["get", "post", "post_with_body", "other"]`,
 												Validators: []validator.String{
 													stringvalidator.OneOf(
 														"get",
@@ -2067,14 +2067,20 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 												},
 											},
 											"discover_type": schema.StringAttribute{
-												Optional:    true,
-												Description: `must be "http"`,
+												Required:    true,
+												Description: `must be one of ["http", "json", "list", "none"]`,
 												Validators: []validator.String{
-													stringvalidator.OneOf("http"),
+													stringvalidator.OneOf(
+														"http",
+														"json",
+														"list",
+														"none",
+													),
 												},
 											},
 											"discover_url": schema.StringAttribute{
-												Optional: true,
+												Optional:    true,
+												Description: `URL to hit for rest type collectors, required for 'http' discoverType`,
 											},
 											"enable_discover_code": schema.BoolAttribute{
 												Computed:    true,
@@ -2088,6 +2094,11 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 											"item_list": schema.ListAttribute{
 												Optional:    true,
 												ElementType: types.StringType,
+												Description: `comma separated list of strings to return from discovery section required for 'list' discoverType`,
+											},
+											"manual_discover_result": schema.StringAttribute{
+												Optional:    true,
+												Description: `json payload to return manually, required for 'json' discoverType`,
 											},
 											"pagination": schema.SingleNestedAttribute{
 												Optional: true,

--- a/internal/provider/collector_resource_sdk.go
+++ b/internal/provider/collector_resource_sdk.go
@@ -1100,181 +1100,180 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			for safeHeadersIndex := range r.InputCollectorRest.Collector.Conf.SafeHeaders {
 				safeHeaders = append(safeHeaders, r.InputCollectorRest.Collector.Conf.SafeHeaders[safeHeadersIndex].ValueString())
 			}
-			var discovery *shared.DiscoveryConfiguration
-			if r.InputCollectorRest.Collector.Conf.Discovery != nil {
-				discoverType := new(shared.DiscoverType)
-				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverType.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverType.IsNull() {
-					*discoverType = shared.DiscoverType(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverType.ValueString())
+			discoverType := shared.DiscoverType(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverType.ValueString())
+			discoverMethod := new(shared.DiscoverMethod)
+			if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverMethod.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverMethod.IsNull() {
+				*discoverMethod = shared.DiscoverMethod(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverMethod.ValueString())
+			} else {
+				discoverMethod = nil
+			}
+			var pagination *shared.PaginationConfig
+			if r.InputCollectorRest.Collector.Conf.Discovery.Pagination != nil {
+				typeVar4 := new(shared.PaginationType)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Type.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Type.IsNull() {
+					*typeVar4 = shared.PaginationType(r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Type.ValueString())
 				} else {
-					discoverType = nil
+					typeVar4 = nil
 				}
-				discoverMethod := new(shared.DiscoverMethod)
-				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverMethod.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverMethod.IsNull() {
-					*discoverMethod = shared.DiscoverMethod(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverMethod.ValueString())
+				offsetField := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.OffsetField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.OffsetField.IsNull() {
+					*offsetField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.OffsetField.ValueString()
 				} else {
-					discoverMethod = nil
+					offsetField = nil
 				}
-				var pagination *shared.PaginationConfig
-				if r.InputCollectorRest.Collector.Conf.Discovery.Pagination != nil {
-					typeVar4 := new(shared.PaginationType)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Type.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Type.IsNull() {
-						*typeVar4 = shared.PaginationType(r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Type.ValueString())
-					} else {
-						typeVar4 = nil
-					}
-					offsetField := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.OffsetField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.OffsetField.IsNull() {
-						*offsetField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.OffsetField.ValueString()
-					} else {
-						offsetField = nil
-					}
-					limitField := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LimitField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LimitField.IsNull() {
-						*limitField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LimitField.ValueString()
-					} else {
-						limitField = nil
-					}
-					limit := new(int64)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Limit.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Limit.IsNull() {
-						*limit = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Limit.ValueInt64()
-					} else {
-						limit = nil
-					}
-					maxPages := new(int64)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.MaxPages.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.MaxPages.IsNull() {
-						*maxPages = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.MaxPages.ValueInt64()
-					} else {
-						maxPages = nil
-					}
-					zeroIndexed := new(bool)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.ZeroIndexed.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.ZeroIndexed.IsNull() {
-						*zeroIndexed = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.ZeroIndexed.ValueBool()
-					} else {
-						zeroIndexed = nil
-					}
-					pageField := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.PageField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.PageField.IsNull() {
-						*pageField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.PageField.ValueString()
-					} else {
-						pageField = nil
-					}
-					sizeField := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.SizeField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.SizeField.IsNull() {
-						*sizeField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.SizeField.ValueString()
-					} else {
-						sizeField = nil
-					}
-					size := new(int64)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Size.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Size.IsNull() {
-						*size = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Size.ValueInt64()
-					} else {
-						size = nil
-					}
-					attribute := make([]string, 0, len(r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Attribute))
-					for attributeIndex := range r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Attribute {
-						attribute = append(attribute, r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Attribute[attributeIndex].ValueString())
-					}
-					lastPageExpr := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LastPageExpr.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LastPageExpr.IsNull() {
-						*lastPageExpr = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LastPageExpr.ValueString()
-					} else {
-						lastPageExpr = nil
-					}
-					offset := new(int64)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Offset.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Offset.IsNull() {
-						*offset = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Offset.ValueInt64()
-					} else {
-						offset = nil
-					}
-					totalRecordField := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.TotalRecordField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.TotalRecordField.IsNull() {
-						*totalRecordField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.TotalRecordField.ValueString()
-					} else {
-						totalRecordField = nil
-					}
-					pagination = &shared.PaginationConfig{
-						Type:             typeVar4,
-						OffsetField:      offsetField,
-						LimitField:       limitField,
-						Limit:            limit,
-						MaxPages:         maxPages,
-						ZeroIndexed:      zeroIndexed,
-						PageField:        pageField,
-						SizeField:        sizeField,
-						Size:             size,
-						Attribute:        attribute,
-						LastPageExpr:     lastPageExpr,
-						Offset:           offset,
-						TotalRecordField: totalRecordField,
-					}
-				}
-				enableDiscoverCode := new(bool)
-				if !r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode.IsNull() {
-					*enableDiscoverCode = r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode.ValueBool()
+				limitField := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LimitField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LimitField.IsNull() {
+					*limitField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LimitField.ValueString()
 				} else {
-					enableDiscoverCode = nil
+					limitField = nil
 				}
-				itemList := make([]string, 0, len(r.InputCollectorRest.Collector.Conf.Discovery.ItemList))
-				for itemListIndex := range r.InputCollectorRest.Collector.Conf.Discovery.ItemList {
-					itemList = append(itemList, r.InputCollectorRest.Collector.Conf.Discovery.ItemList[itemListIndex].ValueString())
-				}
-				discoverURL := new(string)
-				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL.IsNull() {
-					*discoverURL = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL.ValueString()
+				limit := new(int64)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Limit.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Limit.IsNull() {
+					*limit = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Limit.ValueInt64()
 				} else {
-					discoverURL = nil
+					limit = nil
 				}
-				discoverRequestHeaders := make([]shared.DiscoverRequestHeader, 0, len(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders))
-				for discoverRequestHeadersIndex := range r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders {
-					name6 := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Name.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Name.IsNull() {
-						*name6 = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Name.ValueString()
-					} else {
-						name6 = nil
-					}
-					value6 := new(string)
-					if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Value.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Value.IsNull() {
-						*value6 = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Value.ValueString()
-					} else {
-						value6 = nil
-					}
-					discoverRequestHeaders = append(discoverRequestHeaders, shared.DiscoverRequestHeader{
-						Name:  name6,
-						Value: value6,
-					})
-				}
-				discoverRequestParams := make([]shared.DiscoverRequestParam, len(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams))
-				discoverBody := new(string)
-				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.IsNull() {
-					*discoverBody = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.ValueString()
+				maxPages := new(int64)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.MaxPages.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.MaxPages.IsNull() {
+					*maxPages = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.MaxPages.ValueInt64()
 				} else {
-					discoverBody = nil
+					maxPages = nil
 				}
-				formatResultCode := new(string)
-				if !r.InputCollectorRest.Collector.Conf.Discovery.FormatResultCode.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.FormatResultCode.IsNull() {
-					*formatResultCode = r.InputCollectorRest.Collector.Conf.Discovery.FormatResultCode.ValueString()
+				zeroIndexed := new(bool)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.ZeroIndexed.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.ZeroIndexed.IsNull() {
+					*zeroIndexed = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.ZeroIndexed.ValueBool()
 				} else {
-					formatResultCode = nil
+					zeroIndexed = nil
 				}
-				discoverDataField := new(string)
-				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverDataField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverDataField.IsNull() {
-					*discoverDataField = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverDataField.ValueString()
+				pageField := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.PageField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.PageField.IsNull() {
+					*pageField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.PageField.ValueString()
 				} else {
-					discoverDataField = nil
+					pageField = nil
 				}
-				discovery = &shared.DiscoveryConfiguration{
-					DiscoverType:           discoverType,
-					DiscoverMethod:         discoverMethod,
-					Pagination:             pagination,
-					EnableDiscoverCode:     enableDiscoverCode,
-					ItemList:               itemList,
-					DiscoverURL:            discoverURL,
-					DiscoverRequestHeaders: discoverRequestHeaders,
-					DiscoverRequestParams:  discoverRequestParams,
-					DiscoverBody:           discoverBody,
-					FormatResultCode:       formatResultCode,
-					DiscoverDataField:      discoverDataField,
+				sizeField := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.SizeField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.SizeField.IsNull() {
+					*sizeField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.SizeField.ValueString()
+				} else {
+					sizeField = nil
 				}
+				size := new(int64)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Size.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Size.IsNull() {
+					*size = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Size.ValueInt64()
+				} else {
+					size = nil
+				}
+				attribute := make([]string, 0, len(r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Attribute))
+				for attributeIndex := range r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Attribute {
+					attribute = append(attribute, r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Attribute[attributeIndex].ValueString())
+				}
+				lastPageExpr := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LastPageExpr.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LastPageExpr.IsNull() {
+					*lastPageExpr = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.LastPageExpr.ValueString()
+				} else {
+					lastPageExpr = nil
+				}
+				offset := new(int64)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Offset.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Offset.IsNull() {
+					*offset = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.Offset.ValueInt64()
+				} else {
+					offset = nil
+				}
+				totalRecordField := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.TotalRecordField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.Pagination.TotalRecordField.IsNull() {
+					*totalRecordField = r.InputCollectorRest.Collector.Conf.Discovery.Pagination.TotalRecordField.ValueString()
+				} else {
+					totalRecordField = nil
+				}
+				pagination = &shared.PaginationConfig{
+					Type:             typeVar4,
+					OffsetField:      offsetField,
+					LimitField:       limitField,
+					Limit:            limit,
+					MaxPages:         maxPages,
+					ZeroIndexed:      zeroIndexed,
+					PageField:        pageField,
+					SizeField:        sizeField,
+					Size:             size,
+					Attribute:        attribute,
+					LastPageExpr:     lastPageExpr,
+					Offset:           offset,
+					TotalRecordField: totalRecordField,
+				}
+			}
+			enableDiscoverCode := new(bool)
+			if !r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode.IsNull() {
+				*enableDiscoverCode = r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode.ValueBool()
+			} else {
+				enableDiscoverCode = nil
+			}
+			itemList := make([]string, 0, len(r.InputCollectorRest.Collector.Conf.Discovery.ItemList))
+			for itemListIndex := range r.InputCollectorRest.Collector.Conf.Discovery.ItemList {
+				itemList = append(itemList, r.InputCollectorRest.Collector.Conf.Discovery.ItemList[itemListIndex].ValueString())
+			}
+			discoverURL := new(string)
+			if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL.IsNull() {
+				*discoverURL = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL.ValueString()
+			} else {
+				discoverURL = nil
+			}
+			discoverRequestHeaders := make([]shared.DiscoverRequestHeader, 0, len(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders))
+			for discoverRequestHeadersIndex := range r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders {
+				name6 := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Name.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Name.IsNull() {
+					*name6 = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Name.ValueString()
+				} else {
+					name6 = nil
+				}
+				value6 := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Value.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Value.IsNull() {
+					*value6 = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders[discoverRequestHeadersIndex].Value.ValueString()
+				} else {
+					value6 = nil
+				}
+				discoverRequestHeaders = append(discoverRequestHeaders, shared.DiscoverRequestHeader{
+					Name:  name6,
+					Value: value6,
+				})
+			}
+			manualDiscoverResult := new(string)
+			if !r.InputCollectorRest.Collector.Conf.Discovery.ManualDiscoverResult.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.ManualDiscoverResult.IsNull() {
+				*manualDiscoverResult = r.InputCollectorRest.Collector.Conf.Discovery.ManualDiscoverResult.ValueString()
+			} else {
+				manualDiscoverResult = nil
+			}
+			discoverRequestParams := make([]shared.DiscoverRequestParam, len(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams))
+			discoverBody := new(string)
+			if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.IsNull() {
+				*discoverBody = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.ValueString()
+			} else {
+				discoverBody = nil
+			}
+			formatResultCode := new(string)
+			if !r.InputCollectorRest.Collector.Conf.Discovery.FormatResultCode.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.FormatResultCode.IsNull() {
+				*formatResultCode = r.InputCollectorRest.Collector.Conf.Discovery.FormatResultCode.ValueString()
+			} else {
+				formatResultCode = nil
+			}
+			discoverDataField := new(string)
+			if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverDataField.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverDataField.IsNull() {
+				*discoverDataField = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverDataField.ValueString()
+			} else {
+				discoverDataField = nil
+			}
+			discovery := shared.DiscoveryConfiguration{
+				DiscoverType:           discoverType,
+				DiscoverMethod:         discoverMethod,
+				Pagination:             pagination,
+				EnableDiscoverCode:     enableDiscoverCode,
+				ItemList:               itemList,
+				DiscoverURL:            discoverURL,
+				DiscoverRequestHeaders: discoverRequestHeaders,
+				ManualDiscoverResult:   manualDiscoverResult,
+				DiscoverRequestParams:  discoverRequestParams,
+				DiscoverBody:           discoverBody,
+				FormatResultCode:       formatResultCode,
+				DiscoverDataField:      discoverDataField,
 			}
 			var pagination1 *shared.PaginationConfig
 			if r.InputCollectorRest.Collector.Conf.Pagination != nil {

--- a/internal/provider/types/discovery_configuration.go
+++ b/internal/provider/types/discovery_configuration.go
@@ -17,5 +17,6 @@ type DiscoveryConfiguration struct {
 	EnableDiscoverCode     types.Bool              `tfsdk:"enable_discover_code"`
 	FormatResultCode       types.String            `tfsdk:"format_result_code"`
 	ItemList               []types.String          `tfsdk:"item_list"`
+	ManualDiscoverResult   types.String            `tfsdk:"manual_discover_result"`
 	Pagination             *PaginationConfig       `tfsdk:"pagination"`
 }

--- a/internal/provider/types/input_collector_rest_conf.go
+++ b/internal/provider/types/input_collector_rest_conf.go
@@ -22,7 +22,7 @@ type InputCollectorRestConf struct {
 	CredentialsSecret     types.String             `tfsdk:"credentials_secret"`
 	DecodeURL             types.Bool               `tfsdk:"decode_url"`
 	DisableTimeFilter     types.Bool               `tfsdk:"disable_time_filter"`
-	Discovery             *DiscoveryConfiguration  `tfsdk:"discovery"`
+	Discovery             DiscoveryConfiguration   `tfsdk:"discovery"`
 	LoginBody             types.String             `tfsdk:"login_body"`
 	LoginURL              types.String             `tfsdk:"login_url"`
 	Pagination            *PaginationConfig        `tfsdk:"pagination"`

--- a/openapi.yml
+++ b/openapi.yml
@@ -1401,6 +1401,7 @@ components:
                   enum: [rest]
                   example: "rest"
                 conf:
+                  required: [discovery]
                   type: object
                   properties:
                     # Authentication Properties
@@ -1565,21 +1566,22 @@ components:
                         type: string
                         example: "Authorization"
                       example: ["Content-Type","Authorization"]
-                    # Discovery Configuration
                     discovery:
                       type: object
                       title: Discovery Configuration
+                      required: [discoverType]
                       properties:
                         discoverType:
                           type: string
                           title: Discover type
-                          enum: [http]
+                          enum: [http, json, list, none]
                           example: "http"
                         discoverMethod:
                           type: string
                           title: Discover method
                           enum: [get, post, post_with_body, other]
                           example: "get"
+                          description: protocol used for http discovery, required for 'http' type
                         pagination:
                           $ref: '#/components/schemas/PaginationConfig'
                         enableDiscoverCode:
@@ -1594,10 +1596,13 @@ components:
                             type: string
                             example: "item1"
                           example: ["item1","item2"]
+                          description: comma separated list of strings to return from discovery section
+                            required for 'list' discoverType
                         discoverUrl:
                           type: string
                           title: Discover URL
-                          example: "https://api.example.com/discover"
+                          example: "api.example.com/discover"
+                          description: URL to hit for rest type collectors, required for 'http' discoverType
                         discoverRequestHeaders:
                           type: array
                           title: Discover request headers
@@ -1613,6 +1618,11 @@ components:
                                 title: Header value
                                 example: "Bearer token"
                           example: [{"name": "Authorization", "value": "Bearer token"}]
+                        manualDiscoverResult:
+                          type: string
+                          title: Manual discovery result, stringified json payload
+                          example: '{"result":"true"}'
+                          description: json payload to return manually, required for 'json' discoverType
                         discoverRequestParams:
                           type: array
                           title: Discover request parameters


### PR DESCRIPTION
CHANGES

- updated required fields in openapi.yml
- expanded allowed discovery types
- expanded documentation for the required paths for the individual collectors

TESTING

- added the four rest_collector types to unit testing