### PR TITLE
Adding support to exclude-defaults flag.

### DIFF
--- a/tools/import-cli/cmd/export.go
+++ b/tools/import-cli/cmd/export.go
@@ -45,18 +45,19 @@ func (f *logFilterWriter) Write(p []byte) (n int, err error) {
 // NewExportCommand returns the export subcommand.
 func NewExportCommand() *cobra.Command {
 	var (
-		outputDir   string
-		include     []string
-		exclude     []string
-		group       []string
-		flat        bool // if true, use flat layout (output-dir/<type>/); default is group-by (output-dir/<group_id>/<type>/)
-		parallel    int
-		dryRun      bool
-		verbose     bool
-		serverURL   string
-		orgID       string
-		workspaceID string
-		cloudDomain string
+		outputDir       string
+		include         []string
+		exclude         []string
+		group           []string
+		flat            bool // if true, use flat layout (output-dir/<type>/); default is group-by (output-dir/<group_id>/<type>/)
+		parallel        int
+		dryRun          bool
+		verbose         bool
+		excludeDefaults bool
+		serverURL       string
+		orgID           string
+		workspaceID     string
+		cloudDomain     string
 	)
 	v := viper.New()
 	cfg := config.NewConfig(v)
@@ -162,7 +163,7 @@ func NewExportCommand() *cobra.Command {
 			progress := func(format string, args ...interface{}) {
 				fmt.Fprintf(c.ErrOrStderr(), "  "+format+"\n", args...)
 			}
-			exportResult, exportErr := export.ToResourceItems(ctx, sdkClient, reg, results, groupIDs, group, parallel, progress)
+			exportResult, exportErr := export.ToResourceItems(ctx, sdkClient, reg, results, groupIDs, group, parallel, excludeDefaults, progress)
 			exportResult.DiscoveredTotal = discoveredTotal
 			if exportErr != nil {
 				fmt.Fprintln(c.ErrOrStderr(), "Warning:", exportErr.Error())
@@ -199,6 +200,7 @@ func NewExportCommand() *cobra.Command {
 	exp.Flags().IntVar(&parallel, "parallel", 5, "Max concurrent API calls during export (default 5).")
 	exp.Flags().BoolVar(&dryRun, "dry-run", false, "Preview resource counts and types only; no conversion or file writes. Uses List* API only (no Get*ByID).")
 	exp.Flags().BoolVar(&verbose, "verbose", false, "Enable debug logging")
+	exp.Flags().BoolVar(&excludeDefaults, "exclude-defaults", false, "Exclude built-in Cribl resources (lib=cribl, tags=cribl:default, known default IDs)")
 
 	exp.Flags().StringVar(&serverURL, "server-url", "", "On-prem base URL")
 	exp.Flags().StringVar(&orgID, "org-id", "", "Cribl org identifier")
@@ -332,6 +334,9 @@ func printExportSummary(cmd *cobra.Command, res *export.ExportResult, verbose bo
 				fmt.Fprintf(out, "  %s: %s\n", s.TypeName, s.Reason)
 			}
 		}
+	}
+	if res.DefaultsSkipped > 0 {
+		fmt.Fprintf(out, "Skipped %d built-in default resources (--exclude-defaults).\n", res.DefaultsSkipped)
 	}
 	if len(res.ConvertSkipped) > 0 {
 		if verbose {

--- a/tools/import-cli/internal/converter/converter.go
+++ b/tools/import-cli/internal/converter/converter.go
@@ -169,24 +169,28 @@ func Convert(ctx context.Context, client *sdk.CriblIo, e registry.Entry, request
 	return converted, nil
 }
 
-// fillPackPipelineConf fills the pack pipeline model's Conf. GetPipelinesByPackWithID returns only
-// Routes (items), not the pipeline definition. We try Pipelines.GetPipelineByID (lib) for the same
-// group/id; if that returns one pipeline we use it. Otherwise we set minimal conf so HCL is valid.
+// fillPackPipelineConf fills the pack pipeline model's Conf. GetPipelinesByPackWithID returns the
+// pipeline definition for pack pipelines. We need Pack, GroupID, and ID to fetch the correct content.
 func fillPackPipelineConf(ctx context.Context, client *sdk.CriblIo, converted interface{}, requestParams map[string]string) {
 	pm, ok := converted.(*provider.PackPipelineResourceModel)
-	if !ok || client == nil || client.Pipelines == nil {
+	if !ok || client == nil || client.Routes == nil {
 		return
 	}
 	groupID := requestParams["GroupID"]
 	id := requestParams["ID"]
+	pack := requestParams["Pack"]
 	if groupID == "" {
 		groupID = "default"
 	}
-	if id == "" {
+	if id == "" || pack == "" {
 		ensureMinimalPackPipelineConf(pm)
 		return
 	}
-	resp, err := client.Pipelines.GetPipelineByID(ctx, operations.GetPipelineByIDRequest{GroupID: groupID, ID: id})
+	resp, err := client.Routes.GetPipelinesByPackWithID(ctx, operations.GetPipelinesByPackWithIDRequest{
+		GroupID: groupID,
+		Pack:    pack,
+		ID:      id,
+	})
 	if err != nil || resp == nil || resp.Object == nil {
 		ensureMinimalPackPipelineConf(pm)
 		return

--- a/tools/import-cli/internal/custom/searchlist.go
+++ b/tools/import-cli/internal/custom/searchlist.go
@@ -40,6 +40,21 @@ var SkipPacks = map[string]bool{
 	"HelloPacks": true,
 }
 
+// DefaultPackIDs are built-in pack IDs that ship with Cribl.
+var DefaultPackIDs = map[string]bool{
+	"HelloPacks":      true,
+	"example-pack-id": true,
+	"string":          true,
+}
+
+// DefaultGroupIDs are built-in group IDs that ship with Cribl.
+// These are skipped when --exclude-defaults is used.
+var DefaultGroupIDs = map[string]bool{
+	"default":       true,
+	"default_fleet": true,
+	"defaultHybrid": true,
+}
+
 // DefaultSearchDatasetProviderIDs are built-in dataset provider IDs that are never imported.
 // We skip these when parsing the dataset-providers list so only user-created providers are imported.
 var DefaultSearchDatasetProviderIDs = map[string]bool{
@@ -49,6 +64,7 @@ var DefaultSearchDatasetProviderIDs = map[string]bool{
 	"cribl_s3sample_provider": true,
 	"cribl_meta":              true,
 	"cribl_lake":              true,
+	"lakehouse":               true,
 }
 
 // DefaultSearchDatasetIDs are built-in search dataset IDs that are never imported.
@@ -61,13 +77,42 @@ var DefaultSearchDatasetIDs = map[string]bool{
 	"default_metrics": true,
 	"default_spans":   true,
 	"S3":              true, // default S3 dataset
+	"main":            true, // default search dataset
 }
 
-// DefaultDestinationIDs are built-in destination IDs (default, devnull) that are never imported.
+// DefaultSearchDatasetRulesetIDs are built-in search dataset ruleset IDs.
+var DefaultSearchDatasetRulesetIDs = map[string]bool{
+	"default": true,
+}
+
+// DefaultSearchDatatypeRulesetIDs are built-in search datatype ruleset IDs.
+var DefaultSearchDatatypeRulesetIDs = map[string]bool{
+	"default": true,
+}
+
+// DefaultSearchSavedQueryIDs are built-in search saved query IDs (prefixed with cribl_).
+var DefaultSearchSavedQueryIDs = map[string]bool{
+	"cribl_search_finished_1h": true,
+	"cribl_search_started_1h":  true,
+}
+
+// DefaultDestinationIDs are built-in destination IDs that are never imported.
 // We skip these when listing destinations so only user-created destinations are exported.
 var DefaultDestinationIDs = map[string]bool{
-	"default": true,
-	"devnull": true,
+	"default":               true,
+	"devnull":               true,
+	"engine_router":         true,
+	"metrics_engine_router": true,
+	// OTel default destinations
+	"otel-data-router": true,
+	"otel-logs":        true,
+	"otel-metrics":     true,
+	"otel-traces":      true,
+	// Elastic integration defaults
+	"elastic-otel":       true,
+	"elastic-prometheus": true,
+	// Cribl HTTP route default
+	"cribl_http_route": true,
 }
 
 // DefaultCriblLakeDatasetIDs are built-in Cribl Lake dataset IDs that are never imported.
@@ -80,6 +125,103 @@ var DefaultCriblLakeDatasetIDs = map[string]bool{
 	"default_metrics": true,
 	"default_spans":   true,
 	"S3":              true,
+}
+
+// DefaultPipelineIDs are built-in pipeline IDs that ship with Cribl.
+var DefaultPipelineIDs = map[string]bool{
+	"cisco_asa":            true,
+	"cisco_estreamer":      true,
+	"cribl_metrics_rollup": true,
+	"devnull":              true,
+	"kubernetes_logs":      true,
+	"main":                 true,
+	"metrics_ingest":       true, // search-specific default pipeline
+	"palo_alto_traffic":    true,
+	"passthru":             true,
+	"prometheus_metrics":   true,
+	"wineventlogs":         true,
+}
+
+// DefaultGrokIDs are built-in grok pattern library IDs.
+var DefaultGrokIDs = map[string]bool{
+	"aws":           true,
+	"core-patterns": true,
+	"firewalls":     true,
+	"httpd":         true,
+	"java":          true,
+	"linux-syslog":  true,
+}
+
+// DefaultParquetSchemaIDs are built-in parquet schema IDs.
+var DefaultParquetSchemaIDs = map[string]bool{
+	"sample_compression_encoding": true,
+	"sample_logical_types":        true,
+	"sample_nested":               true,
+	"sample_parquet":              true,
+	"sample_primitive":            true,
+	"sample_repetition_type":      true,
+	"syslog_parquet":              true,
+}
+
+// DefaultSchemaIDs are built-in schema IDs.
+var DefaultSchemaIDs = map[string]bool{
+	"cribl_internal": true,
+	"sample_schema":  true,
+}
+
+// DefaultSourceIDs are built-in source IDs.
+var DefaultSourceIDs = map[string]bool{
+	// Stream sources
+	"CriblLogs":       true,
+	"CriblMetrics":    true,
+	"http":            true,
+	"in_appscope_tcp": true,
+	"in_appscope_tls": true,
+	"in_cribl_http":   true,
+	"in_cribl_tcp":    true,
+	"in_elastic":      true,
+	"in_splunk_hec":   true,
+	"in_splunk_tcp":   true,
+	"in_syslog":       true,
+	"in_tcp":          true,
+	"in_tcp_json":     true,
+	"open_telemetry":  true,
+	// Edge sources
+	"in_appscope":        true,
+	"in_file_auto":       true,
+	"in_file_varlog":     true,
+	"in_journal_local":   true,
+	"in_kube_events":     true,
+	"in_kube_logs":       true,
+	"in_kube_metrics":    true,
+	"in_snmp_trap":       true,
+	"in_system_metrics":  true,
+	"in_system_state":    true,
+	"in_win_event_logs":  true,
+	"in_windows_metrics": true,
+}
+
+// DefaultEventBreakerRulesetIDs are built-in event breaker ruleset IDs.
+// Used across groups, packs, and search contexts.
+var DefaultEventBreakerRulesetIDs = map[string]bool{
+	"Apache Ruleset":               true,
+	"AWS Ruleset":                  true,
+	"AWS VPC Flow Ruleset":         true,
+	"Bro Ruleset":                  true,
+	"Cisco ASA Ruleset":            true,
+	"Cisco Ruleset":                true,
+	"Cribl":                        true,
+	"Cribl - Do Not Break Ruleset": true,
+	"Cribl Search":                 true,
+	"CrowdStrike Ruleset":          true,
+	"CSV Ruleset":                  true,
+	"JSON Newline Delimited":       true,
+	"NDJSON Ruleset":               true,
+	"Office 365":                   true,
+	"Palo Alto Ruleset":            true,
+	"Splunk Search Ruleset":        true,
+	"Syslog Ruleset":               true,
+	"Wiz Ruleset":                  true,
 }
 
 // SearchDatasetTypeCriblLake is the API type for Cribl Lake datasets. They appear in the search

--- a/tools/import-cli/internal/discovery/engine.go
+++ b/tools/import-cli/internal/discovery/engine.go
@@ -813,6 +813,14 @@ func identifiersFromItems(items reflect.Value, groupID string, e registry.Entry)
 		if (e.TypeName == "criblio_event_breaker_ruleset" || e.TypeName == "criblio_search_macro") && strings.Contains(id, ".") {
 			continue
 		}
+		// Skip pack pipelines (id starts with "pack:") — they belong to criblio_pack_pipeline, not criblio_pipeline.
+		if e.TypeName == "criblio_pipeline" && strings.HasPrefix(id, "pack:") {
+			continue
+		}
+		// Strip "pack:" prefix from pack pipeline IDs if present (API may return full ID format).
+		if e.TypeName == "criblio_pack_pipeline" && strings.HasPrefix(id, "pack:") {
+			id = strings.TrimPrefix(id, "pack:")
+		}
 		// Skip built-in destinations (default, devnull) so only user-created are imported.
 		if (e.TypeName == "criblio_destination" || e.TypeName == "criblio_pack_destination") && custom.DefaultDestinationIDs[id] {
 			continue

--- a/tools/import-cli/internal/export/export.go
+++ b/tools/import-cli/internal/export/export.go
@@ -13,6 +13,7 @@ import (
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/operations"
 	"github.com/criblio/terraform-provider-criblio/internal/sdk/models/shared"
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/converter"
+	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/custom"
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/discovery"
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/generator"
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/hcl"
@@ -37,6 +38,7 @@ type ExportResult struct {
 	Items           []generator.ResourceItem
 	ListSkipped     []ListSkipReason // types skipped at list (no metadata, list failed, or list returned 0 ids)
 	ConvertSkipped  []string         // one message per resource that failed convert/hcl/import
+	DefaultsSkipped int              // count of resources skipped due to --exclude-defaults
 	DiscoveredTotal int              // sum of discovery counts for types we attempted (set by caller)
 }
 
@@ -46,13 +48,14 @@ type ProgressFunc func(format string, args ...interface{})
 // ToResourceItems turns discovery results into generator ResourceItems for types
 // that have GetMethod and ImportIDFormat. Uses groupIDs for list/get requests.
 // parallel limits concurrent API calls (default 5); use 1 for sequential.
+// excludeDefaults, when true, skips built-in Cribl resources (lib=cribl, tags=cribl:default, known default IDs).
 // progress, when non-nil, is called to report progress per resource type.
 // Continues on list-level and per-item errors so as many resources as possible are exported;
 // failed types or items are recorded in result.ListSkipped and result.ConvertSkipped.
 // Caller should set result.DiscoveredTotal to the sum of discovery counts for reporting.
 // groupFilter is the CLI --group slice; when non-empty, export only resources whose output folder
 // matches a resolved worker/search group (see skipExportForGroupFilter).
-func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Registry, results []discovery.Result, groupIDs []string, groupFilter []string, parallel int, progress ProgressFunc) (result *ExportResult, err error) {
+func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Registry, results []discovery.Result, groupIDs []string, groupFilter []string, parallel int, excludeDefaults bool, progress ProgressFunc) (result *ExportResult, err error) {
 	if parallel < 1 {
 		parallel = 1
 	}
@@ -97,7 +100,7 @@ func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Reg
 					out.ConvertSkipped = append(out.ConvertSkipped, fmt.Sprintf("%s %v: %s", r.TypeName, idMap, sanitizeConvertError(convErr)))
 					continue
 				}
-				if appendErr := appendResourceItemFromModel(out, r.TypeName, e, idMap, model, groupFilter, groupIDs); appendErr != nil {
+				if appendErr := appendResourceItemFromModel(out, r.TypeName, e, idMap, model, groupFilter, groupIDs, excludeDefaults); appendErr != nil {
 					if errors.Is(appendErr, ErrSkipResourceLibCribl) {
 						out.ConvertSkipped = append(out.ConvertSkipped, fmt.Sprintf("%s %v: lib is cribl (built-in, skip export)", r.TypeName, idMap))
 					} else {
@@ -159,7 +162,7 @@ func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Reg
 		}
 		if parallel <= 1 {
 			for _, idMap := range idMaps {
-				item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs)
+				item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs, excludeDefaults, out)
 				if skipMsg != "" {
 					out.ConvertSkipped = append(out.ConvertSkipped, skipMsg)
 				} else if item != nil {
@@ -177,7 +180,7 @@ func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Reg
 					defer wg.Done()
 					sem <- struct{}{}
 					defer func() { <-sem }()
-					item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs)
+					item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs, excludeDefaults, out)
 					mu.Lock()
 					if skipMsg != "" {
 						out.ConvertSkipped = append(out.ConvertSkipped, skipMsg)
@@ -192,5 +195,39 @@ func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Reg
 	}
 	// ConvertSkipped is informational (oneOf unsupported, skip by config, etc.); do not treat as fatal error.
 	// printExportSummary reports skipped resources; export succeeds with best-effort output.
+
+	// Post-process: if excludeDefaults, remove default group resources that have no user-created resources.
+	if excludeDefaults {
+		filterEmptyDefaultGroups(out)
+	}
+
 	return out, nil
+}
+
+// filterEmptyDefaultGroups removes criblio_group resources for default groups (default, default_fleet, defaultHybrid)
+// if no other user-created resources exist in that group. Modifies out.Items in place.
+func filterEmptyDefaultGroups(out *ExportResult) {
+	// Count non-group resources per group_id
+	resourcesPerGroup := make(map[string]int)
+	for _, item := range out.Items {
+		if item.TypeName == "criblio_group" {
+			continue
+		}
+		if item.GroupID != "" {
+			resourcesPerGroup[item.GroupID]++
+		}
+	}
+
+	// Filter out default group resources that have no other resources
+	filtered := make([]generator.ResourceItem, 0, len(out.Items))
+	for _, item := range out.Items {
+		if item.TypeName == "criblio_group" && custom.DefaultGroupIDs[item.GroupID] {
+			if resourcesPerGroup[item.GroupID] == 0 {
+				out.DefaultsSkipped++
+				continue
+			}
+		}
+		filtered = append(filtered, item)
+	}
+	out.Items = filtered
 }

--- a/tools/import-cli/internal/export/export_test.go
+++ b/tools/import-cli/internal/export/export_test.go
@@ -25,7 +25,7 @@ func TestToResourceItems_empty_results(t *testing.T) {
 		{TypeName: "criblio_source", Count: 0},
 		{TypeName: "criblio_pipeline", Count: 0},
 	}
-	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, nil)
+	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Items)
@@ -37,7 +37,7 @@ func TestToResourceItems_nil_client_list_skipped(t *testing.T) {
 	results := []discovery.Result{
 		{TypeName: "criblio_source", Count: 1},
 	}
-	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, nil)
+	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Items)
@@ -232,7 +232,7 @@ func TestAppendResourceItemFromModel_skipsSearchWorkerGroup(t *testing.T) {
 		ImportIDFormat: "group_id",
 	}
 	idMap := map[string]string{"group_id": "search", "product": "stream"}
-	err := appendResourceItemFromModel(out, "criblio_group", e, idMap, nil, nil, nil)
+	err := appendResourceItemFromModel(out, "criblio_group", e, idMap, nil, nil, nil, false)
 	require.NoError(t, err)
 	assert.Empty(t, out.Items)
 }
@@ -282,6 +282,54 @@ func TestSkipResourceWhenLibCribl(t *testing.T) {
 	t.Run("not skip when lib missing", func(t *testing.T) {
 		attrs := map[string]hcl.Value{}
 		assert.False(t, skipResourceWhenLibCribl(attrs))
+	})
+}
+
+func TestDefaultResource(t *testing.T) {
+	t.Run("skip when lib is cribl", func(t *testing.T) {
+		attrs := map[string]hcl.Value{"lib": {Kind: hcl.KindString, String: "cribl"}}
+		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "custom"}, attrs))
+	})
+	t.Run("skip when tags equals cribl:default", func(t *testing.T) {
+		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindString, String: "cribl:default"}}
+		assert.True(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs))
+	})
+	t.Run("not skip when tags is partial cribl match", func(t *testing.T) {
+		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindString, String: "my-cribl-app"}}
+		assert.False(t, DefaultResource("criblio_appscope_config", map[string]string{"id": "custom"}, attrs))
+	})
+	t.Run("skip when tags list contains cribl:default", func(t *testing.T) {
+		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindList, List: []hcl.Value{
+			{Kind: hcl.KindString, String: "other"},
+			{Kind: hcl.KindString, String: "cribl:default"},
+		}}}
+		assert.True(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs))
+	})
+	t.Run("skip default pipeline IDs", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "devnull"}, attrs))
+		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "main"}, attrs))
+		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "passthru"}, attrs))
+	})
+	t.Run("skip default grok IDs", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "aws"}, attrs))
+		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "core-patterns"}, attrs))
+	})
+	t.Run("skip default source IDs", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblLogs"}, attrs))
+		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblMetrics"}, attrs))
+	})
+	t.Run("not skip user-created resources", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		assert.False(t, DefaultResource("criblio_pipeline", map[string]string{"id": "my_custom_pipeline"}, attrs))
+		assert.False(t, DefaultResource("criblio_grok", map[string]string{"id": "my_grok"}, attrs))
+		assert.False(t, DefaultResource("criblio_source", map[string]string{"id": "my_source"}, attrs))
+	})
+	t.Run("not skip when tags is empty list", func(t *testing.T) {
+		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindList, List: []hcl.Value{}}}
+		assert.False(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs))
 	})
 }
 

--- a/tools/import-cli/internal/export/filters.go
+++ b/tools/import-cli/internal/export/filters.go
@@ -85,3 +85,101 @@ func skipResourceWhenLibCribl(attrs map[string]hcl.Value) bool {
 	}
 	return v.String == "cribl"
 }
+
+// DefaultResource reports whether the resource is a built-in Cribl default.
+func DefaultResource(typeName string, idMap map[string]string, attrs map[string]hcl.Value) bool {
+	if skipResourceWhenLibCribl(attrs) {
+		return true
+	}
+	if criblDefaultTag(attrs) {
+		return true
+	}
+	id := idMap["id"]
+	pack := idMap["pack"]
+	switch typeName {
+	case "criblio_destination":
+		return custom.DefaultDestinationIDs[id]
+	case "criblio_pack_destination":
+		if custom.DefaultPackIDs[pack] {
+			return true
+		}
+		return custom.DefaultDestinationIDs[id]
+	case "criblio_search_dataset":
+		return custom.DefaultSearchDatasetIDs[id]
+	case "criblio_search_dataset_provider":
+		return custom.DefaultSearchDatasetProviderIDs[id]
+	case "criblio_cribl_lake_dataset":
+		return custom.DefaultCriblLakeDatasetIDs[id]
+	case "criblio_group":
+		// Groups are filtered in post-processing (filterEmptyDefaultGroups) to keep
+		// default groups that have user-created resources within them.
+		return false
+	case "criblio_pack":
+		return custom.DefaultPackIDs[id]
+	case "criblio_pipeline":
+		if custom.DefaultPipelineIDs[id] {
+			return true
+		}
+		if strings.HasPrefix(id, "pack:") {
+			packName := strings.TrimPrefix(id, "pack:")
+			return custom.DefaultPackIDs[packName]
+		}
+		return false
+	case "criblio_grok":
+		return custom.DefaultGrokIDs[id]
+	case "criblio_parquet_schema":
+		return custom.DefaultParquetSchemaIDs[id]
+	case "criblio_schema":
+		return custom.DefaultSchemaIDs[id]
+	case "criblio_source":
+		return custom.DefaultSourceIDs[id]
+	case "criblio_event_breaker_ruleset":
+		return custom.DefaultEventBreakerRulesetIDs[id]
+	case "criblio_pack_breakers":
+		if custom.DefaultPackIDs[pack] {
+			return true
+		}
+		return custom.DefaultEventBreakerRulesetIDs[id]
+	case "criblio_pack_pipeline":
+		if custom.DefaultPackIDs[pack] {
+			return true
+		}
+		return custom.DefaultPipelineIDs[id]
+	case "criblio_pack_source":
+		if custom.DefaultPackIDs[pack] {
+			return true
+		}
+		return custom.DefaultSourceIDs[id]
+	case "criblio_pack_vars":
+		return custom.DefaultPackIDs[pack]
+	case "criblio_routes", "criblio_pack_routes":
+		// Routes are a singleton per group/pack; users modify but don't create them from scratch.
+		return true
+	case "criblio_search_dataset_ruleset":
+		return custom.DefaultSearchDatasetRulesetIDs[id]
+	case "criblio_search_datatype_ruleset":
+		return custom.DefaultSearchDatatypeRulesetIDs[id]
+	case "criblio_search_saved_query":
+		return custom.DefaultSearchSavedQueryIDs[id]
+	}
+	return false
+}
+
+// criblDefaultTag reports whether attrs contains the cribl:default tag.
+func criblDefaultTag(attrs map[string]hcl.Value) bool {
+	v, ok := attrs["tags"]
+	if !ok {
+		return false
+	}
+	if v.Kind == hcl.KindString {
+		return v.String == custom.CriblDefaultTag
+	}
+	if v.Kind == hcl.KindList {
+		for _, item := range v.List {
+			if item.Kind == hcl.KindString && item.String == custom.CriblDefaultTag {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/tools/import-cli/internal/export/filters.go
+++ b/tools/import-cli/internal/export/filters.go
@@ -141,15 +141,11 @@ func DefaultResource(typeName string, idMap map[string]string, attrs map[string]
 		}
 		return custom.DefaultEventBreakerRulesetIDs[id]
 	case "criblio_pack_pipeline":
-		if custom.DefaultPackIDs[pack] {
-			return true
-		}
-		return custom.DefaultPipelineIDs[id]
+		// Only check if the pack itself is a default; pipeline IDs like "main" are valid inside user packs.
+		return custom.DefaultPackIDs[pack]
 	case "criblio_pack_source":
-		if custom.DefaultPackIDs[pack] {
-			return true
-		}
-		return custom.DefaultSourceIDs[id]
+		// Only check if the pack itself is a default; source IDs are valid inside user packs.
+		return custom.DefaultPackIDs[pack]
 	case "criblio_pack_vars":
 		return custom.DefaultPackIDs[pack]
 	case "criblio_routes", "criblio_pack_routes":

--- a/tools/import-cli/internal/export/items.go
+++ b/tools/import-cli/internal/export/items.go
@@ -19,7 +19,7 @@ import (
 )
 
 // convertOneResource fetches a single resource via the converter, builds HCL attrs, and returns a ResourceItem or skip message.
-func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Result, e registry.Entry, idMap map[string]string, groupFilter []string, groupIDs []string) (item *generator.ResourceItem, skipMsg string) {
+func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Result, e registry.Entry, idMap map[string]string, groupFilter []string, groupIDs []string, excludeDefaults bool, out *ExportResult) (item *generator.ResourceItem, skipMsg string) {
 	if skipExportForGroupFilter(r.TypeName, idMap, groupFilter, groupIDs) {
 		return nil, ""
 	}
@@ -130,6 +130,10 @@ func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Re
 	if skipResourceWhenLibCribl(attrs) {
 		return nil, fmt.Sprintf("%s %v: lib is cribl (built-in, skip export)", r.TypeName, idMap)
 	}
+	if excludeDefaults && DefaultResource(r.TypeName, idMap, attrs) {
+		out.DefaultsSkipped++
+		return nil, fmt.Sprintf("%s %v: built-in default (--exclude-defaults)", r.TypeName, idMap)
+	}
 	if r.TypeName == "criblio_search_datatype_ruleset" || r.TypeName == "criblio_search_dataset_ruleset" {
 		if injErr := injectSearchRulesetRulesForExport(r.TypeName, model, attrs, e); injErr != nil {
 			return nil, fmt.Sprintf("%s %v: search ruleset rules: %s", r.TypeName, idMap, sanitizeConvertError(injErr))
@@ -194,7 +198,7 @@ func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Re
 }
 
 // appendResourceItemFromModel builds HCL attrs and appends a ResourceItem to out.Items (used for criblio_group and shared conversion path).
-func appendResourceItemFromModel(out *ExportResult, typeName string, e registry.Entry, idMap map[string]string, model interface{}, groupFilter []string, groupIDs []string) error {
+func appendResourceItemFromModel(out *ExportResult, typeName string, e registry.Entry, idMap map[string]string, model interface{}, groupFilter []string, groupIDs []string, excludeDefaults bool) error {
 	if skipResourceByID(typeName, idMap) {
 		return nil
 	}
@@ -254,6 +258,10 @@ func appendResourceItemFromModel(out *ExportResult, typeName string, e registry.
 	filterAttrsBySchema(attrs, e.ModelTypeName)
 	if skipResourceWhenLibCribl(attrs) {
 		return ErrSkipResourceLibCribl
+	}
+	if excludeDefaults && DefaultResource(typeName, idMap, attrs) {
+		out.DefaultsSkipped++
+		return nil
 	}
 	importID, idErr := generator.BuildImportID(e.ImportIDFormat, idMap)
 	if idErr != nil {


### PR DESCRIPTION
Adding a mechanism to exclude-defaults within the bulk-exporter cli tool.

- Added a flag exclude-defaults and captured most of the resources that needs to be excluded
- Fixed a minor issue with pack-pipeline not exporting entire content