### PR TITLE
Fix goatify semantic version

### DIFF
--- a/.github/workflows/goatify_release.yaml
+++ b/.github/workflows/goatify_release.yaml
@@ -39,6 +39,6 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          args: release --config .goreleaser-goatify.yml --clean --parallelism=1
+          args: release --config .goreleaser-goatify.yml --clean -p 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/goatify_release.yaml
+++ b/.github/workflows/goatify_release.yaml
@@ -27,9 +27,9 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
           # Use v0.0.1-goatify format: valid semver, no collision with provider v0.0.1
-          # Don't push - GoReleaser creates the release; GitHub creates the tag via API
           GORELEASER_TAG="v${TAG#goatify-v}-goatify"
           git tag "$GORELEASER_TAG"
+          git push origin "$GORELEASER_TAG"
           echo "GORELEASER_CURRENT_TAG=$GORELEASER_TAG" >> $GITHUB_ENV
           # Display version (0.0.1) for release name and artifacts; only when triggered by goatify-v* tag
           if [[ "$TAG" == goatify-v* ]]; then

--- a/.github/workflows/goatify_release.yaml
+++ b/.github/workflows/goatify_release.yaml
@@ -23,6 +23,11 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
+      - name: Set tag for GoReleaser
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "GORELEASER_CURRENT_TAG=${TAG#goatify-}" >> $GITHUB_ENV
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/goatify_release.yaml
+++ b/.github/workflows/goatify_release.yaml
@@ -23,10 +23,18 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
 
-      - name: Set tag for GoReleaser
+      - name: Prepare tag for GoReleaser
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          echo "GORELEASER_CURRENT_TAG=${TAG#goatify-}" >> $GITHUB_ENV
+          # Use v0.0.1-goatify format: valid semver, no collision with provider v0.0.1
+          # Don't push - GoReleaser creates the release; GitHub creates the tag via API
+          GORELEASER_TAG="v${TAG#goatify-v}-goatify"
+          git tag "$GORELEASER_TAG"
+          echo "GORELEASER_CURRENT_TAG=$GORELEASER_TAG" >> $GITHUB_ENV
+          # Display version (0.0.1) for release name and artifacts; only when triggered by goatify-v* tag
+          if [[ "$TAG" == goatify-v* ]]; then
+            echo "GOATIFY_VERSION=${TAG#goatify-v}" >> $GITHUB_ENV
+          fi
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/tf_provider_release.yaml
+++ b/.github/workflows/tf_provider_release.yaml
@@ -7,6 +7,7 @@ on:
   push:
     tags:
       - 'v*'
+      - '!*-goatify'   # exclude v0.0.1-goatify (created by goatify release)
   workflow_dispatch:
 
 # Releases need permission to read and write the repository contents.

--- a/.goreleaser-goatify.yml
+++ b/.goreleaser-goatify.yml
@@ -14,6 +14,8 @@ builds:
     binary: goatify
     env:
       - CGO_ENABLED=0
+      - GOMAXPROCS=1
+      - GOMEMLIMIT=512MiB
     flags:
       - -trimpath
     ldflags:

--- a/.goreleaser-goatify.yml
+++ b/.goreleaser-goatify.yml
@@ -14,8 +14,6 @@ builds:
     binary: goatify
     env:
       - CGO_ENABLED=0
-      - GOMAXPROCS=1
-      - GOMEMLIMIT=512MiB
     flags:
       - -trimpath
     ldflags:

--- a/.goreleaser-goatify.yml
+++ b/.goreleaser-goatify.yml
@@ -31,10 +31,10 @@ builds:
 
 archives:
   - formats: [zip]
-    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    name_template: "{{ .ProjectName }}_{{ or .Env.GOATIFY_VERSION .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:
-  name_template: "{{ .ProjectName }}_{{ .Version }}_SHA256SUMS"
+  name_template: "{{ .ProjectName }}_{{ or .Env.GOATIFY_VERSION .Version }}_SHA256SUMS"
   algorithm: sha256
 
 changelog:
@@ -47,4 +47,4 @@ changelog:
       - "^chore:"
 
 release:
-  name_template: "goatify {{ .Version }}"
+  name_template: "goatify {{ or .Env.GOATIFY_VERSION .Version }}"

--- a/tools/import-cli/cmd/import.go
+++ b/tools/import-cli/cmd/import.go
@@ -96,10 +96,11 @@ func NewImportCommand() *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("build registry: %w", err)
 			}
+			onPrem := cfg.Get(config.KeyOnpremServerURL) != ""
 			excludeMerged := append([]string{}, exclude...)
 			excludeMerged = append(excludeMerged, exclusions.NoExportTypes...)
 			fmt.Fprintln(c.ErrOrStderr(), "Discovering resources...")
-			results, err := discovery.Discover(ctx, sdkClient, reg, include, excludeMerged, group)
+			results, err := discovery.Discover(ctx, sdkClient, reg, include, excludeMerged, group, onPrem)
 			if err != nil {
 				return fmt.Errorf("discovery: %w", err)
 			}
@@ -109,6 +110,9 @@ func NewImportCommand() *cobra.Command {
 				var firstErr error
 				for _, r := range results {
 					if r.Err != nil && firstErr == nil {
+						if onPrem && isOnPremUnsupportedError(r.Err) {
+							continue // skip: expected for on-prem (search, lake, etc. not supported)
+						}
 						firstErr = r.Err
 					}
 				}
@@ -117,10 +121,14 @@ func NewImportCommand() *cobra.Command {
 				}
 				return nil
 			}
-			// Surface SDK errors with resource context; fail if any discovery failed
+			// Surface SDK errors with resource context; fail if any discovery failed.
+			// On-prem: "not supported for on-prem" errors are expected (search, lake, etc.) and are skipped.
 			var firstErr error
 			for _, r := range results {
 				if r.Err != nil {
+					if onPrem && isOnPremUnsupportedError(r.Err) {
+						continue // skip: expected for on-prem
+					}
 					fmt.Fprintln(c.ErrOrStderr(), r.Err.Error())
 					if firstErr == nil {
 						firstErr = r.Err
@@ -130,7 +138,7 @@ func NewImportCommand() *cobra.Command {
 			if firstErr != nil {
 				return fmt.Errorf("discovery failed for one or more resource types: %w", firstErr)
 			}
-			groupIDs, err := discovery.GetGroupIDs(ctx, sdkClient, group)
+			groupIDs, err := discovery.GetGroupIDs(ctx, sdkClient, group, onPrem)
 			if err != nil {
 				return fmt.Errorf("get group IDs: %w", err)
 			}
@@ -168,7 +176,7 @@ func NewImportCommand() *cobra.Command {
 				}
 			}
 			fmt.Fprintf(c.OutOrStdout(), "Wrote Terraform HCL and import blocks to %s (%d resources)\n", outputDir, len(exportResult.Items))
-			printExportSummary(c, exportResult, verbose)
+			printExportSummary(c, exportResult, verbose, onPrem)
 			return nil
 		},
 	}
@@ -290,7 +298,8 @@ func printDryRunPreview(cmd *cobra.Command, results []discovery.Result, groupFil
 
 
 // printExportSummary prints why some resources were not exported (list skips and convert skips).
-func printExportSummary(cmd *cobra.Command, res *export.ExportResult, verbose bool) {
+// When onPrem is true, skips due to "not supported for on-prem" are summarized in one line instead of listing each type.
+func printExportSummary(cmd *cobra.Command, res *export.ExportResult, verbose bool, onPrem bool) {
 	if res == nil {
 		return
 	}
@@ -301,7 +310,7 @@ func printExportSummary(cmd *cobra.Command, res *export.ExportResult, verbose bo
 	if total > 0 && exported != total {
 		fmt.Fprintf(out, "Exported %d of %d discovered resources (%d unexported).\n", exported, total, unexported)
 	}
-	if len(res.ListSkipped) > 0 {
+	if len(res.ListSkipped) > 0 && !onPrem {
 		listCount := 0
 		for _, s := range res.ListSkipped {
 			listCount += s.Count
@@ -381,6 +390,19 @@ func buildRegistry(ctx context.Context) (*registry.Registry, error) {
 	p := provider.New(ver)()
 	constructors := p.Resources(ctx)
 	return registry.NewFromResources(ctx, constructors, registry.MetadataFromProvider(), nil, converter.OneOfBlockNamesFromModel)
+}
+
+// isOnPremUnsupportedError reports whether err is an expected/skip-worthy error on on-prem.
+// Includes: hook's "not supported for on-prem"; 403 enterprise feature (e.g. projects, subscriptions).
+// Import-cli skips these during discovery and continues.
+func isOnPremUnsupportedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "not supported for on-prem") ||
+		strings.Contains(s, "enterprise feature") ||
+		strings.Contains(s, "Status 403")
 }
 
 // ValidateImportFlags returns an error if include and exclude overlap.

--- a/tools/import-cli/internal/discovery/engine.go
+++ b/tools/import-cli/internal/discovery/engine.go
@@ -112,7 +112,8 @@ type Result struct {
 // available so list requests (e.g. /m/{groupId}/...) succeed; falls back to
 // ["default"] if the groups API is unavailable.
 // groupFilter restricts to specific groups (by ID or label e.g. "default (stream)"); empty = all groups.
-func Discover(ctx context.Context, client *sdk.CriblIo, reg *registry.Registry, include, exclude, groupFilter []string) ([]Result, error) {
+// onPrem: when true, exclude default_search from groupIDs (all m/default_search/* endpoints are restricted on on-prem).
+func Discover(ctx context.Context, client *sdk.CriblIo, reg *registry.Registry, include, exclude, groupFilter []string, onPrem bool) ([]Result, error) {
 	includeSet := sliceToSet(include)
 	excludeSet := sliceToSet(exclude)
 
@@ -134,10 +135,13 @@ func Discover(ctx context.Context, client *sdk.CriblIo, reg *registry.Registry, 
 	groupIDs = append(groupIDs, streamIDs...)
 	groupIDs = append(groupIDs, edgeIDs...)
 	if len(groupIDs) == 0 && len(groupFilter) == 0 {
-		groupIDs = fallbackGroupIDs()
+		groupIDs = fallbackGroupIDs(onPrem)
 	} else {
 		// Always include "default" and "default_search" so resources under those groups (e.g. certificates, lookups, parser_lib_entry) are discovered.
 		groupIDs = ensureDefaultGroups(groupIDs)
+	}
+	if onPrem {
+		groupIDs = filterOutDefaultSearch(groupIDs)
 	}
 	// Map group ID -> label for PerGroupCounts (stream and edge).
 	idToLabel := make(map[string]string)
@@ -382,7 +386,8 @@ func inSet(s string, m map[string]struct{}) bool {
 
 // GetGroupIDs returns group IDs used for list/export (stream + edge, filtered by groupFilter).
 // Same logic as inside Discover. Use when exporting so list and get calls use the same groups.
-func GetGroupIDs(ctx context.Context, client *sdk.CriblIo, groupFilter []string) ([]string, error) {
+// onPrem: when true, exclude default_search (m/default_search/* restricted on on-prem).
+func GetGroupIDs(ctx context.Context, client *sdk.CriblIo, groupFilter []string, onPrem bool) ([]string, error) {
 	streamIDs, streamNames, err := fetchGroupsByProduct(ctx, client, operations.GetProductsGroupsByProductProductStream)
 	if err != nil {
 		return nil, fmt.Errorf("fetch stream groups: %w", err)
@@ -397,12 +402,26 @@ func GetGroupIDs(ctx context.Context, client *sdk.CriblIo, groupFilter []string)
 	groupIDs = append(groupIDs, streamIDs...)
 	groupIDs = append(groupIDs, edgeIDs...)
 	if len(groupIDs) == 0 && len(groupFilter) == 0 {
-		groupIDs = fallbackGroupIDs()
+		groupIDs = fallbackGroupIDs(onPrem)
 	} else {
 		// Always include "default" and "default_search" so resources under those groups are listed.
 		groupIDs = ensureDefaultGroups(groupIDs)
 	}
+	if onPrem {
+		groupIDs = filterOutDefaultSearch(groupIDs)
+	}
 	return groupIDs, nil
+}
+
+// filterOutDefaultSearch removes default_search from groupIDs. Used when on-prem since m/default_search/* is restricted.
+func filterOutDefaultSearch(groupIDs []string) []string {
+	out := make([]string, 0, len(groupIDs))
+	for _, gid := range groupIDs {
+		if gid != "default_search" {
+			out = append(out, gid)
+		}
+	}
+	return out
 }
 
 // ensureDefaultGroups prepends "default" and "default_search" to groupIDs if not already present,
@@ -437,8 +456,12 @@ func ensureDefaultGroups(groupIDs []string) []string {
 // fallbackGroupIDs returns group IDs to try when the groups API returned none.
 // Uses "default", "default_search" (search/parser resources), and, if set, CRIBL_WORKSPACE_ID
 // (e.g. cloud workspace "main") so list calls like /m/{groupId}/lib/grok succeed.
-func fallbackGroupIDs() []string {
-	ids := []string{"default", "default_search"}
+// onPrem: when true, omit default_search (restricted on on-prem).
+func fallbackGroupIDs(onPrem bool) []string {
+	ids := []string{"default"}
+	if !onPrem {
+		ids = append(ids, "default_search")
+	}
 	if w := os.Getenv("CRIBL_WORKSPACE_ID"); w != "" && w != "default" && w != "default_search" {
 		ids = append(ids, w)
 	}

--- a/tools/import-cli/internal/discovery/engine_test.go
+++ b/tools/import-cli/internal/discovery/engine_test.go
@@ -53,7 +53,7 @@ func TestDiscover_AllSupportedTypesListed(t *testing.T) {
 	reg := mustBuildRegistry(t, ctx)
 	client := sdk.New(sdk.WithServerURL(server.URL), sdk.WithClient(server.Client()))
 
-	results, err := Discover(ctx, client, reg, nil, nil, nil)
+	results, err := Discover(ctx, client, reg, nil, nil, nil, false)
 	require.NoError(t, err)
 
 	// Every registry entry gets a result (types without list method show count 0).
@@ -84,7 +84,7 @@ func TestDiscover_IncludeExcludeFilter(t *testing.T) {
 	client := sdk.New(sdk.WithServerURL(server.URL), sdk.WithClient(server.Client()))
 
 	// Only criblio_source and criblio_pipeline
-	results, err := Discover(ctx, client, reg, []string{"criblio_source", "criblio_pipeline"}, nil, nil)
+	results, err := Discover(ctx, client, reg, []string{"criblio_source", "criblio_pipeline"}, nil, nil, false)
 	require.NoError(t, err)
 	assert.Len(t, results, 2)
 	names := make(map[string]bool)
@@ -95,7 +95,7 @@ func TestDiscover_IncludeExcludeFilter(t *testing.T) {
 	assert.True(t, names["criblio_pipeline"])
 
 	// Exclude criblio_source
-	results, err = Discover(ctx, client, reg, nil, []string{"criblio_source"}, nil)
+	results, err = Discover(ctx, client, reg, nil, []string{"criblio_source"}, nil, false)
 	require.NoError(t, err)
 	for _, r := range results {
 		assert.NotEqual(t, "criblio_source", r.TypeName, "omitted type should not appear")
@@ -110,7 +110,7 @@ func TestDiscover_SDKErrorsSurfacedWithResourceContext(t *testing.T) {
 	reg := mustBuildRegistry(t, ctx)
 	client := sdk.New(sdk.WithServerURL(server.URL), sdk.WithClient(server.Client()))
 
-	results, err := Discover(ctx, client, reg, []string{"criblio_source"}, nil, nil)
+	results, err := Discover(ctx, client, reg, []string{"criblio_source"}, nil, nil, false)
 	require.NoError(t, err)
 	require.Len(t, results, 1)
 	r := results[0]
@@ -130,7 +130,7 @@ func TestDiscover_EmptyIncludeNoDiscoverableTypes(t *testing.T) {
 	client := sdk.New(sdk.WithServerURL(server.URL), sdk.WithClient(server.Client()))
 
 	// Include only a type that doesn't exist
-	results, err := Discover(ctx, client, reg, []string{"criblio_nonexistent"}, nil, nil)
+	results, err := Discover(ctx, client, reg, []string{"criblio_nonexistent"}, nil, nil, false)
 	require.NoError(t, err)
 	assert.Empty(t, results)
 }


### PR DESCRIPTION
### Goatify Release Workflow
- Add tag preparation step to create `v0.0.1-goatify` from `goatify-v0.0.1` for valid semver
- Use `GOATIFY_VERSION` in GoReleaser so release names and artifacts show the correct version (e.g. `goatify_0.0.1` instead of `goatify_v0.0.1-goatify`)

### Provider Release Workflow
- Exclude `*-goatify` tags so provider releases are not triggered by goatify tags

### On-Prem Import Support
- Exclude `default_search` from group IDs on-prem (endpoints are restricted)
- Treat expected on-prem errors as skips: "not supported for on-prem", 403, and enterprise feature errors
- Suppress "Skipped at list" output on-prem
- Add `onPrem` parameter to `Discover` and `GetGroupIDs`