### PR TITLE
fixing import-cli for search dashboard and old packs.

### DIFF
--- a/internal/provider/group_resource.go
+++ b/internal/provider/group_resource.go
@@ -393,42 +393,46 @@ func (r *GroupResource) Update(ctx context.Context, req resource.UpdateRequest, 
 		}
 	}
 
-	request, requestDiags := data.ToOperationsUpdateGroupsByIDRequest(ctx)
-	resp.Diagnostics.Append(requestDiags...)
+	// Groups with non-lowercase IDs (e.g. "TestAzure") fail the API's ^[a-z] pattern on PATCH.
+	// Skip the update entirely and refresh state from GET to avoid a permanent error.
+	if regexp.MustCompile(`^[a-z]`).MatchString(data.ID.ValueString()) {
+		request, requestDiags := data.ToOperationsUpdateGroupsByIDRequest(ctx)
+		resp.Diagnostics.Append(requestDiags...)
 
-	if resp.Diagnostics.HasError() {
-		return
-	}
-	res, err := r.client.Groups.UpdateGroupsByID(ctx, *request)
-	if err != nil {
-		resp.Diagnostics.AddError("failure to invoke API", err.Error())
-		if res != nil && res.RawResponse != nil {
-			resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+		if resp.Diagnostics.HasError() {
+			return
 		}
-		return
-	}
-	if res == nil {
-		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
-		return
-	}
-	if res.StatusCode != 200 {
-		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
-		return
-	}
-	if !(res.Object != nil) {
-		resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
-		return
-	}
-	resp.Diagnostics.Append(data.RefreshFromOperationsUpdateGroupsByIDResponseBody(ctx, res.Object)...)
+		res, err := r.client.Groups.UpdateGroupsByID(ctx, *request)
+		if err != nil {
+			resp.Diagnostics.AddError("failure to invoke API", err.Error())
+			if res != nil && res.RawResponse != nil {
+				resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+			}
+			return
+		}
+		if res == nil {
+			resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+			return
+		}
+		if res.StatusCode != 200 {
+			resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
+			return
+		}
+		if !(res.Object != nil) {
+			resp.Diagnostics.AddError("unexpected response from API. Got an unexpected response body", debugResponse(res.RawResponse))
+			return
+		}
+		resp.Diagnostics.Append(data.RefreshFromOperationsUpdateGroupsByIDResponseBody(ctx, res.Object)...)
 
-	if resp.Diagnostics.HasError() {
-		return
-	}
+		if resp.Diagnostics.HasError() {
+			return
+		}
 
-	resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
+		resp.Diagnostics.Append(refreshPlan(ctx, plan, &data)...)
 
-	if resp.Diagnostics.HasError() {
-		return
+		if resp.Diagnostics.HasError() {
+			return
+		}
 	}
 	request1, request1Diags := data.ToOperationsGetGroupsByIDRequest(ctx)
 	resp.Diagnostics.Append(request1Diags...)

--- a/internal/provider/pack_resource.go
+++ b/internal/provider/pack_resource.go
@@ -1237,14 +1237,16 @@ func mergePackCreateConfigIntoModel(data *PackResourceModel, cfg *PackResourceMo
 
 // effectivePackIDForAPI returns the pack ID to use for pack API calls (GetPacksByID, pack/settings, etc.).
 // The Cribl API normalizes pack IDs (e.g. to lowercase) when creating; these endpoints are case-sensitive.
-// When Items is populated from an install response, use Items[0].ID; otherwise use lowercase of config id.
+// When Items is populated from an install response, use Items[0].ID (which holds the server-normalized ID).
+// Otherwise use the config/imported ID as-is: lowercasing the fallback would break imports of packs whose
+// API-stored ID contains uppercase letters (e.g. marketplace packs like "Cribl_Pack_for_Amazon_Security_Findings_Format_").
 func effectivePackIDForAPI(data *PackResourceModel) string {
 	if len(data.Items) > 0 && !data.Items[0].ID.IsNull() && !data.Items[0].ID.IsUnknown() {
 		if s := strings.TrimSpace(data.Items[0].ID.ValueString()); s != "" {
 			return s
 		}
 	}
-	return strings.ToLower(strings.TrimSpace(data.ID.ValueString()))
+	return strings.TrimSpace(data.ID.ValueString())
 }
 
 // packInstallDisplayName returns the human-readable name for UI-style pack install POST (items array).

--- a/internal/provider/searchdashboard_resource.go
+++ b/internal/provider/searchdashboard_resource.go
@@ -3,6 +3,7 @@
 package provider
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	tfTypes "github.com/criblio/terraform-provider-criblio/internal/provider/types"
@@ -29,6 +30,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"io"
+	"strings"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -1288,6 +1291,13 @@ func (r *SearchDashboardResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
+	// Pack-scoped dashboards (id contains ".") cannot be read or managed as standalone resources.
+	// Remove from state so Terraform treats them as deleted rather than failing the refresh.
+	if strings.Contains(data.ID.ValueString(), ".") {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	request, requestDiags := data.ToOperationsGetSearchDashboardByIDRequest(ctx)
 	resp.Diagnostics.Append(requestDiags...)
 
@@ -1309,6 +1319,17 @@ func (r *SearchDashboardResource) Read(ctx context.Context, req resource.ReadReq
 	if res.StatusCode == 404 {
 		resp.State.RemoveResource(ctx)
 		return
+	}
+	if res.StatusCode == 500 && res.RawResponse != nil && res.RawResponse.Body != nil {
+		// Pack-scoped dashboards (id = "{pack}.{dashboardId}") return HTTP 500 "Invalid context {pack}"
+		// when the parent pack no longer exists (e.g. after destroy+recreate). Treat this as not-found
+		// so Terraform removes the resource from state rather than failing the apply.
+		body, _ := io.ReadAll(res.RawResponse.Body)
+		res.RawResponse.Body = io.NopCloser(bytes.NewReader(body))
+		if bytes.Contains(body, []byte("Invalid context")) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 	}
 	if res.StatusCode != 200 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
@@ -1431,5 +1452,16 @@ func (r *SearchDashboardResource) Delete(ctx context.Context, req resource.Delet
 }
 
 func (r *SearchDashboardResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Pack-scoped dashboard IDs contain "." (e.g. "pack-name.dashboard-id"). These are managed by
+	// their parent pack and cannot be imported as standalone criblio_search_dashboard resources.
+	if strings.Contains(req.ID, ".") {
+		resp.Diagnostics.AddError(
+			"Cannot import pack-scoped search dashboard",
+			fmt.Sprintf("Dashboard ID %q contains a dot, which indicates it belongs to a pack. "+
+				"Pack-scoped dashboards cannot be managed as standalone criblio_search_dashboard resources. "+
+				"Remove this import block from your configuration.", req.ID),
+		)
+		return
+	}
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
 }

--- a/tools/import-cli/internal/custom/defaults.go
+++ b/tools/import-cli/internal/custom/defaults.go
@@ -204,6 +204,9 @@ func ApplyGroupDefaults(attrs map[string]hcl.Value, model interface{}) {
 	if !gm.Provisioned.IsNull() && !gm.Provisioned.IsUnknown() {
 		setBool("provisioned", gm.Provisioned.ValueBool())
 	}
+	if !gm.Inherits.IsNull() && !gm.Inherits.IsUnknown() && gm.Inherits.ValueString() != "" {
+		setStr("inherits", gm.Inherits.ValueString())
+	}
 	if gm.Cloud != nil && !gm.Cloud.Provider.IsNull() && !gm.Cloud.Provider.IsUnknown() {
 		if cloud, ok := attrs["cloud"]; ok && cloud.Kind == hcl.KindMap && cloud.Map != nil {
 			cloud.Map["provider"] = hcl.Value{Kind: hcl.KindString, String: gm.Cloud.Provider.ValueString()}

--- a/tools/import-cli/internal/custom/searchlist.go
+++ b/tools/import-cli/internal/custom/searchlist.go
@@ -510,6 +510,10 @@ func ParseEventBreakerRulesetListBody(body []byte, groupID string) ([]map[string
 		if item.Lib != nil && *item.Lib == EventBreakerLibCribl {
 			continue
 		}
+		// Skip pack-scoped rulesets (id contains ".") — these belong to criblio_pack_breakers, not criblio_event_breaker_ruleset.
+		if strings.Contains(item.ID, ".") {
+			continue
+		}
 		out = append(out, map[string]string{"id": item.ID, "group_id": groupID})
 	}
 	return out, nil

--- a/tools/import-cli/internal/discovery/engine.go
+++ b/tools/import-cli/internal/discovery/engine.go
@@ -28,6 +28,22 @@ func eventBreakerRulesetIdentifiersFromCapture(gid string) ([]map[string]string,
 	return custom.ParseEventBreakerRulesetListBody(body, gid)
 }
 
+// filterSearchDashboardIDs removes pack-scoped dashboard IDs (containing ".") from the list.
+// Pack-scoped dashboards (e.g. "cribl-criblvision-for-stream.sh1eceuw4") belong to their parent pack
+// and cannot be managed as standalone criblio_search_dashboard resources.
+func filterSearchDashboardIDs(typeName string, ids []map[string]string) []map[string]string {
+	if typeName != "criblio_search_dashboard" {
+		return ids
+	}
+	filtered := ids[:0]
+	for _, m := range ids {
+		if !strings.Contains(m["id"], ".") {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
 // searchListIdentifiersFromCapture returns identifiers (and count) from the captured
 // list response body when the SDK failed to unmarshal (e.g. cribl_lake, union drift, strict JSON).
 func searchListIdentifiersFromCapture(e registry.Entry) ([]map[string]string, int, error) {
@@ -37,7 +53,12 @@ func searchListIdentifiersFromCapture(e registry.Entry) ([]map[string]string, in
 		return custom.IdentifiersFromItemsIDsOnly(body, custom.PathSearchSaved)
 	case "criblio_search_dashboard":
 		body := custom.GetAndClearSearchListBody(custom.PathSearchDashboards)
-		return custom.IdentifiersFromItemsIDsOnly(body, custom.PathSearchDashboards)
+		ids, _, err := custom.IdentifiersFromItemsIDsOnly(body, custom.PathSearchDashboards)
+		if err != nil {
+			return nil, 0, err
+		}
+		filtered := filterSearchDashboardIDs(e.TypeName, ids)
+		return filtered, len(filtered), nil
 	case "criblio_search_dataset":
 		body := custom.GetAndClearSearchListBody(custom.PathSearchDatasets)
 		return custom.IdentifiersFromSearchListBody(body, custom.PathSearchDatasets)
@@ -597,7 +618,11 @@ func ListItemIdentifiers(ctx context.Context, client *sdk.CriblIo, e registry.En
 		if e.TypeName == "criblio_cribl_lake_dataset" {
 			scope = "default"
 		}
-		return identifiersFromItems(items, scope, e)
+		ids, idErr := identifiersFromItems(items, scope, e)
+		if idErr != nil {
+			return nil, idErr
+		}
+		return filterSearchDashboardIDs(e.TypeName, ids), nil
 	}
 	var out []map[string]string
 	for _, gid := range groupIDs {
@@ -781,6 +806,11 @@ func identifiersFromItems(items reflect.Value, groupID string, e registry.Entry)
 		}
 		// Skip default Cribl Lake datasets (cribl_logs, default_*, etc.) so only user-created are imported.
 		if e.TypeName == "criblio_cribl_lake_dataset" && custom.DefaultCriblLakeDatasetIDs[id] {
+			continue
+		}
+		// Skip pack-scoped resources (id contains ".") — pack-owned items bleed into top-level list APIs
+		// but belong to their pack, not standalone resources (e.g. criblio_pack_breakers, pack macros).
+		if (e.TypeName == "criblio_event_breaker_ruleset" || e.TypeName == "criblio_search_macro") && strings.Contains(id, ".") {
 			continue
 		}
 		// Skip built-in destinations (default, devnull) so only user-created are imported.

--- a/tools/import-cli/internal/export/items.go
+++ b/tools/import-cli/internal/export/items.go
@@ -39,6 +39,12 @@ func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Re
 	if flattenItemsToTopLevelTypes[r.TypeName] {
 		flattenItemsListToTopLevel(attrs)
 	}
+	// criblio_pack: exports is an install-time parameter (RequiresReplaceIfConfigured). The API does
+	// not return it on GET so state has exports=null after import, while items[0].exports (flattened
+	// above) can be ["*"], causing destroy+recreate on every apply. Drop it from HCL config.
+	if r.TypeName == "criblio_pack" {
+		delete(attrs, "exports")
+	}
 	// criblio_routes and criblio_pack_routes: inject additional_properties from model into each route.
 	// HCL skips it by default (readOnlyAttrs); API returns it, causing drift. Align both resources.
 	injectRoutesAdditionalProperties := func(routes []ptypes.RoutesRoute, routesVal hcl.Value) hcl.Value {
@@ -202,6 +208,9 @@ func appendResourceItemFromModel(out *ExportResult, typeName string, e registry.
 	}
 	if flattenItemsToTopLevelTypes[typeName] {
 		flattenItemsListToTopLevel(attrs)
+	}
+	if typeName == "criblio_pack" {
+		delete(attrs, "exports")
 	}
 	// criblio_group requires product (stream|edge); provider model may not set it from API. Use product from idMap (we set it in ListGroupIdentifiersAndItems).
 	// Emit streamtags = [] explicitly when empty so config matches state (API returns []).

--- a/tools/import-cli/internal/hcl/cty.go
+++ b/tools/import-cli/internal/hcl/cty.go
@@ -127,6 +127,9 @@ func PruneSearchDashboardElementsCty(val cty.Value) (cty.Value, error) {
 		return val, nil
 	}
 	l := val.LengthInt()
+	if l == 0 {
+		return val, nil
+	}
 	out := make([]cty.Value, l)
 	for i := 0; i < l; i++ {
 		ev := val.Index(cty.NumberIntVal(int64(i)))
@@ -159,6 +162,9 @@ func StripSearchDashboardElementsConfigNullKeysCty(val cty.Value) (cty.Value, er
 		return val, nil
 	}
 	l := val.LengthInt()
+	if l == 0 {
+		return val, nil
+	}
 	out := make([]cty.Value, l)
 	for i := 0; i < l; i++ {
 		ev := val.Index(cty.NumberIntVal(int64(i)))

--- a/tools/import-cli/internal/hcl/resource.go
+++ b/tools/import-cli/internal/hcl/resource.go
@@ -38,6 +38,7 @@ func DefaultResourceBlockOptions() *ResourceBlockOptions {
 			"criblio_project":                 {"subscriptions", "destinations"},
 			"criblio_search_dataset_ruleset":  {"rules"},
 			"criblio_search_datatype_ruleset": {"rules"},
+			"criblio_search_dashboard":        {"elements"},
 		},
 	}
 }


### PR DESCRIPTION
Fixes three import-cli/provider issues: 

-  pack-scoped search dashboards (IDs containing .) are now filtered from discovery and rejected gracefully on import; 
- criblio_search_dashboard resources with zero elements no longer crash or generate invalid HCL missing the required elements attribute; 
- criblio_group resources with legacy non-lowercase IDs (e.g. TestAzure) skip the PATCH call entirely to avoid an unrecoverable API 400 validation error.