### PR TITLE
collector resource: discover_request_params schema and conf update plan modifier

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,11 +1,11 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: ad6fe8e06ba61a080887400bacab7bc0
+  docChecksum: 15606be21fbd4b94a3287f50927f5681
   speakeasyVersion: 1.761.1
   generationVersion: 2.879.6
-  releaseVersion: 1.23.31
-  configChecksum: 33892b69f52ebd0a387fddd7c062e515
+  releaseVersion: 1.23.32
+  configChecksum: 1c415a416136861c189dc209e0a9dc09
   published: true
 persistentEdits:
   generation_id: e52d5ce0-d97b-4ec8-89ab-e5f05e0474e8
@@ -278,7 +278,7 @@ trackedFiles:
     pristine_git_object: 1959198f7669fee4593aeb084e44e34317718e0d
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:4c533b010a643145faf2a3b92da0176e9ca77aab
+    last_write_checksum: sha1:c2e4ae8c5164fd3aef5903aa9d74d19ace7c93ea
     pristine_git_object: 02f445a76d1365acf6ca17232bb2e4c0a07e52ea
   examples/resources/criblio_appscope_config/import-by-string-id.tf:
     id: 13b421bc255d
@@ -314,7 +314,7 @@ trackedFiles:
     pristine_git_object: 34881c7aef598a7326bc17e95699982113b35320
   examples/resources/criblio_collector/resource.tf:
     id: bdc9d57d429e
-    last_write_checksum: sha1:31ac55ef3444a858630a85dd57bf7cdb2f75cda9
+    last_write_checksum: sha1:94d5ce5649b044ad2de8331a3979ba441cb2bf0f
     pristine_git_object: 2fdcd50ee231c3c39ff0b25059d7b2ea166abe6c
   examples/resources/criblio_commit/resource.tf:
     id: b0c2c323ed11
@@ -1012,21 +1012,23 @@ trackedFiles:
     pristine_git_object: 8d64b83919d1d9ea9e9d7f167090a955eb2fb623
   internal/provider/collector_data_source.go:
     id: 9e6119bfd14f
-    last_write_checksum: sha1:0d80c828793aa3300efc964748a05087da974472
+    last_write_checksum: sha1:8a4f069e3e5350ca06a2ea1b5de729862b55284b
     pristine_git_object: adec255f9d06ba326baba69c65c1aa3f8a60eae6
   internal/provider/collector_data_source_sdk.go:
     id: 0f4fcc949cb8
-    last_write_checksum: sha1:7d1a655ddb2315fbc39eff565aef1d3965c2a58f
+    last_write_checksum: sha1:4e3f29027fc854d75db43824c7ddfcd3a8ccd4e2
     pristine_git_object: bec4673fb0e1ec80ebb2898436e1c1679550237d
+  internal/provider/collector_resource.go:
+    last_write_checksum: sha1:d79b5e2adfcd492864ebe1e8830616ddf02ac727
   internal/provider/collector_resource_sdk.go:
-    last_write_checksum: sha1:17d6d5e316bb5d8c6e8bbbd27b6f093416ef5509
+    last_write_checksum: sha1:987f71e9860b06195e7692db6760d56373f3146d
   internal/provider/collectors_data_source.go:
     id: bbe19bfa87c6
-    last_write_checksum: sha1:43fd168e05e5407bb3bd3860f3f44811bf43b5b7
+    last_write_checksum: sha1:22e0615a3b4028f4f0d3d89bf769e14bc7afb578
     pristine_git_object: 1945183aa70411b654b02d62942457ecd38ff389
   internal/provider/collectors_data_source_sdk.go:
     id: 0cc6109f5fb8
-    last_write_checksum: sha1:59cbf5b1c0c2da7ecb2da03c6bea44bf6e90c7fb
+    last_write_checksum: sha1:e1cee0de3540d761a9808255eb4bbf2ede2fc0a2
     pristine_git_object: 5dbf43ad4bd088e498ff87d53c8e33d187ef3924
   internal/provider/commit_resource.go:
     id: f56219f826b2
@@ -2076,7 +2078,7 @@ trackedFiles:
     pristine_git_object: 886fb1d7c9cfdfbfdab09dd2fbbcc08cabc8f880
   internal/provider/types/discover_request_param.go:
     id: a5329d633b64
-    last_write_checksum: sha1:d7b2865342b3eeb804e81e913676222f1a2c59f6
+    last_write_checksum: sha1:62a57231723e3e37bc9a9c77cf7b5076a8d61027
     pristine_git_object: de7506eec483fb936a8f6a071bcfbfa6681f1b08
   internal/provider/types/discovery_configuration.go:
     id: eee40e6902ff
@@ -4412,7 +4414,7 @@ trackedFiles:
     pristine_git_object: bf71ee999b1aa29b59f13528fb9772327ebaf583
   internal/sdk/criblio.go:
     id: a2ae69529b28
-    last_write_checksum: sha1:01e646c999e109d235c91c25e9f0938c94474e6a
+    last_write_checksum: sha1:2ea4126a09431116e05511d268c38ae428719188
     pristine_git_object: 9c817ff838a5053031217d727197743322914bb0
   internal/sdk/dashboardcategories.go:
     id: 1cc9a977a86d
@@ -7462,7 +7464,7 @@ trackedFiles:
     pristine_git_object: 52dcc396f12ede70abfd4dfe36cb1d736b055bb7
   internal/sdk/models/shared/inputcollectorrest.go:
     id: 4376d43c4027
-    last_write_checksum: sha1:1dd5d2f024c0c681f2edbfffab457ba754788eb2
+    last_write_checksum: sha1:f8d067a5294fdb6f319b479b2dc522f81c974211
     pristine_git_object: 5f293521e6d75d77241a9f3b23e55921d259e44f
   internal/sdk/models/shared/inputcollectors3.go:
     id: 40ef740c9aa7

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -30,7 +30,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.23.31
+  version: 1.23.32
   additionalActions: []
   additionalDataSources: []
   additionalDependencies:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,16 +2,16 @@ speakeasyVersion: 1.761.1
 sources:
     Cribl Control Plane and Management API:
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:63e0ababb815bd44427322f09ff9a543248893f0cb212e4d38e33d57045d6f84
-        sourceBlobDigest: sha256:f0e6dd0ea90f5c5d0a679f05257383b944f0b280ea24d12be306df0d815143b8
+        sourceRevisionDigest: sha256:eb72bf40ba8b85326ff6f5eda06175947a8fcd50189ec7ea64fea4385ed93049
+        sourceBlobDigest: sha256:3b5ee3c05cf4a2962055a52b718da7a3fcdc4e56b0eaf862069c5f67d4f526f5
         tags:
             - latest
 targets:
     cribl-io:
         source: Cribl Control Plane and Management API
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:63e0ababb815bd44427322f09ff9a543248893f0cb212e4d38e33d57045d6f84
-        sourceBlobDigest: sha256:f0e6dd0ea90f5c5d0a679f05257383b944f0b280ea24d12be306df0d815143b8
+        sourceRevisionDigest: sha256:eb72bf40ba8b85326ff6f5eda06175947a8fcd50189ec7ea64fea4385ed93049
+        sourceBlobDigest: sha256:3b5ee3c05cf4a2962055a52b718da7a3fcdc4e56b0eaf862069c5f67d4f526f5
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.761.1

--- a/docs/data-sources/collector.md
+++ b/docs/data-sources/collector.md
@@ -828,6 +828,11 @@ Read-Only:
 <a id="nestedatt--input_collector_rest--collector--conf--discovery--discover_request_params"></a>
 ### Nested Schema for `input_collector_rest.collector.conf.discovery.discover_request_params`
 
+Read-Only:
+
+- `name` (String)
+- `value` (String)
+
 
 <a id="nestedatt--input_collector_rest--collector--conf--discovery--pagination"></a>
 ### Nested Schema for `input_collector_rest.collector.conf.discovery.pagination`

--- a/docs/data-sources/collectors.md
+++ b/docs/data-sources/collectors.md
@@ -828,6 +828,11 @@ Read-Only:
 <a id="nestedatt--items--input_collector_rest--collector--conf--discovery--discover_request_params"></a>
 ### Nested Schema for `items.input_collector_rest.collector.conf.discovery.discover_request_params`
 
+Read-Only:
+
+- `name` (String)
+- `value` (String)
+
 
 <a id="nestedatt--items--input_collector_rest--collector--conf--discovery--pagination"></a>
 ### Nested Schema for `items.input_collector_rest.collector.conf.discovery.pagination`

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.23.31"
+      version = "1.23.32"
     }
   }
 }

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -495,7 +495,8 @@ resource "criblio_collector" "my_collector" {
           ]
           discover_request_params = [
             {
-              # ...
+              name  = "param"
+              value = "value"
             }
           ]
           discover_type        = "http"
@@ -944,8 +945,6 @@ resource "criblio_collector" "my_collector" {
 
 ### Optional
 
-- `environment` (String) Mirrors the environment from the active input_collector_* block. May be set in configuration or left unset (computed).
-- `ignore_group_jobs_limit` (Boolean) Mirrors ignore_group_jobs_limit from the active input_collector_* block (no root default; use nested field defaults).
 - `input_collector_azure_blob` (Attributes) (see [below for nested schema](#nestedatt--input_collector_azure_blob))
 - `input_collector_cribl_lake` (Attributes) (see [below for nested schema](#nestedatt--input_collector_cribl_lake))
 - `input_collector_database` (Attributes) (see [below for nested schema](#nestedatt--input_collector_database))
@@ -955,9 +954,14 @@ resource "criblio_collector" "my_collector" {
 - `input_collector_s3` (Attributes) (see [below for nested schema](#nestedatt--input_collector_s3))
 - `input_collector_script` (Attributes) (see [below for nested schema](#nestedatt--input_collector_script))
 - `input_collector_splunk` (Attributes) (see [below for nested schema](#nestedatt--input_collector_splunk))
-- `resume_on_boot` (Boolean) Mirrors resume_on_boot from the active input_collector_* block (no root default; nested block sets provider defaults).
-- `ttl` (String) Mirrors ttl from the active input_collector_* block (no root default; nested block sets provider defaults).
-- `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node (no root default; use nested field defaults).
+
+### Read-Only
+
+- `environment` (String)
+- `ignore_group_jobs_limit` (Boolean)
+- `resume_on_boot` (Boolean)
+- `ttl` (String)
+- `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
 
 <a id="nestedatt--input_collector_azure_blob"></a>
 ### Nested Schema for `input_collector_azure_blob`
@@ -1122,7 +1126,7 @@ Optional:
 Optional:
 
 - `conf` (Attributes) (see [below for nested schema](#nestedatt--input_collector_cribl_lake--collector--conf))
-- `type` (String) Not Null; must match the Stream jobs API ("cribl_lake"). The legacy spelling "cribllake" is accepted and sent as "cribl_lake".
+- `type` (String) Not Null; must be "cribl_lake"
 
 <a id="nestedatt--input_collector_cribl_lake--collector--conf"></a>
 ### Nested Schema for `input_collector_cribl_lake.collector.conf`
@@ -1742,6 +1746,11 @@ Optional:
 
 <a id="nestedatt--input_collector_rest--collector--conf--discovery--discover_request_params"></a>
 ### Nested Schema for `input_collector_rest.collector.conf.discovery.discover_request_params`
+
+Optional:
+
+- `name` (String)
+- `value` (String)
 
 
 <a id="nestedatt--input_collector_rest--collector--conf--discovery--pagination"></a>

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -248,6 +248,7 @@ resource "criblio_collector" "rest_api_collector_discovery_http" {
   }
 }
 
+/*
 resource "criblio_collector" "rest_conf_update_test" {
   group_id = "default"
   id       = "rest-conf-update-test"
@@ -269,6 +270,7 @@ resource "criblio_collector" "rest_conf_update_test" {
     ignore_group_jobs_limit = false
   }
 }
+*/
 
 resource "criblio_collector" "rest_api_collector_discovery_json" {
   group_id = "default"

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -207,6 +207,22 @@ resource "criblio_collector" "rest_api_collector_discovery_http" {
           discover_method = "get"
           # API validates discoverUrl as a jsExpression; use a string literal, not a bare URL
           discover_url = "'https://discover.test.example.com/v1'"
+          discover_request_params = [
+            {
+              name  = "filter"
+              value = "'active=true'"
+            },
+            {
+              name  = "limit"
+              value = "'100'"
+            }
+          ]
+          discover_request_headers = [
+            {
+              name  = "X-Custom-Header"
+              value = "'test-value'"
+            }
+          ]
         }
         # Additional REST configuration
         authentication = "basic"
@@ -228,6 +244,28 @@ resource "criblio_collector" "rest_api_collector_discovery_http" {
     }
     environment             = "demo"
     id                      = "rest-api-demo-collector_discovery_http"
+    ignore_group_jobs_limit = false
+  }
+}
+
+resource "criblio_collector" "rest_conf_update_test" {
+  group_id = "default"
+  id       = "rest-conf-update-test"
+  input_collector_rest = {
+    collector = {
+      type = "rest"
+      conf = {
+        authentication = "none"
+        discovery      = { discover_type = "none" }
+        # Change this value after initial apply to test Bug 2 fix
+        timeout             = 60
+        collect_method      = "get"
+        collect_url         = "'https://api.test.example.com/data'"
+        reject_unauthorized = false
+      }
+    }
+    environment             = "demo"
+    id                      = "rest-conf-update-test"
     ignore_group_jobs_limit = false
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.23.31"
+      version = "1.23.32"
     }
   }
 }

--- a/examples/resources/criblio_collector/resource.tf
+++ b/examples/resources/criblio_collector/resource.tf
@@ -480,7 +480,8 @@ resource "criblio_collector" "my_collector" {
           ]
           discover_request_params = [
             {
-              # ...
+              name  = "param"
+              value = "value"
             }
           ]
           discover_type        = "http"

--- a/internal/planmodifiers/objectplanmodifier/prefer_config_or_state.go
+++ b/internal/planmodifiers/objectplanmodifier/prefer_config_or_state.go
@@ -1,0 +1,116 @@
+package objectplanmodifier
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+// PreferConfigOrState returns a plan modifier that deeply merges config and state:
+// - For each attribute, if config has a non-null value, use config
+// - If config has null, use state value (preserving API-computed defaults)
+// This allows user changes while preserving computed defaults for unspecified fields.
+func PreferConfigOrState() planmodifier.Object {
+	return preferConfigOrState{}
+}
+
+type preferConfigOrState struct{}
+
+func (m preferConfigOrState) Description(_ context.Context) string {
+	return "Deep merges config and state: uses config values when set, state values for unspecified fields."
+}
+
+func (m preferConfigOrState) MarkdownDescription(_ context.Context) string {
+	return "Deep merges config and state: uses config values when set, state values for unspecified fields."
+}
+
+func (m preferConfigOrState) PlanModifyObject(ctx context.Context, req planmodifier.ObjectRequest, resp *planmodifier.ObjectResponse) {
+	// For new resources (no prior state), let normal flow proceed
+	if req.StateValue.IsUnknown() || req.StateValue.IsNull() {
+		return
+	}
+
+	// If config is entirely null/unknown, use state (original PreferState behavior)
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		resp.PlanValue = req.StateValue
+		return
+	}
+
+	// Deep merge recursively
+	merged := deepMergeObjects(ctx, req.ConfigValue, req.StateValue)
+	if merged != nil {
+		resp.PlanValue = *merged
+	}
+}
+
+// deepMergeObjects recursively merges config and state objects
+func deepMergeObjects(ctx context.Context, config, state basetypes.ObjectValue) *basetypes.ObjectValue {
+	configAttrs := config.Attributes()
+	stateAttrs := state.Attributes()
+
+	if len(configAttrs) == 0 || len(stateAttrs) == 0 {
+		return &state
+	}
+
+	mergedAttrs := make(map[string]attr.Value)
+
+	for key, stateVal := range stateAttrs {
+		configVal, hasConfig := configAttrs[key]
+
+		// Use state value if config doesn't have this key or config value is null/unknown
+		if !hasConfig || configVal == nil || configVal.IsNull() || configVal.IsUnknown() {
+			mergedAttrs[key] = stateVal
+			continue
+		}
+
+		// Check if both are objects - if so, merge recursively
+		configObj, configIsObj := configVal.(basetypes.ObjectValue)
+		stateObj, stateIsObj := stateVal.(basetypes.ObjectValue)
+
+		if configIsObj && stateIsObj && !configObj.IsNull() && !stateObj.IsNull() {
+			// Recursively merge nested objects
+			merged := deepMergeObjects(ctx, configObj, stateObj)
+			if merged != nil {
+				mergedAttrs[key] = *merged
+			} else {
+				mergedAttrs[key] = stateVal
+			}
+			continue
+		}
+
+		// Check if both are lists - handle empty list vs null
+		configList, configIsList := configVal.(types.List)
+		stateList, stateIsList := stateVal.(types.List)
+
+		if configIsList && stateIsList {
+			// If config list is empty and state list is also empty (or vice versa), use state
+			// This handles the [] vs null equivalence
+			if configList.IsNull() && len(stateList.Elements()) == 0 {
+				mergedAttrs[key] = stateVal
+				continue
+			}
+		}
+
+		// Config has a real value - use it
+		mergedAttrs[key] = configVal
+	}
+
+	// Include any config attrs that weren't in state (shouldn't happen normally)
+	for key, configVal := range configAttrs {
+		if _, exists := mergedAttrs[key]; !exists && configVal != nil {
+			mergedAttrs[key] = configVal
+		}
+	}
+
+	// Build the merged object using state's attribute types
+	attrTypes := state.AttributeTypes(ctx)
+	mergedObj, diags := basetypes.NewObjectValue(attrTypes, mergedAttrs)
+	if diags.HasError() {
+		return &state
+	}
+
+	return &mergedObj
+}

--- a/internal/provider/collector_data_source.go
+++ b/internal/provider/collector_data_source.go
@@ -1362,7 +1362,14 @@ func (r *CollectorDataSource) Schema(ctx context.Context, req datasource.SchemaR
 											"discover_request_params": schema.ListNestedAttribute{
 												Computed: true,
 												NestedObject: schema.NestedAttributeObject{
-													Attributes: map[string]schema.Attribute{},
+													Attributes: map[string]schema.Attribute{
+														"name": schema.StringAttribute{
+															Computed: true,
+														},
+														"value": schema.StringAttribute{
+															Computed: true,
+														},
+													},
 												},
 											},
 											"discover_type": schema.StringAttribute{

--- a/internal/provider/collector_data_source_sdk.go
+++ b/internal/provider/collector_data_source_sdk.go
@@ -823,6 +823,16 @@ func (r *CollectorDataSourceModel) RefreshFromSharedInputCollector(ctx context.C
 
 				r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders = append(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders, discoverRequestHeaders)
 			}
+			r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams = []tfTypes.DiscoverRequestParam{}
+
+			for _, discoverRequestParamsItem := range resp.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams {
+				var discoverRequestParams tfTypes.DiscoverRequestParam
+
+				discoverRequestParams.Name = types.StringPointerValue(discoverRequestParamsItem.Name)
+				discoverRequestParams.Value = types.StringPointerValue(discoverRequestParamsItem.Value)
+
+				r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams = append(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams, discoverRequestParams)
+			}
 			r.InputCollectorRest.Collector.Conf.Discovery.DiscoverType = types.StringValue(string(resp.InputCollectorRest.Collector.Conf.Discovery.DiscoverType))
 			r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL = types.StringPointerValue(resp.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL)
 			r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode = types.BoolPointerValue(resp.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode)

--- a/internal/provider/collector_resource.go
+++ b/internal/provider/collector_resource.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
-
 	speakeasy_boolplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/boolplanmodifier"
 	custom_objectplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/objectplanmodifier"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/stringplanmodifier"
@@ -36,6 +34,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"regexp"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -109,7 +108,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.Bool{
-					speakeasy_boolplanmodifier.UseHoistedValue([]speakeasy_planmodifierutils.HoistedSource{speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_splunk"), FieldPath: path.Root("input_collector_splunk").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_rest"), FieldPath: path.Root("input_collector_rest").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_s3"), FieldPath: path.Root("input_collector_s3").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_azure_blob"), FieldPath: path.Root("input_collector_azure_blob").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_cribl_lake"), FieldPath: path.Root("input_collector_cribl_lake").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_database"), FieldPath: path.Root("input_collector_database").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_gcs"), FieldPath: path.Root("input_collector_gcs").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_health_check"), FieldPath: path.Root("input_collector_health_check").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_script"), FieldPath: path.Root("input_collector_script").AtName("ignore_group_jobs_limit")}}),
+					speakeasy_boolplanmodifier.UseHoistedValue([]speakeasy_planmodifierutils.HoistedSource{speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_splunk"), FieldPath: path.Root("input_collector_splunk").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_rest"), FieldPath: path.Root("input_collector_rest").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_s3"), FieldPath: path.Root("input_collector_s3").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_azure_blob"), FieldPath: path.Root("input_collector_azure_blob").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_database"), FieldPath: path.Root("input_collector_database").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_gcs"), FieldPath: path.Root("input_collector_gcs").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_health_check"), FieldPath: path.Root("input_collector_health_check").AtName("ignore_group_jobs_limit")}, speakeasy_planmodifierutils.HoistedSource{AssociatedTypePath: path.Root("input_collector_script"), FieldPath: path.Root("input_collector_script").AtName("ignore_group_jobs_limit")}}),
 				},
 				Description: `Mirrors ignore_group_jobs_limit from the active input_collector_* block (no root default; use nested field defaults).`,
 			},
@@ -124,7 +123,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"auth_type": schema.StringAttribute{
@@ -240,7 +239,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -372,7 +371,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -589,7 +588,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"dataset": schema.StringAttribute{
@@ -643,7 +642,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -775,7 +774,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -992,7 +991,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"connection_id": schema.StringAttribute{
@@ -1051,7 +1050,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -1183,7 +1182,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -1400,7 +1399,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"auth_type": schema.StringAttribute{
@@ -1509,7 +1508,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -1641,7 +1640,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -1858,7 +1857,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"authentication": schema.StringAttribute{
@@ -1967,7 +1966,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -2099,7 +2098,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -2316,7 +2315,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"auth_header_expr": schema.StringAttribute{
@@ -2525,7 +2524,16 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 													Validators: []validator.Object{
 														speakeasy_objectvalidators.NotNull(),
 													},
-													Attributes: map[string]schema.Attribute{},
+													Attributes: map[string]schema.Attribute{
+														"name": schema.StringAttribute{
+															Computed: true,
+															Optional: true,
+														},
+														"value": schema.StringAttribute{
+															Computed: true,
+															Optional: true,
+														},
+													},
 												},
 											},
 											"discover_type": schema.StringAttribute{
@@ -2954,7 +2962,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -3086,7 +3094,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -3303,7 +3311,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"aws_api_key": schema.StringAttribute{
@@ -3424,7 +3432,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -3556,7 +3564,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -3773,7 +3781,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"collect_script": schema.StringAttribute{
@@ -3830,7 +3838,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -3962,7 +3970,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -4179,7 +4187,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 								Computed: true,
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
-									custom_objectplanmodifier.PreferState(),
+									custom_objectplanmodifier.PreferConfigOrState(),
 								},
 								Attributes: map[string]schema.Attribute{
 									"authentication": schema.StringAttribute{
@@ -4324,7 +4332,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"breaker_rulesets": schema.ListAttribute{
@@ -4456,7 +4464,7 @@ func (r *CollectorResource) Schema(ctx context.Context, req resource.SchemaReque
 						Computed: true,
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
-							custom_objectplanmodifier.PreferState(),
+							custom_objectplanmodifier.PreferConfigOrState(),
 						},
 						Attributes: map[string]schema.Attribute{
 							"cron_schedule": schema.StringAttribute{
@@ -4792,9 +4800,6 @@ func collectorRestoreEnvironmentIfNulled(current, preserved types.String) types.
 	return current
 }
 
-// collectorEnsureDefaultInputAndSchedule populates input and schedule with empty
-// default structs when both API and plan return nil. This prevents drift when
-// the user doesn't configure these optional PreferState fields.
 func collectorEnsureDefaultInputAndSchedule(data *CollectorResourceModel) {
 	if data.InputCollectorRest != nil {
 		if data.InputCollectorRest.Input == nil {

--- a/internal/provider/collector_resource_sdk.go
+++ b/internal/provider/collector_resource_sdk.go
@@ -863,6 +863,16 @@ func (r *CollectorResourceModel) RefreshFromSharedInputCollector(ctx context.Con
 
 				r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders = append(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders, discoverRequestHeaders)
 			}
+			r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams = []tfTypes.DiscoverRequestParam{}
+
+			for _, discoverRequestParamsItem := range resp.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams {
+				var discoverRequestParams tfTypes.DiscoverRequestParam
+
+				discoverRequestParams.Name = types.StringPointerValue(discoverRequestParamsItem.Name)
+				discoverRequestParams.Value = types.StringPointerValue(discoverRequestParamsItem.Value)
+
+				r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams = append(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams, discoverRequestParams)
+			}
 			r.InputCollectorRest.Collector.Conf.Discovery.DiscoverType = types.StringValue(string(resp.InputCollectorRest.Collector.Conf.Discovery.DiscoverType))
 			r.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL = types.StringPointerValue(resp.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL)
 			r.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode = types.BoolPointerValue(resp.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode)
@@ -2732,7 +2742,25 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			} else {
 				manualDiscoverResult = nil
 			}
-			discoverRequestParams := make([]shared.DiscoverRequestParam, len(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams))
+			discoverRequestParams := make([]shared.DiscoverRequestParam, 0, len(r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams))
+			for discoverRequestParamsIndex := range r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams {
+				name7 := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams[discoverRequestParamsIndex].Name.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams[discoverRequestParamsIndex].Name.IsNull() {
+					*name7 = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams[discoverRequestParamsIndex].Name.ValueString()
+				} else {
+					name7 = nil
+				}
+				value7 := new(string)
+				if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams[discoverRequestParamsIndex].Value.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams[discoverRequestParamsIndex].Value.IsNull() {
+					*value7 = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams[discoverRequestParamsIndex].Value.ValueString()
+				} else {
+					value7 = nil
+				}
+				discoverRequestParams = append(discoverRequestParams, shared.DiscoverRequestParam{
+					Name:  name7,
+					Value: value7,
+				})
+			}
 			discoverBody := new(string)
 			if !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.IsUnknown() && !r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.IsNull() {
 				*discoverBody = r.InputCollectorRest.Collector.Conf.Discovery.DiscoverBody.ValueString()
@@ -3275,15 +3303,15 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			}
 			metadata2 := make([]shared.InputCollectorS3Metadatum, 0, len(r.InputCollectorS3.Input.Metadata))
 			for metadataIndex2 := range r.InputCollectorS3.Input.Metadata {
-				var name7 string
-				name7 = r.InputCollectorS3.Input.Metadata[metadataIndex2].Name.ValueString()
+				var name8 string
+				name8 = r.InputCollectorS3.Input.Metadata[metadataIndex2].Name.ValueString()
 
-				var value7 string
-				value7 = r.InputCollectorS3.Input.Metadata[metadataIndex2].Value.ValueString()
+				var value8 string
+				value8 = r.InputCollectorS3.Input.Metadata[metadataIndex2].Value.ValueString()
 
 				metadata2 = append(metadata2, shared.InputCollectorS3Metadatum{
-					Name:  name7,
-					Value: value7,
+					Name:  name8,
+					Value: value8,
 				})
 			}
 			pipeline2 := new(string)
@@ -3688,15 +3716,15 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			}
 			metadata3 := make([]shared.InputCollectorAzureBlobMetadatum, 0, len(r.InputCollectorAzureBlob.Input.Metadata))
 			for metadataIndex3 := range r.InputCollectorAzureBlob.Input.Metadata {
-				var name8 string
-				name8 = r.InputCollectorAzureBlob.Input.Metadata[metadataIndex3].Name.ValueString()
+				var name9 string
+				name9 = r.InputCollectorAzureBlob.Input.Metadata[metadataIndex3].Name.ValueString()
 
-				var value8 string
-				value8 = r.InputCollectorAzureBlob.Input.Metadata[metadataIndex3].Value.ValueString()
+				var value9 string
+				value9 = r.InputCollectorAzureBlob.Input.Metadata[metadataIndex3].Value.ValueString()
 
 				metadata3 = append(metadata3, shared.InputCollectorAzureBlobMetadatum{
-					Name:  name8,
-					Value: value8,
+					Name:  name9,
+					Value: value9,
 				})
 			}
 			pipeline3 := new(string)
@@ -4087,15 +4115,15 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			}
 			metadata4 := make([]shared.InputCollectorCriblLakeMetadatum, 0, len(r.InputCollectorCriblLake.Input.Metadata))
 			for metadataIndex4 := range r.InputCollectorCriblLake.Input.Metadata {
-				var name9 string
-				name9 = r.InputCollectorCriblLake.Input.Metadata[metadataIndex4].Name.ValueString()
+				var name10 string
+				name10 = r.InputCollectorCriblLake.Input.Metadata[metadataIndex4].Name.ValueString()
 
-				var value9 string
-				value9 = r.InputCollectorCriblLake.Input.Metadata[metadataIndex4].Value.ValueString()
+				var value10 string
+				value10 = r.InputCollectorCriblLake.Input.Metadata[metadataIndex4].Value.ValueString()
 
 				metadata4 = append(metadata4, shared.InputCollectorCriblLakeMetadatum{
-					Name:  name9,
-					Value: value9,
+					Name:  name10,
+					Value: value10,
 				})
 			}
 			pipeline4 := new(string)
@@ -4417,15 +4445,15 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			}
 			metadata5 := make([]shared.InputCollectorDatabaseMetadatum, 0, len(r.InputCollectorDatabase.Input.Metadata))
 			for metadataIndex5 := range r.InputCollectorDatabase.Input.Metadata {
-				var name10 string
-				name10 = r.InputCollectorDatabase.Input.Metadata[metadataIndex5].Name.ValueString()
+				var name11 string
+				name11 = r.InputCollectorDatabase.Input.Metadata[metadataIndex5].Name.ValueString()
 
-				var value10 string
-				value10 = r.InputCollectorDatabase.Input.Metadata[metadataIndex5].Value.ValueString()
+				var value11 string
+				value11 = r.InputCollectorDatabase.Input.Metadata[metadataIndex5].Value.ValueString()
 
 				metadata5 = append(metadata5, shared.InputCollectorDatabaseMetadatum{
-					Name:  name10,
-					Value: value10,
+					Name:  name11,
+					Value: value11,
 				})
 			}
 			pipeline5 := new(string)
@@ -4761,15 +4789,15 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			}
 			metadata6 := make([]shared.InputCollectorGCSMetadatum, 0, len(r.InputCollectorGCS.Input.Metadata))
 			for metadataIndex6 := range r.InputCollectorGCS.Input.Metadata {
-				var name11 string
-				name11 = r.InputCollectorGCS.Input.Metadata[metadataIndex6].Name.ValueString()
+				var name12 string
+				name12 = r.InputCollectorGCS.Input.Metadata[metadataIndex6].Name.ValueString()
 
-				var value11 string
-				value11 = r.InputCollectorGCS.Input.Metadata[metadataIndex6].Value.ValueString()
+				var value12 string
+				value12 = r.InputCollectorGCS.Input.Metadata[metadataIndex6].Value.ValueString()
 
 				metadata6 = append(metadata6, shared.InputCollectorGCSMetadatum{
-					Name:  name11,
-					Value: value11,
+					Name:  name12,
+					Value: value12,
 				})
 			}
 			pipeline6 := new(string)
@@ -5153,15 +5181,15 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			}
 			metadata7 := make([]shared.InputCollectorHealthCheckMetadatum, 0, len(r.InputCollectorHealthCheck.Input.Metadata))
 			for metadataIndex7 := range r.InputCollectorHealthCheck.Input.Metadata {
-				var name12 string
-				name12 = r.InputCollectorHealthCheck.Input.Metadata[metadataIndex7].Name.ValueString()
+				var name13 string
+				name13 = r.InputCollectorHealthCheck.Input.Metadata[metadataIndex7].Name.ValueString()
 
-				var value12 string
-				value12 = r.InputCollectorHealthCheck.Input.Metadata[metadataIndex7].Value.ValueString()
+				var value13 string
+				value13 = r.InputCollectorHealthCheck.Input.Metadata[metadataIndex7].Value.ValueString()
 
 				metadata7 = append(metadata7, shared.InputCollectorHealthCheckMetadatum{
-					Name:  name12,
-					Value: value12,
+					Name:  name13,
+					Value: value13,
 				})
 			}
 			pipeline7 := new(string)
@@ -5532,15 +5560,15 @@ func (r *CollectorResourceModel) ToSharedInputCollector(ctx context.Context) (*s
 			}
 			metadata8 := make([]shared.InputCollectorScriptMetadatum, 0, len(r.InputCollectorScript.Input.Metadata))
 			for metadataIndex8 := range r.InputCollectorScript.Input.Metadata {
-				var name13 string
-				name13 = r.InputCollectorScript.Input.Metadata[metadataIndex8].Name.ValueString()
+				var name14 string
+				name14 = r.InputCollectorScript.Input.Metadata[metadataIndex8].Name.ValueString()
 
-				var value13 string
-				value13 = r.InputCollectorScript.Input.Metadata[metadataIndex8].Value.ValueString()
+				var value14 string
+				value14 = r.InputCollectorScript.Input.Metadata[metadataIndex8].Value.ValueString()
 
 				metadata8 = append(metadata8, shared.InputCollectorScriptMetadatum{
-					Name:  name13,
-					Value: value13,
+					Name:  name14,
+					Value: value14,
 				})
 			}
 			pipeline8 := new(string)

--- a/internal/provider/collectors_data_source.go
+++ b/internal/provider/collectors_data_source.go
@@ -1342,7 +1342,14 @@ func (r *CollectorsDataSource) Schema(ctx context.Context, req datasource.Schema
 														"discover_request_params": schema.ListNestedAttribute{
 															Computed: true,
 															NestedObject: schema.NestedAttributeObject{
-																Attributes: map[string]schema.Attribute{},
+																Attributes: map[string]schema.Attribute{
+																	"name": schema.StringAttribute{
+																		Computed: true,
+																	},
+																	"value": schema.StringAttribute{
+																		Computed: true,
+																	},
+																},
 															},
 														},
 														"discover_type": schema.StringAttribute{

--- a/internal/provider/collectors_data_source_sdk.go
+++ b/internal/provider/collectors_data_source_sdk.go
@@ -778,6 +778,16 @@ func (r *CollectorsDataSourceModel) RefreshFromOperationsListCollectorsResponseB
 
 						items.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders = append(items.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestHeaders, discoverRequestHeaders)
 					}
+					items.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams = []tfTypes.DiscoverRequestParam{}
+
+					for _, discoverRequestParamsItem := range itemsItem.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams {
+						var discoverRequestParams tfTypes.DiscoverRequestParam
+
+						discoverRequestParams.Name = types.StringPointerValue(discoverRequestParamsItem.Name)
+						discoverRequestParams.Value = types.StringPointerValue(discoverRequestParamsItem.Value)
+
+						items.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams = append(items.InputCollectorRest.Collector.Conf.Discovery.DiscoverRequestParams, discoverRequestParams)
+					}
 					items.InputCollectorRest.Collector.Conf.Discovery.DiscoverType = types.StringValue(string(itemsItem.InputCollectorRest.Collector.Conf.Discovery.DiscoverType))
 					items.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL = types.StringPointerValue(itemsItem.InputCollectorRest.Collector.Conf.Discovery.DiscoverURL)
 					items.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode = types.BoolPointerValue(itemsItem.InputCollectorRest.Collector.Conf.Discovery.EnableDiscoverCode)

--- a/internal/provider/types/discover_request_param.go
+++ b/internal/provider/types/discover_request_param.go
@@ -2,5 +2,11 @@
 
 package types
 
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
 type DiscoverRequestParam struct {
+	Name  types.String `tfsdk:"name"`
+	Value types.String `tfsdk:"value"`
 }

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -359,9 +359,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.23.31",
+		SDKVersion: "1.23.32",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.23.31 2.879.6 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.23.32 2.879.6 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/internal/sdk/models/shared/inputcollectorrest.go
+++ b/internal/sdk/models/shared/inputcollectorrest.go
@@ -904,6 +904,8 @@ func (d *DiscoverRequestHeader) GetValue() *string {
 }
 
 type DiscoverRequestParam struct {
+	Name  *string `json:"name,omitempty"`
+	Value *string `json:"value,omitempty"`
 }
 
 func (d DiscoverRequestParam) MarshalJSON() ([]byte, error) {
@@ -915,6 +917,20 @@ func (d *DiscoverRequestParam) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	return nil
+}
+
+func (d *DiscoverRequestParam) GetName() *string {
+	if d == nil {
+		return nil
+	}
+	return d.Name
+}
+
+func (d *DiscoverRequestParam) GetValue() *string {
+	if d == nil {
+		return nil
+	}
+	return d.Value
 }
 
 type DiscoveryConfiguration struct {

--- a/openapi.yml
+++ b/openapi.yml
@@ -1722,10 +1722,18 @@ components:
                                                 title: Discover request parameters
                                                 items:
                                                     type: object
-                                                    example:
-                                                        param: value
+                                                    properties:
+                                                        name:
+                                                            type: string
+                                                            title: Parameter name
+                                                            example: param
+                                                        value:
+                                                            type: string
+                                                            title: Parameter value
+                                                            example: value
                                                 example:
-                                                    - param: value
+                                                    - name: param
+                                                      value: value
                                             discoverBody:
                                                 type: string
                                                 title: Discover body


### PR DESCRIPTION
- Added discover_request_params that had empty schema - items were missing name and value properties, causing API rejection
- Fixed post-create changes to conf fields not triggering updates - created PreferConfigOrState() plan modifier that deep-merges config and state
- Added test to capture these two changes