### PR TITLE
adding additional suffixes for secrets.

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,11 +1,11 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: 15606be21fbd4b94a3287f50927f5681
+  docChecksum: f0a3920962ced92c073db31ea842b1e2
   speakeasyVersion: 1.761.1
   generationVersion: 2.879.6
-  releaseVersion: 1.23.32
-  configChecksum: 1c415a416136861c189dc209e0a9dc09
+  releaseVersion: 1.23.33
+  configChecksum: 3de86e636a225e7566d2b062ef185da1
   published: true
 persistentEdits:
   generation_id: e52d5ce0-d97b-4ec8-89ab-e5f05e0474e8
@@ -278,7 +278,7 @@ trackedFiles:
     pristine_git_object: 1959198f7669fee4593aeb084e44e34317718e0d
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:c2e4ae8c5164fd3aef5903aa9d74d19ace7c93ea
+    last_write_checksum: sha1:cb2330d135d4a807287a422f8e6c4d8fde1d883f
     pristine_git_object: 02f445a76d1365acf6ca17232bb2e4c0a07e52ea
   examples/resources/criblio_appscope_config/import-by-string-id.tf:
     id: 13b421bc255d
@@ -996,7 +996,7 @@ trackedFiles:
     pristine_git_object: 01275b565bfe6b8af3effbcdd60b2972ba3da4cd
   internal/provider/certificate_resource.go:
     id: bdfa827216a2
-    last_write_checksum: sha1:1aaa50ed2af24d5671c96a4b84a02078c9b0cea8
+    last_write_checksum: sha1:db2c9ae2eb7764e037fa50ec79d4c47dbb0d9c1a
     pristine_git_object: 558a561f4aa01d344249b0866e656352852b71f3
   internal/provider/certificate_resource_sdk.go:
     id: df2508cad27a
@@ -1018,8 +1018,6 @@ trackedFiles:
     id: 0f4fcc949cb8
     last_write_checksum: sha1:4e3f29027fc854d75db43824c7ddfcd3a8ccd4e2
     pristine_git_object: bec4673fb0e1ec80ebb2898436e1c1679550237d
-  internal/provider/collector_resource.go:
-    last_write_checksum: sha1:d79b5e2adfcd492864ebe1e8830616ddf02ac727
   internal/provider/collector_resource_sdk.go:
     last_write_checksum: sha1:987f71e9860b06195e7692db6760d56373f3146d
   internal/provider/collectors_data_source.go:
@@ -4414,7 +4412,7 @@ trackedFiles:
     pristine_git_object: bf71ee999b1aa29b59f13528fb9772327ebaf583
   internal/sdk/criblio.go:
     id: a2ae69529b28
-    last_write_checksum: sha1:2ea4126a09431116e05511d268c38ae428719188
+    last_write_checksum: sha1:c4a66992d12cfb22975f3dbf9feb75ce6f5fbf4b
     pristine_git_object: 9c817ff838a5053031217d727197743322914bb0
   internal/sdk/dashboardcategories.go:
     id: 1cc9a977a86d

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,11 +1,11 @@
 lockVersion: 2.0.0
 id: 1efe501f-0805-447e-ab12-75eb7c79386e
 management:
-  docChecksum: f0a3920962ced92c073db31ea842b1e2
+  docChecksum: f0d11fc082656039da97578eafe764c1
   speakeasyVersion: 1.761.1
   generationVersion: 2.879.6
-  releaseVersion: 1.23.33
-  configChecksum: 3de86e636a225e7566d2b062ef185da1
+  releaseVersion: 1.23.34
+  configChecksum: 9ddb7ea5d374525b9dd05b52a1bf3c52
   published: true
 persistentEdits:
   generation_id: e52d5ce0-d97b-4ec8-89ab-e5f05e0474e8
@@ -278,7 +278,7 @@ trackedFiles:
     pristine_git_object: 1959198f7669fee4593aeb084e44e34317718e0d
   examples/provider/provider.tf:
     id: 954e955c0240
-    last_write_checksum: sha1:cb2330d135d4a807287a422f8e6c4d8fde1d883f
+    last_write_checksum: sha1:65c8c541933044b925827e9994a585aea3fe60f7
     pristine_git_object: 02f445a76d1365acf6ca17232bb2e4c0a07e52ea
   examples/resources/criblio_appscope_config/import-by-string-id.tf:
     id: 13b421bc255d
@@ -1082,7 +1082,7 @@ trackedFiles:
     last_write_checksum: sha1:0ca9bf23ad21d70fa983d95ae7dc8e6752dbc651
   internal/provider/databaseconnection_data_source.go:
     id: c35ca622e07a
-    last_write_checksum: sha1:f3f1056c33c6b377bfa1890f7a8b21603bc4dfe9
+    last_write_checksum: sha1:4b9ce6bd0650f46b945a052ae6c194406584f5e7
     pristine_git_object: 5dee2dd3b86fdca9aa71f2d75595bf00dd10538a
   internal/provider/databaseconnection_data_source_sdk.go:
     id: 5804b5d5567f
@@ -1090,7 +1090,7 @@ trackedFiles:
     pristine_git_object: 2b46bef06750ff94fd345c0135a6f123319f711b
   internal/provider/databaseconnection_resource.go:
     id: 1392fb804bc6
-    last_write_checksum: sha1:5fe84b3d4a02f12f1bea047ff05fef4f34095412
+    last_write_checksum: sha1:0bfffb82a853beaba3f026acca847589b0f36481
     pristine_git_object: 0e3cde2f757fe34c694893c446ad61201107901d
   internal/provider/databaseconnection_resource_sdk.go:
     id: 75650c4856fa
@@ -4412,7 +4412,7 @@ trackedFiles:
     pristine_git_object: bf71ee999b1aa29b59f13528fb9772327ebaf583
   internal/sdk/criblio.go:
     id: a2ae69529b28
-    last_write_checksum: sha1:c4a66992d12cfb22975f3dbf9feb75ce6f5fbf4b
+    last_write_checksum: sha1:7be8a6d03cf86fcef50f9fb78d68c4030cba626e
     pristine_git_object: 9c817ff838a5053031217d727197743322914bb0
   internal/sdk/dashboardcategories.go:
     id: 1cc9a977a86d

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -30,7 +30,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.23.32
+  version: 1.23.33
   additionalActions: []
   additionalDataSources: []
   additionalDependencies:

--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -30,7 +30,7 @@ generation:
     generateNewTests: false
     skipResponseBodyAssertions: false
 terraform:
-  version: 1.23.33
+  version: 1.23.34
   additionalActions: []
   additionalDataSources: []
   additionalDependencies:

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,16 +2,16 @@ speakeasyVersion: 1.761.1
 sources:
     Cribl Control Plane and Management API:
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:970a9e6094854bb768b42ad0d9601e7f9dc4e91ceb5012a69185721598372541
-        sourceBlobDigest: sha256:070738a992190b3a8d41ec68dd7a5976771d2b69c8fe1f7b769c878e3c141e4a
+        sourceRevisionDigest: sha256:081c2c2823ec62906b9c957735c5e9ec878e3f701c64292d66b9b39c4e592476
+        sourceBlobDigest: sha256:d63d734fe676671d0ae053fb885d65cecf9de1b6a8ceac77f316b1f6385c5c51
         tags:
             - latest
 targets:
     cribl-io:
         source: Cribl Control Plane and Management API
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:970a9e6094854bb768b42ad0d9601e7f9dc4e91ceb5012a69185721598372541
-        sourceBlobDigest: sha256:070738a992190b3a8d41ec68dd7a5976771d2b69c8fe1f7b769c878e3c141e4a
+        sourceRevisionDigest: sha256:081c2c2823ec62906b9c957735c5e9ec878e3f701c64292d66b9b39c4e592476
+        sourceBlobDigest: sha256:d63d734fe676671d0ae053fb885d65cecf9de1b6a8ceac77f316b1f6385c5c51
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.761.1

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,16 +2,16 @@ speakeasyVersion: 1.761.1
 sources:
     Cribl Control Plane and Management API:
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:eb72bf40ba8b85326ff6f5eda06175947a8fcd50189ec7ea64fea4385ed93049
-        sourceBlobDigest: sha256:3b5ee3c05cf4a2962055a52b718da7a3fcdc4e56b0eaf862069c5f67d4f526f5
+        sourceRevisionDigest: sha256:970a9e6094854bb768b42ad0d9601e7f9dc4e91ceb5012a69185721598372541
+        sourceBlobDigest: sha256:070738a992190b3a8d41ec68dd7a5976771d2b69c8fe1f7b769c878e3c141e4a
         tags:
             - latest
 targets:
     cribl-io:
         source: Cribl Control Plane and Management API
         sourceNamespace: cribl-control-plane-and-management-api
-        sourceRevisionDigest: sha256:eb72bf40ba8b85326ff6f5eda06175947a8fcd50189ec7ea64fea4385ed93049
-        sourceBlobDigest: sha256:3b5ee3c05cf4a2962055a52b718da7a3fcdc4e56b0eaf862069c5f67d4f526f5
+        sourceRevisionDigest: sha256:970a9e6094854bb768b42ad0d9601e7f9dc4e91ceb5012a69185721598372541
+        sourceBlobDigest: sha256:070738a992190b3a8d41ec68dd7a5976771d2b69c8fe1f7b769c878e3c141e4a
 workflow:
     workflowVersion: 1.0.0
     speakeasyVersion: 1.761.1

--- a/docs/data-sources/database_connection.md
+++ b/docs/data-sources/database_connection.md
@@ -30,12 +30,12 @@ data "criblio_database_connection" "my_databaseconnection" {
 ### Read-Only
 
 - `auth_type` (String)
-- `config_obj` (String)
-- `connection_string` (String)
+- `config_obj` (String, Sensitive)
+- `connection_string` (String, Sensitive)
 - `connection_timeout` (Number)
 - `database_type` (String)
 - `description` (String)
-- `password` (String)
+- `password` (String, Sensitive)
 - `request_timeout` (Number)
 - `tags` (String)
 - `user` (String)

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.23.33"
+      version = "1.23.34"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.23.32"
+      version = "1.23.33"
     }
   }
 }

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -945,6 +945,8 @@ resource "criblio_collector" "my_collector" {
 
 ### Optional
 
+- `environment` (String) Mirrors the environment from the active input_collector_* block. May be set in configuration or left unset (computed).
+- `ignore_group_jobs_limit` (Boolean) Mirrors ignore_group_jobs_limit from the active input_collector_* block (no root default; use nested field defaults).
 - `input_collector_azure_blob` (Attributes) (see [below for nested schema](#nestedatt--input_collector_azure_blob))
 - `input_collector_cribl_lake` (Attributes) (see [below for nested schema](#nestedatt--input_collector_cribl_lake))
 - `input_collector_database` (Attributes) (see [below for nested schema](#nestedatt--input_collector_database))
@@ -954,14 +956,9 @@ resource "criblio_collector" "my_collector" {
 - `input_collector_s3` (Attributes) (see [below for nested schema](#nestedatt--input_collector_s3))
 - `input_collector_script` (Attributes) (see [below for nested schema](#nestedatt--input_collector_script))
 - `input_collector_splunk` (Attributes) (see [below for nested schema](#nestedatt--input_collector_splunk))
-
-### Read-Only
-
-- `environment` (String)
-- `ignore_group_jobs_limit` (Boolean)
-- `resume_on_boot` (Boolean)
-- `ttl` (String)
-- `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
+- `resume_on_boot` (Boolean) Mirrors resume_on_boot from the active input_collector_* block (no root default; nested block sets provider defaults).
+- `ttl` (String) Mirrors ttl from the active input_collector_* block (no root default; nested block sets provider defaults).
+- `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node (no root default; use nested field defaults).
 
 <a id="nestedatt--input_collector_azure_blob"></a>
 ### Nested Schema for `input_collector_azure_blob`
@@ -1126,7 +1123,7 @@ Optional:
 Optional:
 
 - `conf` (Attributes) (see [below for nested schema](#nestedatt--input_collector_cribl_lake--collector--conf))
-- `type` (String) Not Null; must be "cribl_lake"
+- `type` (String) Not Null; must match the Stream jobs API ("cribl_lake"). The legacy spelling "cribllake" is accepted and sent as "cribl_lake".
 
 <a id="nestedatt--input_collector_cribl_lake--collector--conf"></a>
 ### Nested Schema for `input_collector_cribl_lake.collector.conf`

--- a/docs/resources/database_connection.md
+++ b/docs/resources/database_connection.md
@@ -42,10 +42,10 @@ resource "criblio_database_connection" "my_databaseconnection" {
 
 ### Optional
 
-- `config_obj` (String)
-- `connection_string` (String)
+- `config_obj` (String, Sensitive)
+- `connection_string` (String, Sensitive)
 - `connection_timeout` (Number)
-- `password` (String)
+- `password` (String, Sensitive)
 - `request_timeout` (Number)
 - `tags` (String)
 - `user` (String)

--- a/examples/database-connection/main.tf
+++ b/examples/database-connection/main.tf
@@ -15,7 +15,3 @@ resource "criblio_database_connection" "my_databaseconnection" {
   tags               = "test"
   user               = "test"
 }
-
-output "database_connection" {
-  value = criblio_database_connection.my_databaseconnection
-}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.23.32"
+      version = "1.23.33"
     }
   }
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.23.33"
+      version = "1.23.34"
     }
   }
 }

--- a/internal/provider/certificate_resource.go
+++ b/internal/provider/certificate_resource.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	custom_listplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/listplanmodifier"
+	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/stringplanmodifier"
 	speakeasy_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/stringplanmodifier"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -87,8 +89,11 @@ func (r *CertificateResource) Schema(ctx context.Context, req resource.SchemaReq
 				},
 			},
 			"in_use": schema.ListAttribute{
-				Computed:    true,
-				Optional:    true,
+				Computed: true,
+				Optional: true,
+				PlanModifiers: []planmodifier.List{
+					custom_listplanmodifier.PreferState(),
+				},
 				ElementType: types.StringType,
 				Description: `List of configurations that reference this certificate`,
 			},
@@ -100,6 +105,9 @@ func (r *CertificateResource) Schema(ctx context.Context, req resource.SchemaReq
 			"priv_key": schema.StringAttribute{
 				Required:  true,
 				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					custom_stringplanmodifier.PreferState(),
+				},
 			},
 		},
 	}

--- a/internal/provider/databaseconnection_data_source.go
+++ b/internal/provider/databaseconnection_data_source.go
@@ -57,10 +57,12 @@ func (r *DatabaseConnectionDataSource) Schema(ctx context.Context, req datasourc
 				Computed: true,
 			},
 			"config_obj": schema.StringAttribute{
-				Computed: true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"connection_string": schema.StringAttribute{
-				Computed: true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"connection_timeout": schema.Float64Attribute{
 				Computed: true,
@@ -80,7 +82,8 @@ func (r *DatabaseConnectionDataSource) Schema(ctx context.Context, req datasourc
 				Description: `Unique ID to GET`,
 			},
 			"password": schema.StringAttribute{
-				Computed: true,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"request_timeout": schema.Float64Attribute{
 				Computed: true,

--- a/internal/provider/databaseconnection_resource.go
+++ b/internal/provider/databaseconnection_resource.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/stringplanmodifier"
 	speakeasy_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/planmodifiers/stringplanmodifier"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -62,12 +63,20 @@ func (r *DatabaseConnectionResource) Schema(ctx context.Context, req resource.Sc
 				Required: true,
 			},
 			"config_obj": schema.StringAttribute{
-				Computed: true,
-				Optional: true,
+				Computed:  true,
+				Optional:  true,
+				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					custom_stringplanmodifier.PreferState(),
+				},
 			},
 			"connection_string": schema.StringAttribute{
-				Computed: true,
-				Optional: true,
+				Computed:  true,
+				Optional:  true,
+				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					custom_stringplanmodifier.PreferState(),
+				},
 			},
 			"connection_timeout": schema.Float64Attribute{
 				Computed: true,
@@ -104,8 +113,12 @@ func (r *DatabaseConnectionResource) Schema(ctx context.Context, req resource.Sc
 				Description: `Unique ID to PATCH. Requires replacement if changed.`,
 			},
 			"password": schema.StringAttribute{
-				Computed: true,
-				Optional: true,
+				Computed:  true,
+				Optional:  true,
+				Sensitive: true,
+				PlanModifiers: []planmodifier.String{
+					custom_stringplanmodifier.PreferState(),
+				},
 			},
 			"request_timeout": schema.Float64Attribute{
 				Computed: true,

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -359,9 +359,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.23.33",
+		SDKVersion: "1.23.34",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.23.33 2.879.6 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.23.34 2.879.6 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/internal/sdk/criblio.go
+++ b/internal/sdk/criblio.go
@@ -359,9 +359,9 @@ func WithTimeout(timeout time.Duration) SDKOption {
 // New creates a new instance of the SDK with the provided options
 func New(opts ...SDKOption) *CriblIo {
 	sdk := &CriblIo{
-		SDKVersion: "1.23.32",
+		SDKVersion: "1.23.33",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 1.23.32 2.879.6 github.com/criblio/terraform-provider-criblio/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 1.23.33 2.879.6 github.com/criblio/terraform-provider-criblio/internal/sdk",
 			ServerList: ServerList,
 			ServerVariables: map[string]map[string]string{
 				"cloud": {

--- a/openapi.yml
+++ b/openapi.yml
@@ -155,6 +155,7 @@ components:
                     title: Private key
                     example: "dont-share-this-key"
                     x-speakeasy-param-sensitive: true
+                    x-speakeasy-plan-modifiers: PreferState
                 passphrase:
                     type: string
                     title: Passphrase
@@ -172,6 +173,7 @@ components:
                     items:
                         type: string
                     example: ["list", "of", "configurations"]
+                    x-speakeasy-plan-modifiers: PreferState
         FeaturesEntry:
             type: object
             properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -8473,9 +8473,13 @@ components:
                 configObj:
                     type: string
                     example: '{"ssl":true}'
+                    x-speakeasy-param-sensitive: true
+                    x-speakeasy-plan-modifiers: PreferState
                 connectionString:
                     type: string
                     example: postgresql://db.example.com:5432/appdb
+                    x-speakeasy-param-sensitive: true
+                    x-speakeasy-plan-modifiers: PreferState
                 connectionTimeout:
                     type: number
                     example: 30
@@ -8490,6 +8494,8 @@ components:
                 password:
                     type: string
                     example: $${{secret:db_password}
+                    x-speakeasy-param-sensitive: true
+                    x-speakeasy-plan-modifiers: PreferState
                 requestTimeout:
                     type: number
                     example: 60

--- a/tools/import-cli/internal/hcl/destination.go
+++ b/tools/import-cli/internal/hcl/destination.go
@@ -217,6 +217,10 @@ func jsonMapToValueMap(item map[string]string, keysToSkip map[string]bool) (map[
 			return nil, fmt.Errorf("%s: %w", k, err)
 		}
 		v = omitEmptyListsFromValue(v)
+		// Filter urls list items with empty/missing url field (loadBalanced=false case)
+		if sk == "urls" && v.Kind == KindList {
+			v = filterUrlsListItems(v)
+		}
 		// Don't emit empty lists; provider often has listvalidator.SizeAtLeast(1).
 		if v.Kind == KindList && len(v.List) == 0 {
 			continue
@@ -234,6 +238,7 @@ func OmitEmptyListsFromValue(v Value) Value {
 
 // omitEmptyListsFromValue returns a copy of v with empty list values omitted from nested maps.
 // Used so nested attributes like urls = [] are not written (avoids SizeAtLeast(1) errors).
+// Also filters out invalid items from urls lists (items with missing or empty url fields).
 func omitEmptyListsFromValue(v Value) Value {
 	switch v.Kind {
 	case KindMap:
@@ -242,6 +247,13 @@ func omitEmptyListsFromValue(v Value) Value {
 			cleaned := omitEmptyListsFromValue(ev)
 			if cleaned.Kind == KindList && len(cleaned.List) == 0 {
 				continue
+			}
+			// Filter urls list items that have empty or missing url field
+			if k == "urls" && cleaned.Kind == KindList {
+				cleaned = filterUrlsListItems(cleaned)
+				if len(cleaned.List) == 0 {
+					continue
+				}
 			}
 			m[k] = cleaned
 		}
@@ -255,6 +267,28 @@ func omitEmptyListsFromValue(v Value) Value {
 	default:
 		return v
 	}
+}
+
+// filterUrlsListItems filters out items from a urls list where the url field is missing or empty.
+// When loadBalanced=false, the API may return urls: [{ weight: 1 }] or urls: [{ url: "", weight: 1 }],
+// but the terraform schema requires url to be non-null and match the URL regex.
+func filterUrlsListItems(v Value) Value {
+	if v.Kind != KindList {
+		return v
+	}
+	filtered := make([]Value, 0, len(v.List))
+	for _, item := range v.List {
+		if item.Kind != KindMap {
+			filtered = append(filtered, item)
+			continue
+		}
+		urlVal, hasUrl := item.Map["url"]
+		if !hasUrl || (urlVal.Kind == KindString && urlVal.String == "") || urlVal.Kind == KindNull {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	return Value{Kind: KindList, List: filtered}
 }
 
 // jsonStringToValue parses a JSON value string and converts it to Value.

--- a/tools/import-cli/internal/hcl/destination_test.go
+++ b/tools/import-cli/internal/hcl/destination_test.go
@@ -106,6 +106,63 @@ func TestItemMapToBlock_omits_empty_lists(t *testing.T) {
 	assert.NotContains(t, value.Map, "urls", "empty urls list must be omitted to satisfy SizeAtLeast(1)")
 }
 
+func TestItemMapToBlock_omits_urls_with_empty_url(t *testing.T) {
+	// When loadBalanced=false, API returns urls: [{ weight: 1 }] or urls: [{ url: "", weight: 1 }].
+	// The urls[].url field has NotNull and regex validators, so we must omit urls entirely when
+	// all items have empty/missing url values.
+	t.Run("urls with missing url field omitted", func(t *testing.T) {
+		item := map[string]string{
+			"type": `"webhook"`,
+			"id":   `"my-webhook"`,
+			"url":  `"https://example.com/webhook"`,
+			"urls": `[{"weight": 1}]`,
+		}
+		_, value, err := ItemMapToBlock(item, "type", "output_", "", []string{"status"}, nil)
+		require.NoError(t, err)
+		assert.Contains(t, value.Map, "url")
+		assert.NotContains(t, value.Map, "urls", "urls with items missing url field must be omitted")
+	})
+
+	t.Run("urls with empty string url omitted", func(t *testing.T) {
+		item := map[string]string{
+			"type": `"webhook"`,
+			"id":   `"my-webhook"`,
+			"url":  `"https://example.com/webhook"`,
+			"urls": `[{"url": "", "weight": 1}]`,
+		}
+		_, value, err := ItemMapToBlock(item, "type", "output_", "", []string{"status"}, nil)
+		require.NoError(t, err)
+		assert.Contains(t, value.Map, "url")
+		assert.NotContains(t, value.Map, "urls", "urls with empty url strings must be omitted")
+	})
+
+	t.Run("urls with valid urls preserved", func(t *testing.T) {
+		item := map[string]string{
+			"type": `"webhook"`,
+			"id":   `"my-webhook"`,
+			"urls": `[{"url": "https://example.com/webhook", "weight": 1}]`,
+		}
+		_, value, err := ItemMapToBlock(item, "type", "output_", "", []string{"status"}, nil)
+		require.NoError(t, err)
+		assert.Contains(t, value.Map, "urls", "urls with valid url values must be preserved")
+		require.Len(t, value.Map["urls"].List, 1)
+		assert.Equal(t, "https://example.com/webhook", value.Map["urls"].List[0].Map["url"].String)
+	})
+
+	t.Run("mixed urls filters invalid items", func(t *testing.T) {
+		item := map[string]string{
+			"type": `"webhook"`,
+			"id":   `"my-webhook"`,
+			"urls": `[{"url": "", "weight": 1}, {"url": "https://valid.com", "weight": 2}]`,
+		}
+		_, value, err := ItemMapToBlock(item, "type", "output_", "", []string{"status"}, nil)
+		require.NoError(t, err)
+		assert.Contains(t, value.Map, "urls", "urls should be preserved when at least one valid item exists")
+		require.Len(t, value.Map["urls"].List, 1, "only valid url items should remain")
+		assert.Equal(t, "https://valid.com", value.Map["urls"].List[0].Map["url"].String)
+	})
+}
+
 func TestItemMapToBlock_notification_target_suffix(t *testing.T) {
 	t.Run("smtp type gets _target suffix", func(t *testing.T) {
 		item := map[string]string{"type": `"smtp"`, "id": `"system_email"`}

--- a/tools/import-cli/internal/hcl/value.go
+++ b/tools/import-cli/internal/hcl/value.go
@@ -475,7 +475,7 @@ func sanitizeVarName(resourceName, path string) string {
 	return s
 }
 
-// sensitiveAttributeNames lists attribute names that should be treated as secrets.
+// sensitiveAttributeNames lists exact attribute names that should be treated as secrets.
 var sensitiveAttributeNames = []string{
 	"token",
 	"password",
@@ -490,17 +490,50 @@ var sensitiveAttributeNames = []string{
 	"access_key",
 	"secret_key",
 	"credentials",
+	"aws_secret_key",
+	"aws_api_key",
+}
+
+// sensitiveSuffixes lists suffixes that indicate a sensitive field (e.g. aws_secret_key ends with _secret_key).
+var sensitiveSuffixes = []string{
+	"_password",
+	"_secret",
+	"_secret_key",
+	"_api_key",
+	"_apikey",
+	"_token",
+	"_auth_token",
+	"_private_key",
+	"_priv_key",
+	"_access_key",
+	"_credentials",
+	"_passphrase",
 }
 
 // pathRefersToSensitiveAttribute is true when path denotes a sensitive credential field,
 // not unrelated names that merely contain the sensitive word (e.g. token_timeout_secs).
 func pathRefersToSensitiveAttribute(path string) bool {
+	// Check exact match or dotted path match
 	for _, attr := range sensitiveAttributeNames {
 		if path == attr {
 			return true
 		}
 		if strings.HasSuffix(path, "."+attr) || strings.Contains(path, "."+attr+".") {
 			return true
+		}
+	}
+	// Check suffix match (e.g. aws_secret_key ends with _secret_key)
+	for _, suffix := range sensitiveSuffixes {
+		if strings.HasSuffix(path, suffix) {
+			return true
+		}
+		// Also check the last path component for suffix
+		lastDot := strings.LastIndex(path, ".")
+		if lastDot >= 0 {
+			lastPart := path[lastDot+1:]
+			if strings.HasSuffix(lastPart, suffix) {
+				return true
+			}
 		}
 	}
 	return false
@@ -526,6 +559,23 @@ func MaskSensitiveValuesInJSON(jsonStr, resourceName, attrPath string) (string, 
 	return string(masked), varNames
 }
 
+// isSensitiveKey returns true if the key is a sensitive field name.
+func isSensitiveKey(key string) bool {
+	// Check exact match
+	for _, sensitiveKey := range sensitiveAttributeNames {
+		if key == sensitiveKey {
+			return true
+		}
+	}
+	// Check suffix match (e.g. aws_secret_key ends with _secret_key)
+	for _, suffix := range sensitiveSuffixes {
+		if strings.HasSuffix(key, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
 // maskSensitiveValuesInMap recursively masks sensitive values in a map by replacing them with variable references.
 // Appends generated variable names to varNames.
 func maskSensitiveValuesInMap(data map[string]interface{}, pathPrefix, resourceName, attrPath string, varNames *[]string) {
@@ -534,13 +584,11 @@ func maskSensitiveValuesInMap(data map[string]interface{}, pathPrefix, resourceN
 		if pathPrefix != "" {
 			currentPath = pathPrefix + "_" + key
 		}
-		for _, sensitiveKey := range sensitiveAttributeNames {
-			if key == sensitiveKey {
-				if str, ok := val.(string); ok && str != "" {
-					varName := sanitizeVarName(resourceName, attrPath+"_"+currentPath)
-					data[key] = "${var." + varName + "}"
-					*varNames = append(*varNames, varName)
-				}
+		if isSensitiveKey(key) {
+			if str, ok := val.(string); ok && str != "" {
+				varName := sanitizeVarName(resourceName, attrPath+"_"+currentPath)
+				data[key] = "${var." + varName + "}"
+				*varNames = append(*varNames, varName)
 			}
 		}
 		if nested, ok := val.(map[string]interface{}); ok {


### PR DESCRIPTION
This PR fixes these issues raised by govTech during their use of bulk-exporter:

- Added additional suffexes to filter secrets and mask those values, our schema have multiple different names and types of secrets based on the resource/endpoint
- Updated few properties of database-connection and certificate resource to mark them as sensitive after recent API response changes
- Updated tests to handle these cases