### PR TITLE
changing pack id to lowercase as api needs.

### DIFF
--- a/.genignore
+++ b/.genignore
@@ -14,6 +14,14 @@ internal/provider/packroutes_resource.go
 internal/provider/packroutes_resource_sdk.go
 internal/provider/pipeline_resource.go
 internal/provider/packsource_resource_sdk.go
+internal/provider/packsource_data_source_sdk.go
+internal/provider/packvars_resource_sdk.go
+internal/provider/packvars_data_source_sdk.go
+internal/provider/packlookups_resource_sdk.go
+internal/provider/packlookups_data_source_sdk.go
+internal/provider/packdestination_resource_sdk.go
+internal/provider/packdestination_data_source_sdk.go
+internal/provider/packroutes_data_source_sdk.go
 internal/provider/pipeline_resource_sdk.go
 internal/provider/pipeline_data_source.go
 internal/provider/pipeline_data_source_sdk.go

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,12 +1,12 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: 8844b47932a447408fc6b424c75bfc8e
+  docChecksum: 834d6e911c3dcfe12f3c59d9c7103129
   docVersion: 4.14.0
   speakeasyVersion: 1.658.2
   generationVersion: 2.755.9
-  releaseVersion: 1.20.138
-  configChecksum: a2ff9327123a0b85794007ec22ce81e4
+  releaseVersion: 1.20.140
+  configChecksum: 81d172c4db83b93d294018a2b4bffbe3
   published: true
 features:
   terraform:
@@ -329,23 +329,15 @@ generatedFiles:
   - internal/provider/pack_data_source.go
   - internal/provider/pack_data_source_sdk.go
   - internal/provider/packdestination_data_source.go
-  - internal/provider/packdestination_data_source_sdk.go
   - internal/provider/packdestination_resource.go
-  - internal/provider/packdestination_resource_sdk.go
   - internal/provider/packlookups_data_source.go
-  - internal/provider/packlookups_data_source_sdk.go
   - internal/provider/packlookups_resource.go
-  - internal/provider/packlookups_resource_sdk.go
   - internal/provider/packpipeline_data_source.go
   - internal/provider/packroutes_data_source.go
-  - internal/provider/packroutes_data_source_sdk.go
   - internal/provider/packsource_data_source.go
-  - internal/provider/packsource_data_source_sdk.go
   - internal/provider/packsource_resource.go
   - internal/provider/packvars_data_source.go
-  - internal/provider/packvars_data_source_sdk.go
   - internal/provider/packvars_resource.go
-  - internal/provider/packvars_resource_sdk.go
   - internal/provider/parquetschema_data_source.go
   - internal/provider/parquetschema_data_source_sdk.go
   - internal/provider/parquetschema_resource.go

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -25,7 +25,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.20.138
+  version: 1.20.140
   additionalDataSources: []
   additionalDependencies:
     github.com/hashicorp/terraform-plugin-framework: v1.19.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,8 +2,8 @@ speakeasyVersion: 1.658.2
 sources:
     Cribl Control Plane and Management API:
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:b5acdd457e61a27f1ee591487b848e9bbdc4699d44e0c59078dca423660133ab
-        sourceBlobDigest: sha256:4d21be1e0063abd9ee24a2be9ef9675ef6c31a190603ececa7e7c1519172567e
+        sourceRevisionDigest: sha256:caf1d388ad83cba611e88928707a809b5895f4cf9db1299828327e6e40ec4220
+        sourceBlobDigest: sha256:c1dd6726b79d0ab7c3aa9b4f821860330ea656df801d52b79e18257b2901b783
         tags:
             - latest
             - 4.14.0
@@ -11,8 +11,8 @@ targets:
     cribl-io:
         source: Cribl Control Plane and Management API
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:b5acdd457e61a27f1ee591487b848e9bbdc4699d44e0c59078dca423660133ab
-        sourceBlobDigest: sha256:4d21be1e0063abd9ee24a2be9ef9675ef6c31a190603ececa7e7c1519172567e
+        sourceRevisionDigest: sha256:caf1d388ad83cba611e88928707a809b5895f4cf9db1299828327e6e40ec4220
+        sourceBlobDigest: sha256:c1dd6726b79d0ab7c3aa9b4f821860330ea656df801d52b79e18257b2901b783
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.658.2

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ page_title: "criblio Provider"
 description: |-
   Cribl Terraform Provider: The Cribl Terraform provider offers a streamlined, repeatable approach for configuring end-to-end infrastructure as code (IaC) and managing resources consistently across Cribl Organizations and Workspaces.
   This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
-  Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/. Product documentation is available at https://docs.cribl.io.
+  Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
 ---
 
 # criblio Provider
@@ -13,7 +13,7 @@ Cribl Terraform Provider: The Cribl Terraform provider offers a streamlined, rep
 
 This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
 
-Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/. Product documentation is available at https://docs.cribl.io.
+Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
 
 ## Example Usage
 
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.138"
+      version = "1.20.140"
     }
   }
 }

--- a/docs/resources/pack.md
+++ b/docs/resources/pack.md
@@ -62,10 +62,10 @@ resource "criblio_pack" "my_pack" {
 ### Optional
 
 - `allow_custom_functions` (Boolean) Requires replacement if changed.
-- `author` (String) Pack author (from pack metadata). Preserved from state when not configured.
-- `description` (String) Pack description (from pack metadata). When filename is set, this comes from the pack file and cannot be overridden; omit from config to avoid drift.
+- `author` (String) Pack author (from pack metadata). Config changes are applied via pack/settings PATCH.
+- `description` (String) Pack description (from pack metadata). Config changes are applied via pack/settings PATCH.
 - `disabled` (Boolean)
-- `display_name` (String) Pack display name (from pack metadata). When filename is set, this comes from the pack file and cannot be overridden; omit from config to avoid drift.
+- `display_name` (String) Pack display name (from pack metadata). Config changes are applied via pack/settings PATCH.
 - `exports` (List of String) Requires replacement if changed.
 - `filename` (String) Local .crbl file path to upload. File is uploaded (PUT) then the pack is installed or updated in place (PATCH); changing filename updates the existing pack rather than replacing it. When set, description and display_name come from the pack file—omit them from config to avoid drift.
 - `force` (Boolean) Requires replacement if changed.

--- a/examples/pack-settings/main.tf
+++ b/examples/pack-settings/main.tf
@@ -1,0 +1,98 @@
+resource "criblio_pack" "edge_supervisor_health" {
+  id           = "EdgeSupervisorHealth"
+  group_id     = "default_fleet"
+  description  = "EdgeSupervisorHealth - Monitors Supervisor process health on Search Deux instances"
+  disabled     = false
+  display_name = "EdgeSupervisorHealth"
+  version      = "1.0.0"
+  author       = "Observability Team"
+}
+
+# Pipeline for EdgeSupervisorHealth - processes Supervisor health check data
+resource "criblio_pack_pipeline" "edge_supervisor_health_main" {
+  id       = "main"
+  pack     = criblio_pack.edge_supervisor_health.id
+  group_id = "default_fleet"
+
+  depends_on = [
+    criblio_pack.edge_supervisor_health
+  ]
+
+  conf = {
+    streamtags = []
+
+    functions = [
+      {
+        id       = "serde"
+        filter   = "true"
+        disabled = false
+        conf = jsonencode({
+          mode     = "extract"
+          type     = "json"
+          srcField = "_raw"
+        })
+      },
+      {
+        id       = "eval"
+        filter   = "true"
+        disabled = false
+        conf = jsonencode({
+          add = [
+            {
+              name     = "_time"
+              value    = "Date.now()/1000"
+              disabled = false
+            },
+            {
+              name     = "value"
+              value    = "Number(return_code)"
+              disabled = false
+            },
+            {
+              name     = "service"
+              value    = "'search-supervisor'"
+              disabled = false
+            }
+          ]
+          remove = [
+            "cribl_*",
+            "source",
+            "_raw",
+            "return_code"
+          ]
+        })
+      },
+      {
+        id       = "publish_metrics"
+        filter   = "true"
+        disabled = false
+        conf = jsonencode({
+          overwrite = false
+          dimensions = [
+            "status",
+            "saas_domain",
+            "service",
+            "fleet",
+            "tenantId",
+            "workspace",
+            "instance",
+            "cloudProvider",
+            "instance_type",
+            "region",
+            "container_tag",
+            "container_state"
+          ]
+          removeMetrics    = []
+          removeDimensions = []
+          fields = [
+            {
+              metricType   = "gauge"
+              inFieldName  = "value"
+              outFieldExpr = "'health_check'"
+            }
+          ]
+        })
+      },
+    ]
+  }
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.20.138"
+      version = "1.20.140"
     }
   }
 }

--- a/internal/provider/pack_resource.go
+++ b/internal/provider/pack_resource.go
@@ -90,18 +90,16 @@ func (r *PackResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-					speakeasy_stringplanmodifier.PreferState(),
 				},
-				Description: `Pack author (from pack metadata). Preserved from state when not configured.`,
+				Description: `Pack author (from pack metadata). Config changes are applied via pack/settings PATCH.`,
 			},
 			"description": schema.StringAttribute{
 				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-					speakeasy_stringplanmodifier.PreferState(),
 				},
-				Description: `Pack description (from pack metadata). When filename is set, this comes from the pack file and cannot be overridden; omit from config to avoid drift.`,
+				Description: `Pack description (from pack metadata). Config changes are applied via pack/settings PATCH.`,
 			},
 			"disabled": schema.BoolAttribute{
 				Optional: true,
@@ -111,9 +109,8 @@ func (r *PackResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 				Optional: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
-					speakeasy_stringplanmodifier.PreferState(),
 				},
-				Description: `Pack display name (from pack metadata). When filename is set, this comes from the pack file and cannot be overridden; omit from config to avoid drift.`,
+				Description: `Pack display name (from pack metadata). Config changes are applied via pack/settings PATCH.`,
 			},
 			"exports": schema.ListAttribute{
 				Optional: true,
@@ -421,6 +418,7 @@ func (r *PackResource) Create(ctx context.Context, req resource.CreateRequest, r
 		checkReq, checkDiags := data.ToOperationsGetPacksByIDRequest(ctx)
 		resp.Diagnostics.Append(checkDiags...)
 		if !resp.Diagnostics.HasError() {
+			checkReq.ID = effectivePackIDForAPI(data)
 			checkRes, checkErr := r.client.Packs.GetPacksByID(ctx, *checkReq)
 			if checkErr == nil && checkRes != nil && checkRes.StatusCode == 200 {
 				packExists = true
@@ -462,6 +460,7 @@ func (r *PackResource) Create(ctx context.Context, req resource.CreateRequest, r
 				getReq, getDiags := data.ToOperationsGetPacksByIDRequest(ctx)
 				resp.Diagnostics.Append(getDiags...)
 				if !resp.Diagnostics.HasError() {
+					getReq.ID = effectivePackIDForAPI(data)
 					getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 					if getErr == nil && getRes != nil && getRes.StatusCode == 200 && getRes.Object != nil {
 						resp.Diagnostics.Append(data.RefreshFromOperationsGetPacksByIDResponseBody(ctx, getRes.Object)...)
@@ -470,13 +469,14 @@ func (r *PackResource) Create(ctx context.Context, req resource.CreateRequest, r
 			}
 		}
 		// Sync metadata (description, display_name, etc.) from config via pack/settings.
-		if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), data.ID.ValueString(), data); patchErr != nil {
+		if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), effectivePackIDForAPI(data), data); patchErr != nil {
 			resp.Diagnostics.AddError("pack settings sync failed", fmt.Sprintf("Could not update pack metadata via pack/settings: %v", patchErr))
 			return
 		}
 		getReq, getDiags := data.ToOperationsGetPacksByIDRequest(ctx)
 		resp.Diagnostics.Append(getDiags...)
 		if !resp.Diagnostics.HasError() {
+			getReq.ID = effectivePackIDForAPI(data)
 			getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 			if getErr == nil && getRes != nil && getRes.StatusCode == 200 && getRes.Object != nil {
 				resp.Diagnostics.Append(data.RefreshFromOperationsGetPacksByIDResponseBody(ctx, getRes.Object)...)
@@ -513,7 +513,7 @@ func (r *PackResource) Create(ctx context.Context, req resource.CreateRequest, r
 		}
 		resp.Diagnostics.Append(data.RefreshFromOperationsCreatePacksResponseBody(ctx, res.Object)...)
 		// Sync metadata (description, display_name, etc.) from config via pack/settings.
-		if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), data.ID.ValueString(), data); patchErr != nil {
+		if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), effectivePackIDForAPI(data), data); patchErr != nil {
 			resp.Diagnostics.AddError("pack settings sync failed", fmt.Sprintf("Could not update pack metadata via pack/settings: %v", patchErr))
 			return
 		}
@@ -534,6 +534,8 @@ func (r *PackResource) Create(ctx context.Context, req resource.CreateRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// Use server's pack ID (e.g. lowercase) after Create; GET /packs/{id} is case-sensitive.
+	request1.ID = effectivePackIDForAPI(data)
 	res1, err := r.client.Packs.GetPacksByID(ctx, *request1)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
@@ -595,6 +597,7 @@ func (r *PackResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	request.ID = effectivePackIDForAPI(data)
 	res, err := r.client.Packs.GetPacksByID(ctx, *request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
@@ -743,7 +746,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 	// When only metadata changed (no upload, no source in plan or state): update via PACK /pack/settings only; do not call PATCH (API requires source).
 	if uploadedSource == "" && (request.Source == nil || *request.Source == "") {
-		if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), data.ID.ValueString(), data); patchErr != nil {
+		if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), effectivePackIDForAPI(data), data); patchErr != nil {
 			resp.Diagnostics.AddError("failure to update pack settings", patchErr.Error())
 			return
 		}
@@ -753,6 +756,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		if resp.Diagnostics.HasError() {
 			return
 		}
+		getReq.ID = effectivePackIDForAPI(data)
 		getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 		if getErr != nil {
 			resp.Diagnostics.AddError("failure to invoke API", getErr.Error())
@@ -813,6 +817,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 				getReq, getDiags := data.ToOperationsGetPacksByIDRequest(ctx)
 				resp.Diagnostics.Append(getDiags...)
 				if !resp.Diagnostics.HasError() {
+					getReq.ID = effectivePackIDForAPI(data)
 					getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 					if getErr == nil && getRes != nil && getRes.StatusCode == 200 && getRes.Object != nil {
 						patchRes = &operations.UpdatePacksByIDResponse{StatusCode: 200, Object: &operations.UpdatePacksByIDResponseBody{Items: getRes.Object.Items}}
@@ -822,7 +827,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 		// Sync metadata (description, display_name, etc.) from config via pack/settings after install.
 		if patchRes != nil {
-			if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), data.ID.ValueString(), data); patchErr != nil {
+			if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), effectivePackIDForAPI(data), data); patchErr != nil {
 				resp.Diagnostics.AddError("pack settings sync failed", fmt.Sprintf("Could not update pack metadata via pack/settings: %v", patchErr))
 				return
 			}
@@ -830,6 +835,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			getReq, getDiags := data.ToOperationsGetPacksByIDRequest(ctx)
 			resp.Diagnostics.Append(getDiags...)
 			if !resp.Diagnostics.HasError() {
+				getReq.ID = effectivePackIDForAPI(data)
 				getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 					if getErr == nil && getRes != nil && getRes.StatusCode == 200 && getRes.Object != nil {
 						resp.Diagnostics.Append(data.RefreshFromOperationsGetPacksByIDResponseBody(ctx, getRes.Object)...)
@@ -846,7 +852,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 	} else {
 		// Sync metadata via pack/settings when plan has author/description/etc.
-		if err := r.patchPackSettings(ctx, data.GroupID.ValueString(), data.ID.ValueString(), data); err != nil {
+		if err := r.patchPackSettings(ctx, data.GroupID.ValueString(), effectivePackIDForAPI(data), data); err != nil {
 			resp.Diagnostics.AddError("pack settings sync failed", fmt.Sprintf("Could not update pack metadata via pack/settings: %v", err))
 			return
 		}
@@ -857,6 +863,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			if resp.Diagnostics.HasError() {
 				return
 			}
+			getReq.ID = effectivePackIDForAPI(data)
 			getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 			if getErr != nil {
 				resp.Diagnostics.AddError("failure to invoke API", getErr.Error())
@@ -895,6 +902,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 			getReq, getDiags := data.ToOperationsGetPacksByIDRequest(ctx)
 			resp.Diagnostics.Append(getDiags...)
 			if !resp.Diagnostics.HasError() {
+				getReq.ID = effectivePackIDForAPI(data)
 				getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 				if getErr == nil && getRes != nil && getRes.StatusCode == 200 && getRes.Object != nil {
 					patchRes = &operations.UpdatePacksByIDResponse{StatusCode: 200, Object: &operations.UpdatePacksByIDResponseBody{Items: getRes.Object.Items}}
@@ -903,13 +911,14 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 		// Sync metadata after pack PATCH (PATCH may reinstall from source and reset metadata).
 		if patchRes != nil {
-			if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), data.ID.ValueString(), data); patchErr != nil {
+			if patchErr := r.patchPackSettings(ctx, data.GroupID.ValueString(), effectivePackIDForAPI(data), data); patchErr != nil {
 				resp.Diagnostics.AddError("pack settings sync failed", fmt.Sprintf("Could not update pack metadata via pack/settings: %v", patchErr))
 				return
 			}
 			getReq, getDiags := data.ToOperationsGetPacksByIDRequest(ctx)
 			resp.Diagnostics.Append(getDiags...)
 			if !resp.Diagnostics.HasError() {
+				getReq.ID = effectivePackIDForAPI(data)
 				getRes, getErr := r.client.Packs.GetPacksByID(ctx, *getReq)
 				if getErr == nil && getRes != nil && getRes.StatusCode == 200 && getRes.Object != nil {
 					resp.Diagnostics.Append(data.RefreshFromOperationsGetPacksByIDResponseBody(ctx, getRes.Object)...)
@@ -958,6 +967,7 @@ func (r *PackResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	request1.ID = effectivePackIDForAPI(data)
 	res1, err := r.client.Packs.GetPacksByID(ctx, *request1)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
@@ -1018,6 +1028,8 @@ func (r *PackResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	// API expects server's pack ID (lowercase); DELETE /packs/{id} is case-sensitive.
+	request.ID = effectivePackIDForAPI(data)
 	res, err := r.client.Packs.DeletePacksByID(ctx, *request)
 	if err != nil {
 		resp.Diagnostics.AddError("failure to invoke API", err.Error())
@@ -1186,6 +1198,16 @@ func fullSourcePath(source string) string {
 		return source
 	}
 	return "file:/opt/cribl_config/state/packs/" + source
+}
+
+// effectivePackIDForAPI returns the pack ID to use for pack API calls (GetPacksByID, pack/settings, etc.).
+// The Cribl API normalizes pack IDs (e.g. to lowercase) when creating; these endpoints are case-sensitive.
+// When Items is populated from an install response, use Items[0].ID; otherwise use lowercase of config id.
+func effectivePackIDForAPI(data *PackResourceModel) string {
+	if len(data.Items) > 0 && !data.Items[0].ID.IsNull() && !data.Items[0].ID.IsUnknown() {
+		return data.Items[0].ID.ValueString()
+	}
+	return strings.ToLower(data.ID.ValueString())
 }
 
 // shortNameForPatch returns the source value for PATCH: API expects only the filename (e.g. "billing_pipeline.W3avtlR.crbl");

--- a/internal/provider/packbreakers_data_source_sdk.go
+++ b/internal/provider/packbreakers_data_source_sdk.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -101,7 +103,7 @@ func (r *PackBreakersDataSourceModel) ToOperationsGetBreakersByPackAndIDRequest(
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packbreakers_resource_sdk.go
+++ b/internal/provider/packbreakers_resource_sdk.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -138,7 +140,7 @@ func (r *PackBreakersResourceModel) ToOperationsCreateBreakersByPackRequest(ctx 
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -166,7 +168,7 @@ func (r *PackBreakersResourceModel) ToOperationsDeleteBreakersByPackAndIDRequest
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -187,7 +189,7 @@ func (r *PackBreakersResourceModel) ToOperationsGetBreakersByPackAndIDRequest(ct
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -208,7 +210,7 @@ func (r *PackBreakersResourceModel) ToOperationsUpdateBreakersByPackAndIDRequest
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packdestination_data_source_sdk.go
+++ b/internal/provider/packdestination_data_source_sdk.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 )
@@ -18,7 +20,7 @@ func (r *PackDestinationDataSourceModel) ToOperationsGetPackOutputByIDRequest(ct
 	groupID = r.GroupID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	out := operations.GetPackOutputByIDRequest{
 		ID:      id,

--- a/internal/provider/packdestination_resource_sdk.go
+++ b/internal/provider/packdestination_resource_sdk.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
+
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -17,7 +19,7 @@ func (r *PackDestinationResourceModel) ToOperationsCreatePackOutputRequest(ctx c
 	groupID = r.GroupID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var id string
 	id = r.ID.ValueString()
@@ -49,7 +51,7 @@ func (r *PackDestinationResourceModel) ToOperationsDeletePackOutputByIDRequest(c
 	groupID = r.GroupID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	out := operations.DeletePackOutputByIDRequest{
 		ID:      id,
@@ -70,7 +72,7 @@ func (r *PackDestinationResourceModel) ToOperationsGetPackOutputByIDRequest(ctx 
 	groupID = r.GroupID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	out := operations.GetPackOutputByIDRequest{
 		ID:      id,
@@ -91,7 +93,7 @@ func (r *PackDestinationResourceModel) ToOperationsUpdatePackOutputByIDRequest(c
 	groupID = r.GroupID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	output, outputDiags := r.ToSharedOutput(ctx)
 	diags.Append(outputDiags...)

--- a/internal/provider/packlookups_data_source_sdk.go
+++ b/internal/provider/packlookups_data_source_sdk.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -56,7 +58,7 @@ func (r *PackLookupsDataSourceModel) ToOperationsGetSystemLookupsByPackAndIDRequ
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packlookups_resource_sdk.go
+++ b/internal/provider/packlookups_resource_sdk.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -129,7 +131,7 @@ func (r *PackLookupsResourceModel) ToOperationsCreateSystemLookupsByPackAndIDReq
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -155,7 +157,7 @@ func (r *PackLookupsResourceModel) ToOperationsCreateSystemLookupsByPackRequest(
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -183,7 +185,7 @@ func (r *PackLookupsResourceModel) ToOperationsDeleteSystemLookupsByPackAndIDReq
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -204,7 +206,7 @@ func (r *PackLookupsResourceModel) ToOperationsGetSystemLookupsByPackAndIDReques
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packpipeline_data_source_sdk.go
+++ b/internal/provider/packpipeline_data_source_sdk.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -83,8 +85,8 @@ func (r *PackPipelineDataSourceModel) RefreshFromSharedPipeline(ctx context.Cont
 func (r *PackPipelineDataSourceModel) ToOperationsGetPipelinesByPackWithIDRequest(ctx context.Context) (*operations.GetPipelinesByPackWithIDRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	var pack string
-	pack = r.Pack.ValueString()
+	// API normalizes pack IDs to lowercase; pack path is case-sensitive.
+	pack := strings.ToLower(r.Pack.ValueString())
 
 	var id string
 	id = r.ID.ValueString()

--- a/internal/provider/packpipeline_resource_sdk.go
+++ b/internal/provider/packpipeline_resource_sdk.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -113,8 +115,8 @@ func (r *PackPipelineResourceModel) RefreshFromSharedPipeline(ctx context.Contex
 func (r *PackPipelineResourceModel) ToOperationsCreatePipelineByPackRequest(ctx context.Context) (*operations.CreatePipelineByPackRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	var pack string
-	pack = r.Pack.ValueString()
+	// API normalizes pack IDs to lowercase; pack path is case-sensitive.
+	pack := strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -138,8 +140,8 @@ func (r *PackPipelineResourceModel) ToOperationsCreatePipelineByPackRequest(ctx 
 func (r *PackPipelineResourceModel) ToOperationsGetPipelinesByPackWithIDRequest(ctx context.Context) (*operations.GetPipelinesByPackWithIDRequest, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	var pack string
-	pack = r.Pack.ValueString()
+	// API normalizes pack IDs to lowercase; pack path is case-sensitive.
+	pack := strings.ToLower(r.Pack.ValueString())
 
 	var id string
 	id = r.ID.ValueString()
@@ -162,8 +164,8 @@ func (r *PackPipelineResourceModel) ToOperationsUpdatePipelineByPackAndIDRequest
 	var id string
 	id = r.ID.ValueString()
 
-	var pack string
-	pack = r.Pack.ValueString()
+	// API normalizes pack IDs to lowercase; pack path is case-sensitive.
+	pack := strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packroutes_data_source_sdk.go
+++ b/internal/provider/packroutes_data_source_sdk.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
@@ -94,7 +96,7 @@ func (r *PackRoutesDataSourceModel) ToOperationsGetRoutesByPackRequest(ctx conte
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packroutes_resource_sdk.go
+++ b/internal/provider/packroutes_resource_sdk.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -173,7 +175,7 @@ func (r *PackRoutesResourceModel) ToOperationsCreateRoutesByPackRequest(ctx cont
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -199,7 +201,7 @@ func (r *PackRoutesResourceModel) ToOperationsGetRoutesByPackRequest(ctx context
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packsource_data_source_sdk.go
+++ b/internal/provider/packsource_data_source_sdk.go
@@ -5,6 +5,8 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -7264,7 +7266,7 @@ func (r *PackSourceDataSourceModel) ToOperationsGetSystemInputsByPackAndIDReques
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packsource_resource_sdk.go
+++ b/internal/provider/packsource_resource_sdk.go
@@ -5,6 +5,7 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -114,7 +115,7 @@ func (r *PackSourceResourceModel) ToOperationsCreateSystemInputsByPackRequest(ct
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -143,7 +144,7 @@ func (r *PackSourceResourceModel) ToOperationsDeleteSystemInputsByPackRequest(ct
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -167,7 +168,7 @@ func (r *PackSourceResourceModel) ToOperationsGetSystemInputsByPackAndIDRequest(
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -185,7 +186,7 @@ func (r *PackSourceResourceModel) ToOperationsUpdateSystemInputsByPackRequest(ct
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packvars_data_source_sdk.go
+++ b/internal/provider/packvars_data_source_sdk.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -65,7 +67,7 @@ func (r *PackVarsDataSourceModel) ToOperationsGetGlobalVariableLibVarsByPackAndI
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/packvars_resource_sdk.go
+++ b/internal/provider/packvars_resource_sdk.go
@@ -4,6 +4,8 @@ package provider
 
 import (
 	"context"
+	"strings"
+
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
@@ -102,7 +104,7 @@ func (r *PackVarsResourceModel) ToOperationsCreateGlobalVariableLibVarsByPackReq
 	var diags diag.Diagnostics
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -130,7 +132,7 @@ func (r *PackVarsResourceModel) ToOperationsDeleteGlobalVariableLibVarsByPackAnd
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -151,7 +153,7 @@ func (r *PackVarsResourceModel) ToOperationsGetGlobalVariableLibVarsByPackAndIDR
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()
@@ -172,7 +174,7 @@ func (r *PackVarsResourceModel) ToOperationsUpdateGlobalVariableLibVarsByPackAnd
 	id = r.ID.ValueString()
 
 	var pack string
-	pack = r.Pack.ValueString()
+	pack = strings.ToLower(r.Pack.ValueString())
 
 	var groupID string
 	groupID = r.GroupID.ValueString()

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -87,7 +87,7 @@ func (p *CriblioProvider) Schema(ctx context.Context, req provider.SchemaRequest
 			`` + "\n" +
 			`This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.` + "\n" +
 			`` + "\n" +
-			`Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/. Product documentation is available at https://docs.cribl.io.`,
+			`Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.`,
 	}
 }
 

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -58,7 +58,7 @@ func Pointer[T any](v T) *T { return &v }
 //
 // This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
 //
-// Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/. Product documentation is available at https://docs.cribl.io.
+// Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
 type CriblIo struct {
 	SDKVersion string
 	// Actions related to REST server health
@@ -358,9 +358,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.20.138",
+		SDKVersion: "1.20.140",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.20.138 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.20.140 2.755.9 4.14.0 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/openapi.yml
+++ b/openapi.yml
@@ -6,7 +6,7 @@ info:
 
     This Preview feature is still being developed. We do not recommend using it in a production environment, because the feature might not be fully tested or optimized for performance, and related documentation could be incomplete.
 
-    Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/control-plane/cribl-core/. Product documentation is available at https://docs.cribl.io.
+    Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
   version: 4.14.0
   contact:
     name: Support

--- a/tests/acceptance/pack_settings_test.go
+++ b/tests/acceptance/pack_settings_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestPackSettings(t *testing.T) {
+	if os.Getenv("DEPLOYMENT") == "onprem" {
+		t.Skip("Skipping pack test for on-prem: uses HelloPacks which causes API 500 errors")
+	}
+	t.Run("plan-diff", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: providerFactory,
+			Steps: []resource.TestStep{
+				{
+					ConfigDirectory: config.TestNameDirectory(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("criblio_pack.edge_supervisor_health", "id", "EdgeSupervisorHealth"),
+						resource.TestCheckResourceAttr("criblio_pack.edge_supervisor_health", "group_id", "default_fleet"),
+						resource.TestCheckResourceAttr("criblio_pack.edge_supervisor_health", "description", "EdgeSupervisorHealth - Monitors Supervisor process health on Search Deux instances"),
+						resource.TestCheckResourceAttr("criblio_pack.edge_supervisor_health", "display_name", "EdgeSupervisorHealth"),
+						resource.TestCheckResourceAttr("criblio_pack_pipeline.edge_supervisor_health_main", "id", "main"),
+						resource.TestCheckResourceAttr("criblio_pack_pipeline.edge_supervisor_health_main", "pack", "EdgeSupervisorHealth"),
+					),
+				},
+				{
+					ConfigDirectory: config.TestNameDirectory(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+				},
+			},
+		})
+	})
+}

--- a/tests/acceptance/testdata/TestPackSettings/plan-diff/main.tf
+++ b/tests/acceptance/testdata/TestPackSettings/plan-diff/main.tf
@@ -1,0 +1,1 @@
+../../../../../examples/pack-settings/main.tf


### PR DESCRIPTION
# Fix pack ID case sensitivity and pack metadata updates

## Changes

- **Pack ID normalization:** Use `strings.ToLower()` for pack IDs in all pack-scoped SDK files (source, vars, lookups, destination, routes, breakers) and for pack delete.
- **.genignore:** Add pack SDK files so changes are not overwritten by `speakeasy generate`.
- **Pack metadata:** Remove `PreferState()` from `author`, `description`, and `display_name` so config changes are applied via pack/settings PATCH.
- **Tests:** Added `pack_settings_test.go` to use correct resource names and simpler checks, issues like this will be caught in future.
- **Docs:** Updated docs references as needed by Hillary