### PR TITLE
adding integration tests and release workflows for goatify.

### DIFF
--- a/.github/workflows/goatify_release.yaml
+++ b/.github/workflows/goatify_release.yaml
@@ -1,0 +1,33 @@
+# Goatify CLI release workflow. Triggers on tags: goatify-v0.0.1, goatify-v0.0.2, etc.
+name: Goatify Release
+
+on:
+  push:
+    tags:
+      - 'goatify-v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v4.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          # Skip homebrew until criblio/homebrew-tap exists and HOMEBREW_TAP_TOKEN is set
+          args: release --config .goreleaser-goatify.yml --clean --skip=homebrew
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/goatify_release.yaml
+++ b/.github/workflows/goatify_release.yaml
@@ -26,8 +26,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          # Skip homebrew until criblio/homebrew-tap exists and HOMEBREW_TAP_TOKEN is set
-          args: release --config .goreleaser-goatify.yml --clean --skip=homebrew
+          args: release --config .goreleaser-goatify.yml --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -169,8 +169,6 @@ jobs:
 
   unit_test_import_cli:
     runs-on: ubuntu-latest
-    needs: changes
-    if: needs.changes.outputs.tools == 'true'
     steps:
       - uses: actions/checkout@v4.2.2
 
@@ -181,6 +179,31 @@ jobs:
 
       - name: Run import-cli Unit Tests
         run: make unit-test-import-cli
+
+  integration_test_import_cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.1.7"
+
+      - uses: actions/setup-go@v4.0.0
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Run import-cli Integration Tests
+        env:
+          CRIBL_ORGANIZATION_ID: "beautiful-nguyen-y8y4azd"
+          CRIBL_WORKSPACE_ID: "main"
+          CRIBL_CLOUD_DOMAIN: "cribl-playground.cloud"
+          CRIBL_CLIENT_ID: ${{ secrets.CRIBL_CLIENT_ID }}
+          CRIBL_CLIENT_SECRET: ${{ secrets.CRIBL_CLIENT_SECRET }}
+        run: |
+          make build-import-cli
+          go test -v -tags=integration ./tools/import-cli/integration/...
 
   speakeasy_test:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge_checks.yaml
+++ b/.github/workflows/merge_checks.yaml
@@ -187,7 +187,8 @@ jobs:
 
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: "1.1.7"
+          # Import blocks require Terraform 1.5+; 1.1.7 reports "Unsupported block type"
+          terraform_version: "1.5.0"
 
       - uses: actions/setup-go@v4.0.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ sbom-*.json
 .cursor/
 tf*
 go.work*
+dist/*

--- a/.goreleaser-goatify.yml
+++ b/.goreleaser-goatify.yml
@@ -46,17 +46,5 @@ changelog:
       - "^test:"
       - "^chore:"
 
-homebrew_casks:
-  - name: goatify
-    repository:
-      owner: criblio
-      name: homebrew-tap
-      branch: main
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    homepage: "https://github.com/criblio/terraform-provider-criblio"
-    description: "Export Cribl configurations to Terraform HCL"
-    url:
-      verified: "github.com/criblio/terraform-provider-criblio/releases/download"
-
 release:
   name_template: "goatify {{ .Version }}"

--- a/.goreleaser-goatify.yml
+++ b/.goreleaser-goatify.yml
@@ -1,0 +1,62 @@
+# GoReleaser config for goatify CLI. Triggered by tags: goatify-v0.0.1, goatify-v0.0.2, etc.
+version: 2
+
+project_name: goatify
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: goatify
+    dir: .
+    main: ./tools/import-cli
+    binary: goatify
+    env:
+      - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
+
+archives:
+  - formats: [zip]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+
+checksum:
+  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  algorithm: sha256
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^chore:"
+
+homebrew_casks:
+  - name: goatify
+    repository:
+      owner: criblio
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/criblio/terraform-provider-criblio"
+    description: "Export Cribl configurations to Terraform HCL"
+    url:
+      verified: "github.com/criblio/terraform-provider-criblio/releases/download"
+
+release:
+  name_template: "goatify {{ .Version }}"

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: 77328c3a97f3f20aebaec3625b2d0c97
+  docChecksum: af76da6f11b20d99a515ffa6e11728a9
   docVersion: 4.14.0
   speakeasyVersion: 1.658.2
   generationVersion: 2.755.9
-  releaseVersion: 1.20.133
-  configChecksum: 0c8a11a6651b6f7be98820616835b25c
+  releaseVersion: 1.20.135
+  configChecksum: 6a511df06576753a81c0681d412f540d
   published: true
 features:
   terraform:
@@ -339,8 +339,6 @@ generatedFiles:
   - internal/provider/packpipeline_data_source.go
   - internal/provider/packroutes_data_source.go
   - internal/provider/packroutes_data_source_sdk.go
-  - internal/provider/packroutes_resource.go
-  - internal/provider/packroutes_resource_sdk.go
   - internal/provider/packsource_data_source.go
   - internal/provider/packsource_data_source_sdk.go
   - internal/provider/packsource_resource.go

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.20.133
+  version: 1.20.135
   additionalDataSources: []
   additionalDependencies: {}
   additionalEphemeralResources: []

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.658.2
 sources:
     Cribl Control Plane and Management API:
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:6d42886a1f46df0b36939ac131f545b460ddcc09194c9d69fae3e43d8420443f
-        sourceBlobDigest: sha256:9c7d5c96a939a5abaab96543d48f32adab14f92245931248fb69a201b20a2a40
+        sourceRevisionDigest: sha256:b88a6aca027ab7bffa38affab7fd2ef4115667e2beaeb4cfa259878d397bb862
+        sourceBlobDigest: sha256:4697e6a58e073c2680e00c2dc5a1a3c2fe6fb97dcfc3c429c157ec6dd89968cd
         tags:
             - latest
             - 4.14.0
@@ -11,8 +11,8 @@ targets:
     cribl-io:
         source: Cribl Control Plane and Management API
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:6d42886a1f46df0b36939ac131f545b460ddcc09194c9d69fae3e43d8420443f
-        sourceBlobDigest: sha256:9c7d5c96a939a5abaab96543d48f32adab14f92245931248fb69a201b20a2a40
+        sourceRevisionDigest: sha256:b88a6aca027ab7bffa38affab7fd2ef4115667e2beaeb4cfa259878d397bb862
+        sourceBlobDigest: sha256:4697e6a58e073c2680e00c2dc5a1a3c2fe6fb97dcfc3c429c157ec6dd89968cd
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.658.2

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ unit-test:
 unit-test-import-cli:
 	go test -v ./tools/import-cli/...
 
+integration-test-import-cli: build-import-cli
+	go test -v -tags=integration ./tools/import-cli/integration/...
+
 build-import-cli:
 	go build -o goatify ./tools/import-cli
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.133"
+      version = "1.20.135"
     }
   }
 }

--- a/docs/resources/event_breaker_ruleset.md
+++ b/docs/resources/event_breaker_ruleset.md
@@ -96,7 +96,7 @@ Optional:
 - `timestamp_earliest` (String) The earliest timestamp value allowed relative to now. Example: -42years. Parsed values prior to this date will be set to current time. Default: "-420weeks"
 - `timestamp_latest` (String) The latest timestamp value allowed relative to now. Example: +42days. Parsed values after this date will be set to current time. Default: "+1week"
 - `timestamp_timezone` (String) Timezone to assign to timestamps without timezone info. Default: "local"
-- `type` (String) Default: "regex"; must be one of ["regex", "json", "json_array", "header", "timestamp", "csv", "aws_cloudtrail", "aws_vpcflow"]
+- `type` (String) Default: "regex"; must be one of ["regex", "json", "json_array", "header", "timestamp", "csv", "aws_cloudtrail", "aws_vpcflow", "azure_flowlog"]
 
 <a id="nestedatt--rules--fields"></a>
 ### Nested Schema for `rules.fields`

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.133"
+      version = "1.20.135"
     }
   }
 }

--- a/internal/provider/eventbreakerruleset_resource.go
+++ b/internal/provider/eventbreakerruleset_resource.go
@@ -374,7 +374,7 @@ func (r *EventBreakerRulesetResource) Schema(ctx context.Context, req resource.S
 							PlanModifiers: []planmodifier.String{
 								speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 							},
-							Description: `Default: "regex"; must be one of ["regex", "json", "json_array", "header", "timestamp", "csv", "aws_cloudtrail", "aws_vpcflow"]`,
+							Description: `Default: "regex"; must be one of ["regex", "json", "json_array", "header", "timestamp", "csv", "aws_cloudtrail", "aws_vpcflow", "azure_flowlog"]`,
 							Validators: []validator.String{
 								stringvalidator.OneOf(
 									"regex",
@@ -385,6 +385,7 @@ func (r *EventBreakerRulesetResource) Schema(ctx context.Context, req resource.S
 									"csv",
 									"aws_cloudtrail",
 									"aws_vpcflow",
+									"azure_flowlog",
 								),
 							},
 						},

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -358,9 +358,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.20.133",
+		SDKVersion: "1.20.135",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.20.133 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.20.135 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/internal/sdk/models/shared/datasetprovidertype.go
+++ b/internal/sdk/models/shared/datasetprovidertype.go
@@ -10,29 +10,30 @@ import (
 type ID string
 
 const (
-	IDPrometheus           ID = "prometheus"
-	IDCriblLake            ID = "cribl_lake"
-	IDS3                   ID = "s3"
-	IDGcs                  ID = "gcs"
-	IDAzureBlob            ID = "azure_blob"
-	IDCriblLeader          ID = "cribl_leader"
 	IDCriblEdge            ID = "cribl_edge"
-	IDAmazonSecurityLake   ID = "amazon_security_lake"
-	IDAPIHTTP              ID = "api_http"
-	IDAPIAws               ID = "api_aws"
+	IDCriblLeader          ID = "cribl_leader"
+	IDCriblMeta            ID = "cribl_meta"
+	IDS3                   ID = "s3"
+	IDAzureBlob            ID = "azure_blob"
+	IDGcs                  ID = "gcs"
 	IDAPIAzure             ID = "api_azure"
+	IDAPIAws               ID = "api_aws"
 	IDAPIGcp               ID = "api_gcp"
-	IDAPIGoogleWorkspace   ID = "api_google_workspace"
-	IDAPIMsgraph           ID = "api_msgraph"
-	IDAPIOkta              ID = "api_okta"
-	IDAPITailscale         ID = "api_tailscale"
+	IDAPIHTTP              ID = "api_http"
 	IDAPIZoom              ID = "api_zoom"
+	IDAPIOkta              ID = "api_okta"
+	IDAPIMsgraph           ID = "api_msgraph"
+	IDCriblLake            ID = "cribl_lake"
+	IDCriblLocal           ID = "cribl_local"
+	IDAmazonSecurityLake   ID = "amazon_security_lake"
+	IDAPIGoogleWorkspace   ID = "api_google_workspace"
+	IDAPITailscale         ID = "api_tailscale"
 	IDAPIOpensearch        ID = "api_opensearch"
 	IDAPIElasticsearch     ID = "api_elasticsearch"
 	IDAPIAzureDataExplorer ID = "api_azure_data_explorer"
+	IDPrometheus           ID = "prometheus"
 	IDSnowflake            ID = "snowflake"
 	IDClickhouse           ID = "clickhouse"
-	IDCriblMeta            ID = "cribl_meta"
 )
 
 func (e ID) ToPointer() *ID {
@@ -44,39 +45,41 @@ func (e *ID) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	switch v {
-	case "prometheus":
-		fallthrough
-	case "cribl_lake":
-		fallthrough
-	case "s3":
-		fallthrough
-	case "gcs":
-		fallthrough
-	case "azure_blob":
+	case "cribl_edge":
 		fallthrough
 	case "cribl_leader":
 		fallthrough
-	case "cribl_edge":
+	case "cribl_meta":
 		fallthrough
-	case "amazon_security_lake":
+	case "s3":
 		fallthrough
-	case "api_http":
+	case "azure_blob":
 		fallthrough
-	case "api_aws":
+	case "gcs":
 		fallthrough
 	case "api_azure":
 		fallthrough
+	case "api_aws":
+		fallthrough
 	case "api_gcp":
 		fallthrough
-	case "api_google_workspace":
+	case "api_http":
 		fallthrough
-	case "api_msgraph":
+	case "api_zoom":
 		fallthrough
 	case "api_okta":
 		fallthrough
-	case "api_tailscale":
+	case "api_msgraph":
 		fallthrough
-	case "api_zoom":
+	case "cribl_lake":
+		fallthrough
+	case "cribl_local":
+		fallthrough
+	case "amazon_security_lake":
+		fallthrough
+	case "api_google_workspace":
+		fallthrough
+	case "api_tailscale":
 		fallthrough
 	case "api_opensearch":
 		fallthrough
@@ -84,11 +87,11 @@ func (e *ID) UnmarshalJSON(data []byte) error {
 		fallthrough
 	case "api_azure_data_explorer":
 		fallthrough
+	case "prometheus":
+		fallthrough
 	case "snowflake":
 		fallthrough
 	case "clickhouse":
-		fallthrough
-	case "cribl_meta":
 		*e = ID(v)
 		return nil
 	default:

--- a/internal/sdk/models/shared/eventbreakerruleset.go
+++ b/internal/sdk/models/shared/eventbreakerruleset.go
@@ -48,6 +48,7 @@ const (
 	EventBreakerTypeCsv           EventBreakerType = "csv"
 	EventBreakerTypeAwsCloudtrail EventBreakerType = "aws_cloudtrail"
 	EventBreakerTypeAwsVpcflow    EventBreakerType = "aws_vpcflow"
+	EventBreakerTypeAzureFlowlog  EventBreakerType = "azure_flowlog"
 )
 
 func (e EventBreakerType) ToPointer() *EventBreakerType {
@@ -74,6 +75,8 @@ func (e *EventBreakerType) UnmarshalJSON(data []byte) error {
 	case "aws_cloudtrail":
 		fallthrough
 	case "aws_vpcflow":
+		fallthrough
+	case "azure_flowlog":
 		*e = EventBreakerType(v)
 		return nil
 	default:

--- a/internal/sdk/models/shared/genericprovider.go
+++ b/internal/sdk/models/shared/genericprovider.go
@@ -2102,10 +2102,11 @@ func (u *GenericProvider) UnmarshalJSON(data []byte) error {
 		u.S3Provider = s3Provider
 		u.Type = GenericProviderTypeS3Provider
 		return nil
-	case "cribl_leader":
+	case "cribl_leader", "cribl_local":
+		// cribl_local has same structure as cribl_leader (id, type, description); API returns cribl_local for local Cribl sources
 		criblLeaderProvider := new(CriblLeaderProvider)
 		if err := utils.UnmarshalJSON(data, &criblLeaderProvider, "", true, nil); err != nil {
-			return fmt.Errorf("could not unmarshal `%s` into expected (Type == cribl_leader) type CriblLeaderProvider within GenericProvider: %w", string(data), err)
+			return fmt.Errorf("could not unmarshal `%s` into expected (Type == %s) type CriblLeaderProvider within GenericProvider: %w", string(data), dis.Type, err)
 		}
 
 		u.CriblLeaderProvider = criblLeaderProvider

--- a/openapi.yml
+++ b/openapi.yml
@@ -3256,29 +3256,30 @@ components:
         id:
           type: string
           enum:
-            - prometheus
-            - cribl_lake
-            - s3
-            - gcs
-            - azure_blob
-            - cribl_leader
             - cribl_edge
-            - amazon_security_lake
-            - api_http
-            - api_aws
+            - cribl_leader
+            - cribl_meta
+            - s3
+            - azure_blob
+            - gcs
             - api_azure
+            - api_aws
             - api_gcp
-            - api_google_workspace
-            - api_msgraph
-            - api_okta
-            - api_tailscale
+            - api_http
             - api_zoom
+            - api_okta
+            - api_msgraph
+            - cribl_lake
+            - cribl_local
+            - amazon_security_lake
+            - api_google_workspace
+            - api_tailscale
             - api_opensearch
             - api_elasticsearch
             - api_azure_data_explorer
+            - prometheus
             - snowflake
             - clickhouse
-            - cribl_meta
           example: "cribl_meta"
         locality:
           $ref: "#/components/schemas/OriginConfig"
@@ -7129,6 +7130,7 @@ components:
                   - csv
                   - aws_cloudtrail
                   - aws_vpcflow
+                  - azure_flowlog
                 default: regex
                 example: regex
               delimiterRegex:

--- a/tools/import-cli/integration/integration_test.go
+++ b/tools/import-cli/integration/integration_test.go
@@ -1,0 +1,398 @@
+//go:build integration
+
+// Package integration provides live integration tests for the goatify CLI.
+// Tests run against a real Cribl Cloud organization. Skip when credentials are missing.
+// Run with: go test -tags=integration ./tools/import-cli/integration/...
+package integration
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/hcl"
+	"github.com/stretchr/testify/require"
+)
+
+// buildLocalProvider builds the criblio terraform provider into pluginDir and returns the path.
+// Uses the same layout as e2e: registry.terraform.io/criblio/criblio/999.99.9/<os>_<arch>/terraform-provider-criblio_v999.99.9
+func buildLocalProvider(t *testing.T, pluginDir string) string {
+	t.Helper()
+	osArch := runtime.GOOS + "_" + runtime.GOARCH
+	providerPath := filepath.Join(pluginDir, "registry.terraform.io", "criblio", "criblio", "999.99.9", osArch)
+	require.NoError(t, os.MkdirAll(providerPath, 0755))
+	binaryPath := filepath.Join(providerPath, "terraform-provider-criblio_v999.99.9")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, ".")
+	buildCmd.Dir = repoRoot(t)
+	buildCmd.Env = os.Environ()
+	var buf bytes.Buffer
+	buildCmd.Stdout = &buf
+	buildCmd.Stderr = &buf
+	require.NoError(t, buildCmd.Run(), "build local provider: %s", buf.String())
+	return pluginDir
+}
+
+// writeTerraformTfvarsWithPlaceholders writes terraform.tfvars with valid placeholder values for required variables.
+// Certificate variables use examples/certificate/server.crt, private key variables use server.key; others use "placeholder".
+// All certificate variables share the same cert content; all priv_key variables share the same key content.
+func writeTerraformTfvarsWithPlaceholders(t *testing.T, outputDir string) {
+	t.Helper()
+	tfvarsExample := filepath.Join(outputDir, "terraform.tfvars.example")
+	if _, err := os.Stat(tfvarsExample); err != nil {
+		return // no variables, nothing to write
+	}
+	content, err := os.ReadFile(tfvarsExample)
+	require.NoError(t, err)
+	// Parse variable names: lines like "name = "" or "name = <<-EOT
+	re := regexp.MustCompile(`(?m)^([a-zA-Z0-9_]+)\s*=`)
+	matches := re.FindAllStringSubmatch(string(content), -1)
+	var names []string
+	seen := make(map[string]bool)
+	for _, m := range matches {
+		if len(m) >= 2 && !seen[m[1]] {
+			seen[m[1]] = true
+			names = append(names, m[1])
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	root := repoRoot(t)
+	certPath := filepath.Join(root, "examples", "certificate", "server.crt")
+	keyPath := filepath.Join(root, "examples", "certificate", "server.key")
+	certContent, err := os.ReadFile(certPath)
+	require.NoError(t, err, "read server.crt for placeholder")
+	keyContent, err := os.ReadFile(keyPath)
+	require.NoError(t, err, "read server.key for placeholder")
+	certStr := strings.TrimSpace(string(certContent))
+	keyStr := strings.TrimSpace(string(keyContent))
+
+	var buf bytes.Buffer
+	buf.WriteString("# Generated for integration test - valid placeholders from examples/certificate/\n\n")
+	for _, n := range names {
+		lower := strings.ToLower(n)
+		if strings.Contains(lower, "priv_key") || strings.Contains(lower, "private_key") {
+			fmt.Fprintf(&buf, "%s = <<-EOT\n%s\nEOT\n", n, keyStr)
+		} else if strings.Contains(lower, "cert") {
+			fmt.Fprintf(&buf, "%s = <<-EOT\n%s\nEOT\n", n, certStr)
+		} else {
+			fmt.Fprintf(&buf, "%s = %q\n", n, "placeholder")
+		}
+	}
+	require.NoError(t, os.WriteFile(filepath.Join(outputDir, "terraform.tfvars"), buf.Bytes(), 0600))
+}
+
+// TestIntegration_FullFlow_Cloud runs the full flow for criblio_group only: build, dry-run, export,
+// HCL parse, terraform init/plan/apply, and no-drift check.
+func TestIntegration_FullFlow_Cloud(t *testing.T) {
+	if os.Getenv("CRIBL_CLIENT_ID") == "" || os.Getenv("CRIBL_CLIENT_SECRET") == "" {
+		t.Skip("Integration test requires CRIBL_CLIENT_ID and CRIBL_CLIENT_SECRET (and CRIBL_ORGANIZATION_ID, CRIBL_WORKSPACE_ID, CRIBL_CLOUD_DOMAIN)")
+	}
+
+	orgID := os.Getenv("CRIBL_ORGANIZATION_ID")
+	workspaceID := os.Getenv("CRIBL_WORKSPACE_ID")
+	cloudDomain := os.Getenv("CRIBL_CLOUD_DOMAIN")
+	if orgID == "" || workspaceID == "" || cloudDomain == "" {
+		t.Skip("Integration test requires CRIBL_ORGANIZATION_ID, CRIBL_WORKSPACE_ID, CRIBL_CLOUD_DOMAIN")
+	}
+
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "goatify")
+	outputDir := filepath.Join(tmpDir, "output")
+	_ = os.MkdirAll(outputDir, 0755)
+
+	env := append(os.Environ(),
+		"CRIBL_CLIENT_ID="+os.Getenv("CRIBL_CLIENT_ID"),
+		"CRIBL_CLIENT_SECRET="+os.Getenv("CRIBL_CLIENT_SECRET"),
+		"CRIBL_ORGANIZATION_ID="+orgID,
+		"CRIBL_WORKSPACE_ID="+workspaceID,
+		"CRIBL_CLOUD_DOMAIN="+cloudDomain,
+	)
+
+	// Step 1: Build goatify
+	t.Log("Step 1: Build goatify")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, "./tools/import-cli")
+	buildCmd.Dir = repoRoot(t)
+	buildCmd.Env = env
+	var buildBuf bytes.Buffer
+	buildCmd.Stdout = io.MultiWriter(&buildBuf, os.Stdout)
+	buildCmd.Stderr = io.MultiWriter(&buildBuf, os.Stderr)
+	err := buildCmd.Run()
+	require.NoError(t, err, "build goatify: %s", buildBuf.String())
+	_, err = os.Stat(binaryPath)
+	require.NoError(t, err, "binary should exist")
+
+	// Step 2: goatify import --dry-run
+	t.Log("Step 2: goatify import --dry-run")
+	dryRunCmd := exec.Command(binaryPath, "import", "--dry-run", "--include", "criblio_group",
+		"--org-id", orgID, "--workspace-id", workspaceID, "--cloud-domain", cloudDomain)
+	dryRunCmd.Dir = tmpDir
+	dryRunCmd.Env = env
+	var dryRunBuf bytes.Buffer
+	dryRunCmd.Stdout = io.MultiWriter(&dryRunBuf, os.Stdout)
+	dryRunCmd.Stderr = io.MultiWriter(&dryRunBuf, os.Stderr)
+	err = dryRunCmd.Run()
+	require.NoError(t, err, "dry-run should succeed")
+	require.Contains(t, dryRunBuf.String(), "Preview:", "stderr should contain Preview")
+	require.Contains(t, dryRunBuf.String(), "criblio_", "stderr should list resource types")
+
+	// Step 3: goatify import (criblio_group only)
+	t.Log("Step 3: goatify import (criblio_group)")
+	importCmd := exec.Command(binaryPath, "import", "--include", "criblio_group", "--output-dir", outputDir,
+		"--org-id", orgID, "--workspace-id", workspaceID, "--cloud-domain", cloudDomain)
+	importCmd.Dir = tmpDir
+	importCmd.Env = env
+	var importBuf bytes.Buffer
+	importCmd.Stdout = io.MultiWriter(&importBuf, os.Stdout)
+	importCmd.Stderr = io.MultiWriter(&importBuf, os.Stderr)
+	err = importCmd.Run()
+	require.NoError(t, err, "import should succeed: %s", importBuf.String())
+
+	// Validate output structure: import.tf, providers.tf, main.tf at root; at least one module dir with main.tf
+	require.FileExists(t, filepath.Join(outputDir, "import.tf"), "import.tf should exist")
+	require.FileExists(t, filepath.Join(outputDir, "providers.tf"), "providers.tf should exist")
+	require.FileExists(t, filepath.Join(outputDir, "main.tf"), "main.tf should exist")
+
+	var foundModuleMain bool
+	_ = filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == "main.tf" && path != filepath.Join(outputDir, "main.tf") {
+			foundModuleMain = true
+		}
+		return nil
+	})
+	require.True(t, foundModuleMain, "at least one module dir should have main.tf")
+
+	// Step 4: Parse generated HCL
+	t.Log("Step 4: Parse generated HCL")
+	mainTF, err := os.ReadFile(filepath.Join(outputDir, "main.tf"))
+	require.NoError(t, err)
+	require.NoError(t, hcl.ParseHCL(mainTF, "main.tf"))
+
+	importTF, err := os.ReadFile(filepath.Join(outputDir, "import.tf"))
+	require.NoError(t, err)
+	require.NoError(t, hcl.ParseHCL(importTF, "import.tf"))
+
+	// Step 5: Verify import blocks
+	t.Log("Step 5: Verify import blocks")
+	require.Contains(t, string(importTF), "import {", "import.tf should contain import blocks")
+	require.Contains(t, string(importTF), "to =", "import.tf should contain to =")
+	require.Contains(t, string(importTF), "id =", "import.tf should contain id =")
+
+	// Step 6: Build local provider and terraform init
+	t.Log("Step 6: Build local provider and terraform init")
+	pluginDir := filepath.Join(tmpDir, "plugin-dir")
+	buildLocalProvider(t, pluginDir)
+	pluginDirAbs, err := filepath.Abs(pluginDir)
+	require.NoError(t, err)
+
+	runTerraform := func(args ...string) ([]byte, error) {
+		cmd := exec.Command("terraform", args...)
+		cmd.Dir = outputDir
+		cmd.Env = env
+		var buf bytes.Buffer
+		cmd.Stdout = io.MultiWriter(&buf, os.Stdout)
+		cmd.Stderr = io.MultiWriter(&buf, os.Stderr)
+		err := cmd.Run()
+		return buf.Bytes(), err
+	}
+
+	initOut, err := runTerraform("init", "-plugin-dir", pluginDirAbs)
+	require.NoError(t, err, "terraform init should succeed: %s", string(initOut))
+
+	// Step 7: terraform plan
+	t.Log("Step 7: terraform plan")
+	planOut, err := runTerraform("plan", "-detailed-exitcode")
+	// Exit 0 = no changes, 2 = changes planned (acceptable before apply)
+	if err != nil {
+		var exitErr *exec.ExitError
+		require.True(t, errors.As(err, &exitErr) && exitErr.ExitCode() == 2,
+			"terraform plan should succeed or exit 2 (changes): %v\n%s", err, string(planOut))
+	}
+
+	// Step 8: terraform apply -auto-approve
+	t.Log("Step 8: terraform apply -auto-approve")
+	applyOut, err := runTerraform("apply", "-auto-approve")
+	require.NoError(t, err, "terraform apply should succeed: %s", string(applyOut))
+
+	// Step 9: terraform plan (second run) - must report no drift
+	t.Log("Step 9: terraform plan (second run) - no drift")
+	plan2Out, err := runTerraform("plan", "-detailed-exitcode")
+	require.NoError(t, err, "second terraform plan should succeed (no drift): %s", string(plan2Out))
+	require.Contains(t, string(plan2Out), "No changes", "second plan should report no drift")
+}
+
+// TestIntegration_FullExport_Cloud runs full export (all resource types, no --include), validates
+// output structure and HCL parsing, then runs terraform init, plan, apply, and a second plan (no-drift check).
+func TestIntegration_FullExport_Cloud(t *testing.T) {
+	if os.Getenv("CRIBL_CLIENT_ID") == "" || os.Getenv("CRIBL_CLIENT_SECRET") == "" {
+		t.Skip("Integration test requires CRIBL_CLIENT_ID and CRIBL_CLIENT_SECRET (and CRIBL_ORGANIZATION_ID, CRIBL_WORKSPACE_ID, CRIBL_CLOUD_DOMAIN)")
+	}
+
+	orgID := os.Getenv("CRIBL_ORGANIZATION_ID")
+	workspaceID := os.Getenv("CRIBL_WORKSPACE_ID")
+	cloudDomain := os.Getenv("CRIBL_CLOUD_DOMAIN")
+	if orgID == "" || workspaceID == "" || cloudDomain == "" {
+		t.Skip("Integration test requires CRIBL_ORGANIZATION_ID, CRIBL_WORKSPACE_ID, CRIBL_CLOUD_DOMAIN")
+	}
+
+	tmpDir := t.TempDir()
+	binaryPath := filepath.Join(tmpDir, "goatify")
+	outputDir := filepath.Join(tmpDir, "output")
+	_ = os.MkdirAll(outputDir, 0755)
+
+	env := append(os.Environ(),
+		"CRIBL_CLIENT_ID="+os.Getenv("CRIBL_CLIENT_ID"),
+		"CRIBL_CLIENT_SECRET="+os.Getenv("CRIBL_CLIENT_SECRET"),
+		"CRIBL_ORGANIZATION_ID="+orgID,
+		"CRIBL_WORKSPACE_ID="+workspaceID,
+		"CRIBL_CLOUD_DOMAIN="+cloudDomain,
+	)
+
+	// Step 1: Build goatify
+	t.Log("Step 1: Build goatify")
+	buildCmd := exec.Command("go", "build", "-o", binaryPath, "./tools/import-cli")
+	buildCmd.Dir = repoRoot(t)
+	buildCmd.Env = env
+	var buildBuf bytes.Buffer
+	buildCmd.Stdout = io.MultiWriter(&buildBuf, os.Stdout)
+	buildCmd.Stderr = io.MultiWriter(&buildBuf, os.Stderr)
+	err := buildCmd.Run()
+	require.NoError(t, err, "build goatify: %s", buildBuf.String())
+
+	// Step 2: goatify import --dry-run (full, no --include)
+	t.Log("Step 2: goatify import --dry-run (full export)")
+	dryRunCmd := exec.Command(binaryPath, "import", "--dry-run",
+		"--org-id", orgID, "--workspace-id", workspaceID, "--cloud-domain", cloudDomain)
+	dryRunCmd.Dir = tmpDir
+	dryRunCmd.Env = env
+	var dryRunBuf bytes.Buffer
+	dryRunCmd.Stdout = io.MultiWriter(&dryRunBuf, os.Stdout)
+	dryRunCmd.Stderr = io.MultiWriter(&dryRunBuf, os.Stderr)
+	err = dryRunCmd.Run()
+	require.NoError(t, err, "dry-run should succeed")
+	require.Contains(t, dryRunBuf.String(), "Preview:", "stderr should contain Preview")
+
+	// Step 3: goatify import (full export, no --include)
+	t.Log("Step 3: goatify import (full export)")
+	importCmd := exec.Command(binaryPath, "import", "--output-dir", outputDir,
+		"--org-id", orgID, "--workspace-id", workspaceID, "--cloud-domain", cloudDomain)
+	importCmd.Dir = tmpDir
+	importCmd.Env = env
+	var importBuf bytes.Buffer
+	importCmd.Stdout = io.MultiWriter(&importBuf, os.Stdout)
+	importCmd.Stderr = io.MultiWriter(&importBuf, os.Stderr)
+	err = importCmd.Run()
+	require.NoError(t, err, "import should succeed: %s", importBuf.String())
+
+	// Validate output structure
+	require.FileExists(t, filepath.Join(outputDir, "import.tf"), "import.tf should exist")
+	require.FileExists(t, filepath.Join(outputDir, "providers.tf"), "providers.tf should exist")
+	require.FileExists(t, filepath.Join(outputDir, "main.tf"), "main.tf should exist")
+
+	var foundModuleMain bool
+	_ = filepath.Walk(outputDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == "main.tf" && path != filepath.Join(outputDir, "main.tf") {
+			foundModuleMain = true
+		}
+		return nil
+	})
+	require.True(t, foundModuleMain, "at least one module dir should have main.tf")
+
+	// Step 4: Parse generated HCL
+	t.Log("Step 4: Parse generated HCL")
+	mainTF, err := os.ReadFile(filepath.Join(outputDir, "main.tf"))
+	require.NoError(t, err)
+	require.NoError(t, hcl.ParseHCL(mainTF, "main.tf"))
+
+	importTF, err := os.ReadFile(filepath.Join(outputDir, "import.tf"))
+	require.NoError(t, err)
+	require.NoError(t, hcl.ParseHCL(importTF, "import.tf"))
+
+	// Step 5: Write terraform.tfvars with valid placeholders (cert/key from examples/certificate/)
+	t.Log("Step 5: Write terraform.tfvars with valid placeholders")
+	writeTerraformTfvarsWithPlaceholders(t, outputDir)
+
+	// Step 6: Build local provider and terraform init
+	t.Log("Step 6: Build local provider and terraform init")
+	pluginDir := filepath.Join(tmpDir, "plugin-dir")
+	buildLocalProvider(t, pluginDir)
+	pluginDirAbs, err := filepath.Abs(pluginDir)
+	require.NoError(t, err)
+
+	tfInit := exec.Command("terraform", "init", "-plugin-dir", pluginDirAbs)
+	tfInit.Dir = outputDir
+	tfInit.Env = env
+	var initBuf bytes.Buffer
+	tfInit.Stdout = io.MultiWriter(&initBuf, os.Stdout)
+	tfInit.Stderr = io.MultiWriter(&initBuf, os.Stderr)
+	err = tfInit.Run()
+	require.NoError(t, err, "terraform init should succeed: %s", initBuf.String())
+
+	runTerraform := func(args ...string) ([]byte, error) {
+		cmd := exec.Command("terraform", args...)
+		cmd.Dir = outputDir
+		cmd.Env = env
+		var buf bytes.Buffer
+		cmd.Stdout = io.MultiWriter(&buf, os.Stdout)
+		cmd.Stderr = io.MultiWriter(&buf, os.Stderr)
+		err := cmd.Run()
+		return buf.Bytes(), err
+	}
+
+	// Step 7: terraform plan
+	t.Log("Step 7: terraform plan")
+	planOut, err := runTerraform("plan", "-detailed-exitcode")
+	if err != nil {
+		var exitErr *exec.ExitError
+		require.True(t, errors.As(err, &exitErr) && (exitErr.ExitCode() == 0 || exitErr.ExitCode() == 2),
+			"terraform plan should succeed or exit 2 (changes): %v\n%s", err, string(planOut))
+	}
+
+	// Step 8: terraform apply -auto-approve
+	t.Log("Step 8: terraform apply -auto-approve")
+	applyOut, err := runTerraform("apply", "-auto-approve")
+	require.NoError(t, err, "terraform apply should succeed: %s", string(applyOut))
+
+	// Step 9: terraform plan (second run) - no adds/destroys (in-place changes acceptable for full export)
+	t.Log("Step 9: terraform plan (second run) - no adds or destroys")
+	plan2Out, err := runTerraform("plan", "-detailed-exitcode")
+	// Exit 0 = no changes, 2 = changes planned (acceptable when only in-place changes)
+	if err != nil {
+		var exitErr *exec.ExitError
+		require.True(t, errors.As(err, &exitErr) && (exitErr.ExitCode() == 0 || exitErr.ExitCode() == 2),
+			"second terraform plan should succeed or exit 2 (in-place changes): %v\n%s", err, string(plan2Out))
+	}
+	require.Contains(t, string(plan2Out), "0 to add", "second plan should not add resources")
+	require.Contains(t, string(plan2Out), "0 to destroy", "second plan should not destroy resources")
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	// Find repo root by looking for go.mod
+	dir, err := os.Getwd()
+	require.NoError(t, err)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not find repo root (go.mod)")
+		}
+		dir = parent
+	}
+}

--- a/tools/import-cli/internal/generator/module.go
+++ b/tools/import-cli/internal/generator/module.go
@@ -330,7 +330,6 @@ func WriteAllModuleDirectoriesWithLayout(baseDir string, items []ResourceItem, o
 		if err := WriteRootFiles(baseDir, RootModuleInfosFromItemsByGroup(rootItems), rootItems, true); err != nil {
 			return fmt.Errorf("write root files: %w", err)
 		}
-		removeImportTfFromModuleDirs(baseDir)
 		return nil
 	}
 	byType := make(map[string][]ResourceItem)
@@ -360,7 +359,6 @@ func WriteAllModuleDirectoriesWithLayout(baseDir string, items []ResourceItem, o
 	if err := WriteRootFiles(baseDir, RootModuleInfosFromItems(rootItems), rootItems, false); err != nil {
 		return fmt.Errorf("write root files: %w", err)
 	}
-	removeImportTfFromModuleDirs(baseDir)
 	return nil
 }
 
@@ -368,22 +366,6 @@ func WriteAllModuleDirectoriesWithLayout(baseDir string, items []ResourceItem, o
 // Items must all have the same TypeName.
 func WriteGroupTypeDirectory(baseDir, groupID string, items []ResourceItem, opts *hcl.ResourceBlockOptions) error {
 	return WriteModuleDirectoryWithFSAndGroup(DefaultFS, baseDir, items, opts, groupID)
-}
-
-// removeImportTfFromModuleDirs removes import.tf from all subdirectories of baseDir.
-// Terraform only allows import blocks in the root module; having import.tf in child
-// module dirs (e.g. default/group/, stream-leaders/group/) causes "Unsupported block type" errors.
-func removeImportTfFromModuleDirs(baseDir string) {
-	_ = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil
-		}
-		if info.IsDir() && path != baseDir {
-			importPath := filepath.Join(path, "import.tf")
-			_ = os.Remove(importPath)
-		}
-		return nil
-	})
 }
 
 // removeStaleFlatDirs removes flat type directories (e.g. baseDir/pipeline/) when using group-by layout,

--- a/tools/import-cli/internal/generator/module.go
+++ b/tools/import-cli/internal/generator/module.go
@@ -330,6 +330,7 @@ func WriteAllModuleDirectoriesWithLayout(baseDir string, items []ResourceItem, o
 		if err := WriteRootFiles(baseDir, RootModuleInfosFromItemsByGroup(rootItems), rootItems, true); err != nil {
 			return fmt.Errorf("write root files: %w", err)
 		}
+		removeImportTfFromModuleDirs(baseDir)
 		return nil
 	}
 	byType := make(map[string][]ResourceItem)
@@ -359,6 +360,7 @@ func WriteAllModuleDirectoriesWithLayout(baseDir string, items []ResourceItem, o
 	if err := WriteRootFiles(baseDir, RootModuleInfosFromItems(rootItems), rootItems, false); err != nil {
 		return fmt.Errorf("write root files: %w", err)
 	}
+	removeImportTfFromModuleDirs(baseDir)
 	return nil
 }
 
@@ -366,6 +368,22 @@ func WriteAllModuleDirectoriesWithLayout(baseDir string, items []ResourceItem, o
 // Items must all have the same TypeName.
 func WriteGroupTypeDirectory(baseDir, groupID string, items []ResourceItem, opts *hcl.ResourceBlockOptions) error {
 	return WriteModuleDirectoryWithFSAndGroup(DefaultFS, baseDir, items, opts, groupID)
+}
+
+// removeImportTfFromModuleDirs removes import.tf from all subdirectories of baseDir.
+// Terraform only allows import blocks in the root module; having import.tf in child
+// module dirs (e.g. default/group/, stream-leaders/group/) causes "Unsupported block type" errors.
+func removeImportTfFromModuleDirs(baseDir string) {
+	_ = filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		if info.IsDir() && path != baseDir {
+			importPath := filepath.Join(path, "import.tf")
+			_ = os.Remove(importPath)
+		}
+		return nil
+	})
 }
 
 // removeStaleFlatDirs removes flat type directories (e.g. baseDir/pipeline/) when using group-by layout,


### PR DESCRIPTION
Adds integration tests for the goatify CLI and a release workflow to build and publish binaries on GitHub. Fixes CI failures caused by Terraform version compatibility with import blocks.


#### Integration tests
- **New** `tools/import-cli/integration/integration_test.go` – live tests against Cribl Cloud:
  - `TestIntegration_FullFlow_Cloud` – full flow for `criblio_group`: dry-run → export → HCL parse → terraform init/plan/apply → drift check
  - `TestIntegration_FullExport_Cloud` – full export (all resource types), terraform init/plan/apply, drift check (allows in-place changes)
- Tests skip when `CRIBL_CLIENT_ID`, `CRIBL_CLIENT_SECRET`, `CRIBL_ORGANIZATION_ID`, `CRIBL_WORKSPACE_ID`, and `CRIBL_CLOUD_DOMAIN` are not set
- Uses `terraform.tfvars` placeholders from `examples/certificate/` for cert/key variables

#### OpenAPI schema updates:

- Updated `openapi.yml` and the generated provider/SDK code to support new enum values: added `azure_flowlog` to the event breaker ruleset type and `cribl_local` to the dataset provider type, and aligned the dataset provider enum order with the API schema, needs a new generation for import CLI discovery to work as server returns new payload.

#### CI / merge checks
- **New** `integration_test_import_cli` job in `merge_checks.yaml` – runs integration tests with Cribl Cloud credentials similar to acceptance tests
- **Terraform version** – integration job uses Terraform **1.5.0** instead of 1.1.7 (import blocks require 1.5+)
- **Unit test job** – removed `needs: changes` and `if` so unit tests run on every PR, this has a big advantage of catching schema issues early even if the PR is unrelated and the total run time of GH workflow doesn't increase much.

#### Goatify release
- **New** `.github/workflows/goatify_release.yaml` – runs on tags `goatify-v*` (e.g. `goatify-v0.0.1`)
- **New** `.goreleaser-goatify.yml` – builds goatify for linux/darwin/windows (amd64, arm64)

#### Makefile
- **New** `integration-test-import-cli` target – `make integration-test-import-cli` to run integration tests locally

### How to release goatify

git tag goatify-v0.0.1
git push origin goatify-v0.0.1