### PR TITLE
Replace Trivy with Grype for vulnerability scanning

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -57,16 +57,16 @@ jobs:
             sbom-cyclonedx.json
           retention-days: 30
       
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+      - name: Run Grype vulnerability scanner
+        uses: anchore/scan-action@1638637db639e0ade3258b51db49a9a137574c3e # v6
+        id: grype-scan
         with:
-          scan-type: 'fs'
-          scan-ref: '.'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-      
-      - name: Upload Trivy scan results
+          path: '.'
+          fail-build: false
+          output-format: 'sarif'
+
+      - name: Upload Grype scan results
         uses: github/codeql-action/upload-sarif@v3
         with:
-          sarif_file: 'trivy-results.sarif'
-          category: 'trivy-sbom-scan'
+          sarif_file: ${{ steps.grype-scan.outputs.sarif }}
+          category: 'grype-sbom-scan'

--- a/SBOM.md
+++ b/SBOM.md
@@ -62,7 +62,7 @@ SBOM files are automatically attached to GitHub releases as:
 
 The SBOM generation process includes:
 
-- **Trivy Scanner** - Filesystem vulnerability scanning
+- **Grype Scanner** - Filesystem vulnerability scanning
 - **SARIF Upload** - Results uploaded to GitHub Security tab
 - **Dependency Analysis** - Go module dependency scanning
 


### PR DESCRIPTION
- Switch from aquasecurity/trivy-action to anchore/scan-action
- Pin action to specific commit hash for security
- Update SBOM.md documentation