### PR TITLE
Implementing an option to include default ids.

### DIFF
--- a/tools/import-cli/cmd/export.go
+++ b/tools/import-cli/cmd/export.go
@@ -45,19 +45,20 @@ func (f *logFilterWriter) Write(p []byte) (n int, err error) {
 // NewExportCommand returns the export subcommand.
 func NewExportCommand() *cobra.Command {
 	var (
-		outputDir       string
-		include         []string
-		exclude         []string
-		group           []string
-		flat            bool // if true, use flat layout (output-dir/<type>/); default is group-by (output-dir/<group_id>/<type>/)
-		parallel        int
-		dryRun          bool
-		verbose         bool
-		excludeDefaults bool
-		serverURL       string
-		orgID           string
-		workspaceID     string
-		cloudDomain     string
+		outputDir         string
+		include           []string
+		exclude           []string
+		group             []string
+		flat              bool // if true, use flat layout (output-dir/<type>/); default is group-by (output-dir/<group_id>/<type>/)
+		parallel          int
+		dryRun            bool
+		verbose           bool
+		excludeDefaults   bool
+		includeDefaultIDs []string
+		serverURL         string
+		orgID             string
+		workspaceID       string
+		cloudDomain       string
 	)
 	v := viper.New()
 	cfg := config.NewConfig(v)
@@ -163,7 +164,8 @@ func NewExportCommand() *cobra.Command {
 			progress := func(format string, args ...interface{}) {
 				fmt.Fprintf(c.ErrOrStderr(), "  "+format+"\n", args...)
 			}
-			exportResult, exportErr := export.ToResourceItems(ctx, sdkClient, reg, results, groupIDs, group, parallel, excludeDefaults, progress)
+			includeOverride := export.ParseIncludeDefaultIDs(includeDefaultIDs)
+			exportResult, exportErr := export.ToResourceItems(ctx, sdkClient, reg, results, groupIDs, group, parallel, excludeDefaults, includeOverride, progress)
 			exportResult.DiscoveredTotal = discoveredTotal
 			if exportErr != nil {
 				fmt.Fprintln(c.ErrOrStderr(), "Warning:", exportErr.Error())
@@ -201,6 +203,7 @@ func NewExportCommand() *cobra.Command {
 	exp.Flags().BoolVar(&dryRun, "dry-run", false, "Preview resource counts and types only; no conversion or file writes. Uses List* API only (no Get*ByID).")
 	exp.Flags().BoolVar(&verbose, "verbose", false, "Enable debug logging")
 	exp.Flags().BoolVar(&excludeDefaults, "exclude-defaults", false, "Exclude built-in Cribl resources (lib=cribl, tags=cribl:default, known default IDs)")
+	exp.Flags().StringSliceVar(&includeDefaultIDs, "include-default-ids", nil, "Resource IDs to include even when --exclude-defaults is set. Use 'id' for any type or 'type:id' for specific type (e.g. criblio_source:in_system_metrics)")
 
 	exp.Flags().StringVar(&serverURL, "server-url", "", "On-prem base URL")
 	exp.Flags().StringVar(&orgID, "org-id", "", "Cribl org identifier")

--- a/tools/import-cli/internal/export/export.go
+++ b/tools/import-cli/internal/export/export.go
@@ -55,7 +55,7 @@ type ProgressFunc func(format string, args ...interface{})
 // Caller should set result.DiscoveredTotal to the sum of discovery counts for reporting.
 // groupFilter is the CLI --group slice; when non-empty, export only resources whose output folder
 // matches a resolved worker/search group (see skipExportForGroupFilter).
-func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Registry, results []discovery.Result, groupIDs []string, groupFilter []string, parallel int, excludeDefaults bool, progress ProgressFunc) (result *ExportResult, err error) {
+func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Registry, results []discovery.Result, groupIDs []string, groupFilter []string, parallel int, excludeDefaults bool, includeOverride IncludeOverride, progress ProgressFunc) (result *ExportResult, err error) {
 	if parallel < 1 {
 		parallel = 1
 	}
@@ -100,7 +100,7 @@ func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Reg
 					out.ConvertSkipped = append(out.ConvertSkipped, fmt.Sprintf("%s %v: %s", r.TypeName, idMap, sanitizeConvertError(convErr)))
 					continue
 				}
-				if appendErr := appendResourceItemFromModel(out, r.TypeName, e, idMap, model, groupFilter, groupIDs, excludeDefaults); appendErr != nil {
+				if appendErr := appendResourceItemFromModel(out, r.TypeName, e, idMap, model, groupFilter, groupIDs, excludeDefaults, includeOverride); appendErr != nil {
 					if errors.Is(appendErr, ErrSkipResourceLibCribl) {
 						out.ConvertSkipped = append(out.ConvertSkipped, fmt.Sprintf("%s %v: lib is cribl (built-in, skip export)", r.TypeName, idMap))
 					} else {
@@ -162,7 +162,7 @@ func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Reg
 		}
 		if parallel <= 1 {
 			for _, idMap := range idMaps {
-				item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs, excludeDefaults, out)
+				item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs, excludeDefaults, includeOverride, out)
 				if skipMsg != "" {
 					out.ConvertSkipped = append(out.ConvertSkipped, skipMsg)
 				} else if item != nil {
@@ -180,7 +180,7 @@ func ToResourceItems(ctx context.Context, client *sdk.CriblIo, reg *registry.Reg
 					defer wg.Done()
 					sem <- struct{}{}
 					defer func() { <-sem }()
-					item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs, excludeDefaults, out)
+					item, skipMsg := convertOneResource(ctx, client, r, e, idMap, groupFilter, groupIDs, excludeDefaults, includeOverride, out)
 					mu.Lock()
 					if skipMsg != "" {
 						out.ConvertSkipped = append(out.ConvertSkipped, skipMsg)

--- a/tools/import-cli/internal/export/export_test.go
+++ b/tools/import-cli/internal/export/export_test.go
@@ -25,7 +25,7 @@ func TestToResourceItems_empty_results(t *testing.T) {
 		{TypeName: "criblio_source", Count: 0},
 		{TypeName: "criblio_pipeline", Count: 0},
 	}
-	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, false, nil)
+	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, false, IncludeOverride{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Items)
@@ -37,7 +37,7 @@ func TestToResourceItems_nil_client_list_skipped(t *testing.T) {
 	results := []discovery.Result{
 		{TypeName: "criblio_source", Count: 1},
 	}
-	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, false, nil)
+	result, err := ToResourceItems(ctx, nil, reg, results, []string{"default"}, nil, 1, false, IncludeOverride{}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Empty(t, result.Items)
@@ -232,7 +232,7 @@ func TestAppendResourceItemFromModel_skipsSearchWorkerGroup(t *testing.T) {
 		ImportIDFormat: "group_id",
 	}
 	idMap := map[string]string{"group_id": "search", "product": "stream"}
-	err := appendResourceItemFromModel(out, "criblio_group", e, idMap, nil, nil, nil, false)
+	err := appendResourceItemFromModel(out, "criblio_group", e, idMap, nil, nil, nil, false, IncludeOverride{})
 	require.NoError(t, err)
 	assert.Empty(t, out.Items)
 }
@@ -286,50 +286,68 @@ func TestSkipResourceWhenLibCribl(t *testing.T) {
 }
 
 func TestDefaultResource(t *testing.T) {
+	noOverride := IncludeOverride{}
 	t.Run("skip when lib is cribl", func(t *testing.T) {
 		attrs := map[string]hcl.Value{"lib": {Kind: hcl.KindString, String: "cribl"}}
-		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "custom"}, attrs))
+		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "custom"}, attrs, noOverride))
 	})
 	t.Run("skip when tags equals cribl:default", func(t *testing.T) {
 		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindString, String: "cribl:default"}}
-		assert.True(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs))
+		assert.True(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs, noOverride))
 	})
 	t.Run("not skip when tags is partial cribl match", func(t *testing.T) {
 		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindString, String: "my-cribl-app"}}
-		assert.False(t, DefaultResource("criblio_appscope_config", map[string]string{"id": "custom"}, attrs))
+		assert.False(t, DefaultResource("criblio_appscope_config", map[string]string{"id": "custom"}, attrs, noOverride))
 	})
 	t.Run("skip when tags list contains cribl:default", func(t *testing.T) {
 		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindList, List: []hcl.Value{
 			{Kind: hcl.KindString, String: "other"},
 			{Kind: hcl.KindString, String: "cribl:default"},
 		}}}
-		assert.True(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs))
+		assert.True(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs, noOverride))
 	})
 	t.Run("skip default pipeline IDs", func(t *testing.T) {
 		attrs := map[string]hcl.Value{}
-		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "devnull"}, attrs))
-		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "main"}, attrs))
-		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "passthru"}, attrs))
+		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "devnull"}, attrs, noOverride))
+		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "main"}, attrs, noOverride))
+		assert.True(t, DefaultResource("criblio_pipeline", map[string]string{"id": "passthru"}, attrs, noOverride))
 	})
 	t.Run("skip default grok IDs", func(t *testing.T) {
 		attrs := map[string]hcl.Value{}
-		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "aws"}, attrs))
-		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "core-patterns"}, attrs))
+		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "aws"}, attrs, noOverride))
+		assert.True(t, DefaultResource("criblio_grok", map[string]string{"id": "core-patterns"}, attrs, noOverride))
 	})
 	t.Run("skip default source IDs", func(t *testing.T) {
 		attrs := map[string]hcl.Value{}
-		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblLogs"}, attrs))
-		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblMetrics"}, attrs))
+		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblLogs"}, attrs, noOverride))
+		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblMetrics"}, attrs, noOverride))
 	})
 	t.Run("not skip user-created resources", func(t *testing.T) {
 		attrs := map[string]hcl.Value{}
-		assert.False(t, DefaultResource("criblio_pipeline", map[string]string{"id": "my_custom_pipeline"}, attrs))
-		assert.False(t, DefaultResource("criblio_grok", map[string]string{"id": "my_grok"}, attrs))
-		assert.False(t, DefaultResource("criblio_source", map[string]string{"id": "my_source"}, attrs))
+		assert.False(t, DefaultResource("criblio_pipeline", map[string]string{"id": "my_custom_pipeline"}, attrs, noOverride))
+		assert.False(t, DefaultResource("criblio_grok", map[string]string{"id": "my_grok"}, attrs, noOverride))
+		assert.False(t, DefaultResource("criblio_source", map[string]string{"id": "my_source"}, attrs, noOverride))
 	})
 	t.Run("not skip when tags is empty list", func(t *testing.T) {
 		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindList, List: []hcl.Value{}}}
-		assert.False(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs))
+		assert.False(t, DefaultResource("criblio_search_dataset", map[string]string{"id": "custom"}, attrs, noOverride))
+	})
+	t.Run("include override bypasses lib=cribl", func(t *testing.T) {
+		attrs := map[string]hcl.Value{"lib": {Kind: hcl.KindString, String: "cribl"}}
+		override := ParseIncludeDefaultIDs([]string{"in_system_metrics"})
+		assert.False(t, DefaultResource("criblio_source", map[string]string{"id": "in_system_metrics"}, attrs, override))
+	})
+	t.Run("include override bypasses cribl:default tag", func(t *testing.T) {
+		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindString, String: "cribl:default"}}
+		override := ParseIncludeDefaultIDs([]string{"criblio_source:CriblLogs"})
+		assert.False(t, DefaultResource("criblio_source", map[string]string{"id": "CriblLogs"}, attrs, override))
+		assert.True(t, DefaultResource("criblio_destination", map[string]string{"id": "CriblLogs"}, attrs, override))
+	})
+	t.Run("include override unqualified matches any type", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		override := ParseIncludeDefaultIDs([]string{"devnull"})
+		assert.False(t, DefaultResource("criblio_pipeline", map[string]string{"id": "devnull"}, attrs, override))
+		assert.False(t, DefaultResource("criblio_destination", map[string]string{"id": "devnull"}, attrs, override))
 	})
 }
 

--- a/tools/import-cli/internal/export/filters.go
+++ b/tools/import-cli/internal/export/filters.go
@@ -9,6 +9,55 @@ import (
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/hcl"
 )
 
+// IncludeOverride holds IDs to include even when --exclude-defaults is set.
+// Supports both unqualified IDs (match any type) and type-qualified IDs (type:id).
+type IncludeOverride struct {
+	ByID   map[string]bool            // unqualified: "in_system_metrics" -> true
+	ByType map[string]map[string]bool // qualified: "criblio_source" -> {"in_system_metrics": true}
+}
+
+// ParseIncludeDefaultIDs parses the --include-default-ids flag values.
+// Supports "id" (any type) and "type:id" (specific type) formats.
+func ParseIncludeDefaultIDs(ids []string) IncludeOverride {
+	override := IncludeOverride{
+		ByID:   make(map[string]bool),
+		ByType: make(map[string]map[string]bool),
+	}
+	for _, s := range ids {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if idx := strings.Index(s, ":"); idx > 0 {
+			typeName := s[:idx]
+			id := s[idx+1:]
+			if override.ByType[typeName] == nil {
+				override.ByType[typeName] = make(map[string]bool)
+			}
+			override.ByType[typeName][id] = true
+		} else {
+			override.ByID[s] = true
+		}
+	}
+	return override
+}
+
+// Includes reports whether the given type+id combination should be included.
+func (o IncludeOverride) Includes(typeName, id string) bool {
+	if id == "" {
+		return false
+	}
+	if typeMap, ok := o.ByType[typeName]; ok && typeMap[id] {
+		return true
+	}
+	return o.ByID[id]
+}
+
+// Empty reports whether no overrides are configured.
+func (o IncludeOverride) Empty() bool {
+	return len(o.ByID) == 0 && len(o.ByType) == 0
+}
+
 // sanitizeConvertError returns a short, safe message for user-facing output.
 // Never includes raw JSON (which may contain credentials or sensitive data).
 func sanitizeConvertError(err error) string {
@@ -87,14 +136,17 @@ func skipResourceWhenLibCribl(attrs map[string]hcl.Value) bool {
 }
 
 // DefaultResource reports whether the resource is a built-in Cribl default.
-func DefaultResource(typeName string, idMap map[string]string, attrs map[string]hcl.Value) bool {
+func DefaultResource(typeName string, idMap map[string]string, attrs map[string]hcl.Value, includeOverride IncludeOverride) bool {
+	id := idMap["id"]
+	if includeOverride.Includes(typeName, id) {
+		return false
+	}
 	if skipResourceWhenLibCribl(attrs) {
 		return true
 	}
 	if criblDefaultTag(attrs) {
 		return true
 	}
-	id := idMap["id"]
 	pack := idMap["pack"]
 	switch typeName {
 	case "criblio_destination":

--- a/tools/import-cli/internal/export/items.go
+++ b/tools/import-cli/internal/export/items.go
@@ -19,7 +19,7 @@ import (
 )
 
 // convertOneResource fetches a single resource via the converter, builds HCL attrs, and returns a ResourceItem or skip message.
-func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Result, e registry.Entry, idMap map[string]string, groupFilter []string, groupIDs []string, excludeDefaults bool, out *ExportResult) (item *generator.ResourceItem, skipMsg string) {
+func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Result, e registry.Entry, idMap map[string]string, groupFilter []string, groupIDs []string, excludeDefaults bool, includeOverride IncludeOverride, out *ExportResult) (item *generator.ResourceItem, skipMsg string) {
 	if skipExportForGroupFilter(r.TypeName, idMap, groupFilter, groupIDs) {
 		return nil, ""
 	}
@@ -130,7 +130,7 @@ func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Re
 	if skipResourceWhenLibCribl(attrs) {
 		return nil, fmt.Sprintf("%s %v: lib is cribl (built-in, skip export)", r.TypeName, idMap)
 	}
-	if excludeDefaults && DefaultResource(r.TypeName, idMap, attrs) {
+	if excludeDefaults && DefaultResource(r.TypeName, idMap, attrs, includeOverride) {
 		out.DefaultsSkipped++
 		return nil, fmt.Sprintf("%s %v: built-in default (--exclude-defaults)", r.TypeName, idMap)
 	}
@@ -198,7 +198,7 @@ func convertOneResource(ctx context.Context, client *sdk.CriblIo, r discovery.Re
 }
 
 // appendResourceItemFromModel builds HCL attrs and appends a ResourceItem to out.Items (used for criblio_group and shared conversion path).
-func appendResourceItemFromModel(out *ExportResult, typeName string, e registry.Entry, idMap map[string]string, model interface{}, groupFilter []string, groupIDs []string, excludeDefaults bool) error {
+func appendResourceItemFromModel(out *ExportResult, typeName string, e registry.Entry, idMap map[string]string, model interface{}, groupFilter []string, groupIDs []string, excludeDefaults bool, includeOverride IncludeOverride) error {
 	if skipResourceByID(typeName, idMap) {
 		return nil
 	}
@@ -259,7 +259,7 @@ func appendResourceItemFromModel(out *ExportResult, typeName string, e registry.
 	if skipResourceWhenLibCribl(attrs) {
 		return ErrSkipResourceLibCribl
 	}
-	if excludeDefaults && DefaultResource(typeName, idMap, attrs) {
+	if excludeDefaults && DefaultResource(typeName, idMap, attrs, includeOverride) {
 		out.DefaultsSkipped++
 		return nil
 	}


### PR DESCRIPTION
- Add --include-default-ids flag to selectively include specific default resources when --exclude-defaults is set
- Supports unqualified IDs (in_system_metrics) matching any type, or type-qualified IDs (criblio_source:in_system_metrics) for disambiguation when the same ID exists across multiple resource types