### PR TITLE
adding auth package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tests/e2e/import.tf
 sbom-*.json 
 .gocache/
 .cursor/
+.claude/
 tf*
 go.work*
 dist/*

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test-cleanup:
 	@cd tests/e2e; rm -rf local-plugins .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
 
 unit-test: 
-	go test -v ./internal/sdk/credentials ./internal/sdk/internal/hooks
+	go test -v ./internal/auth/... ./internal/sdk/credentials ./internal/sdk/internal/hooks
 
 unit-test-import-cli:
 	go test -v ./tools/import-cli/...

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -1,0 +1,317 @@
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+const (
+	defaultCloudDomain = "cribl.cloud"
+	tokenExpiryBuffer  = 30 * time.Second
+	onPremTokenTTL     = time.Hour
+)
+
+var (
+	tokenCache sync.Map
+	timeNow    = time.Now
+)
+
+// GetToken returns an OAuth2 or on-prem auth token for the given config.
+func GetToken(ctx context.Context, config *CriblConfig) (string, error) {
+	if config == nil {
+		return "", fmt.Errorf("config is required for authentication")
+	}
+
+	key, err := tokenCacheKey(config)
+	if err != nil {
+		return "", err
+	}
+
+	if cached, ok := tokenCache.Load(key); ok {
+		tokenInfo, ok := cached.(*TokenInfo)
+		if ok && tokenInfo.ExpiresAt.After(timeNow().Add(tokenExpiryBuffer)) {
+			return tokenInfo.Token, nil
+		}
+	}
+
+	var tokenInfo *TokenInfo
+	if IsOnPrem(config) {
+		tokenInfo, err = getOnPremBearerToken(ctx, config)
+	} else {
+		tokenInfo, err = getCloudBearerToken(ctx, config)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	tokenCache.Store(key, tokenInfo)
+	return tokenInfo.Token, nil
+}
+
+// IsOnPrem reports whether config indicates an on-prem deployment.
+func IsOnPrem(config *CriblConfig) bool {
+	return config != nil && config.OnpremServerURL != ""
+}
+
+// IsGov reports whether domain requires the gov Okta OAuth2 flow.
+func IsGov(domain string) bool {
+	return strings.Contains(domain, "gov")
+}
+
+// ClearTokenCache clears all cached tokens.
+func ClearTokenCache() {
+	tokenCache.Range(func(key, _ interface{}) bool {
+		tokenCache.Delete(key)
+		return true
+	})
+}
+
+// InvalidateToken removes the cached token for config.
+func InvalidateToken(config *CriblConfig) {
+	key, err := tokenCacheKey(config)
+	if err != nil {
+		return
+	}
+	tokenCache.Delete(key)
+}
+
+func tokenCacheKey(config *CriblConfig) (string, error) {
+	if config == nil {
+		return "", fmt.Errorf("config is required for authentication")
+	}
+	if IsOnPrem(config) {
+		if config.OnpremUsername == "" || config.OnpremPassword == "" {
+			return "", fmt.Errorf("on-prem authentication requires username and password")
+		}
+		return fmt.Sprintf("onprem:%s:%s:%s", config.OnpremServerURL, config.OnpremUsername, config.OnpremPassword), nil
+	}
+	if config.ClientID == "" || config.ClientSecret == "" {
+		return "", fmt.Errorf("cloud authentication requires client ID and client secret")
+	}
+	return fmt.Sprintf("%s:%s:%s", config.ClientID, config.ClientSecret, cloudDomain(config)), nil
+}
+
+func cloudDomain(config *CriblConfig) string {
+	switch {
+	case config != nil && config.CloudDomain != "":
+		return config.CloudDomain
+	case os.Getenv("CRIBL_CLOUD_DOMAIN") != "":
+		return os.Getenv("CRIBL_CLOUD_DOMAIN")
+	default:
+		return defaultCloudDomain
+	}
+}
+
+func getOnPremBearerToken(ctx context.Context, config *CriblConfig) (*TokenInfo, error) {
+	authURL := fmt.Sprintf("%s/api/v1/auth/login", strings.TrimRight(config.OnpremServerURL, "/"))
+	log.Printf("[DEBUG] Getting on-prem bearer token from: %s", authURL)
+
+	requestBody := map[string]string{
+		"username": config.OnpremUsername,
+		"password": config.OnpremPassword,
+	}
+
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %v", err)
+	}
+
+	responseBody, err := doTokenRequest(ctx, http.MethodPost, authURL, "application/json", body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get on-prem bearer token: %v", err)
+	}
+
+	var result struct {
+		Token               string `json:"token"`
+		ForcePasswordChange bool   `json:"forcePasswordChange"`
+	}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	return &TokenInfo{
+		Token:     strings.TrimPrefix(result.Token, "Bearer "),
+		ExpiresAt: timeNow().Add(onPremTokenTTL),
+	}, nil
+}
+
+func getCloudBearerToken(ctx context.Context, config *CriblConfig) (*TokenInfo, error) {
+	domain := cloudDomain(config)
+	authURL, audience, useFormEncoded, err := cloudAuthSettings(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	var body []byte
+	var contentType string
+	if useFormEncoded {
+		formData := url.Values{}
+		formData.Set("grant_type", "client_credentials")
+		formData.Set("client_id", config.ClientID)
+		formData.Set("client_secret", config.ClientSecret)
+		formData.Set("audience", audience)
+
+		body = []byte(formData.Encode())
+		contentType = "application/x-www-form-urlencoded"
+	} else {
+		requestBody := map[string]string{
+			"grant_type":    "client_credentials",
+			"client_id":     config.ClientID,
+			"client_secret": config.ClientSecret,
+			"audience":      audience,
+		}
+
+		body, err = json.Marshal(requestBody)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %v", err)
+		}
+		contentType = "application/json"
+	}
+
+	responseBody, err := doTokenRequest(ctx, http.MethodPost, authURL, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+	}
+	if err := json.Unmarshal(responseBody, &result); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+
+	return &TokenInfo{
+		Token:     result.AccessToken,
+		ExpiresAt: timeNow().Add(time.Duration(result.ExpiresIn) * time.Second),
+	}, nil
+}
+
+func cloudAuthSettings(domain string) (string, string, bool, error) {
+	if domain == "" {
+		domain = defaultCloudDomain
+	}
+
+	if baseURL, ok, err := localBaseURL(domain); err != nil {
+		return "", "", false, err
+	} else if ok {
+		return fmt.Sprintf("%s/oauth/token", strings.TrimRight(baseURL, "/")), baseURL, false, nil
+	}
+
+	audience := fmt.Sprintf("https://api.%s", domain)
+	if !IsGov(domain) {
+		return fmt.Sprintf("https://login.%s/oauth/token", domain), audience, false, nil
+	}
+
+	oktaDomain := os.Getenv("CRIBL_OKTA_DOMAIN")
+	if oktaDomain == "" {
+		oktaDomain = strings.ReplaceAll(domain, "cribl-gov-", "criblgov-")
+		oktaDomain = strings.ReplaceAll(oktaDomain, "staging", "stg")
+		oktaDomain = strings.ReplaceAll(oktaDomain, ".cloud", ".okta.com")
+	}
+
+	authServerID := os.Getenv("CRIBL_OKTA_AUTH_SERVER_ID")
+	if authServerID == "" {
+		authServerID = os.Getenv("CRIBL_OKTA_DEFAULT_AUTH_SERVER_ID")
+	}
+	if authServerID == "" {
+		return "", "", false, fmt.Errorf("CRIBL_OKTA_DEFAULT_AUTH_SERVER_ID environment variable is required for gov domains")
+	}
+
+	oktaBaseURL, ok, err := localBaseURL(oktaDomain)
+	if err != nil {
+		return "", "", false, err
+	}
+	if ok {
+		return fmt.Sprintf("%s/oauth2/%s/v1/token", strings.TrimRight(oktaBaseURL, "/"), authServerID), audience, true, nil
+	}
+
+	return fmt.Sprintf("https://%s/oauth2/%s/v1/token", oktaDomain, authServerID), audience, true, nil
+}
+
+func localBaseURL(input string) (string, bool, error) {
+	parsedURL, err := url.Parse(input)
+	if err == nil && parsedURL.Scheme != "" && parsedURL.Host != "" {
+		if IsLocalHost(parsedURL.Host) {
+			return strings.TrimRight(parsedURL.String(), "/"), true, nil
+		}
+		return "", false, nil
+	}
+	if err != nil && strings.Contains(input, "://") {
+		return "", false, fmt.Errorf("failed to parse local URL: %v", err)
+	}
+	if IsLocalHost(input) {
+		return fmt.Sprintf("http://%s", input), true, nil
+	}
+	return "", false, nil
+}
+
+func doTokenRequest(ctx context.Context, method, requestURL, contentType string, body []byte) ([]byte, error) {
+	retryClient := retryablehttp.NewClient()
+	retryClient.RetryMax = 3
+	retryClient.RetryWaitMin = 500 * time.Millisecond
+	retryClient.RetryWaitMax = 5 * time.Second
+	retryClient.Backoff = retryablehttp.DefaultBackoff
+	retryClient.Logger = &retryableLogger{}
+	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
+			log.Printf("[DEBUG] 429 Too Many Requests, will retry")
+			return true, nil
+		}
+		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	}
+
+	req, err := retryablehttp.NewRequest(method, requestURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create retryable request: %v", err)
+	}
+	req = req.WithContext(ctx)
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := retryClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make request with retry: %v", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %v", err)
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		return responseBody, nil
+	}
+
+	return nil, fmt.Errorf("failed to do request: status=%d, body=%s", resp.StatusCode, string(responseBody))
+}
+
+type retryableLogger struct{}
+
+func (l *retryableLogger) Error(msg string, keysAndValues ...interface{}) {
+	log.Printf("[ERROR] retryablehttp: %s %v", msg, keysAndValues)
+}
+
+func (l *retryableLogger) Info(msg string, keysAndValues ...interface{}) {
+	log.Printf("[INFO] retryablehttp: %s %v", msg, keysAndValues)
+}
+
+func (l *retryableLogger) Debug(msg string, keysAndValues ...interface{}) {
+	log.Printf("[DEBUG] retryablehttp: %s %v", msg, keysAndValues)
+}
+
+func (l *retryableLogger) Warn(msg string, keysAndValues ...interface{}) {
+	log.Printf("[WARN] retryablehttp: %s %v", msg, keysAndValues)
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -87,6 +87,12 @@ func InvalidateToken(config *CriblConfig) {
 	tokenCache.Delete(key)
 }
 
+// RefreshToken invalidates the cached token for config and fetches a fresh token.
+func RefreshToken(ctx context.Context, config *CriblConfig) (string, error) {
+	InvalidateToken(config)
+	return GetToken(ctx, config)
+}
+
 func tokenCacheKey(config *CriblConfig) (string, error) {
 	if config == nil {
 		return "", fmt.Errorf("config is required for authentication")
@@ -100,7 +106,7 @@ func tokenCacheKey(config *CriblConfig) (string, error) {
 	if config.ClientID == "" || config.ClientSecret == "" {
 		return "", fmt.Errorf("cloud authentication requires client ID and client secret")
 	}
-	return fmt.Sprintf("%s:%s:%s", config.ClientID, config.ClientSecret, cloudDomain(config)), nil
+	return fmt.Sprintf("%s:%s", config.ClientID, config.ClientSecret), nil
 }
 
 func cloudDomain(config *CriblConfig) string {

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -1,0 +1,432 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestGetTokenCloud(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	var receivedContentType string
+	var receivedBody struct {
+		GrantType    string `json:"grant_type"`
+		ClientID     string `json:"client_id"`
+		ClientSecret string `json:"client_secret"`
+		Audience     string `json:"audience"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/token" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		receivedContentType = r.Header.Get("Content-Type")
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"cloud-token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	token, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if token != "cloud-token" {
+		t.Fatalf("GetToken returned %q, expected %q", token, "cloud-token")
+	}
+	if receivedContentType != "application/json" {
+		t.Errorf("content type = %q, expected application/json", receivedContentType)
+	}
+	if receivedBody.GrantType != "client_credentials" {
+		t.Errorf("grant_type = %q, expected client_credentials", receivedBody.GrantType)
+	}
+	if receivedBody.ClientID != "client-id" {
+		t.Errorf("client_id = %q, expected client-id", receivedBody.ClientID)
+	}
+	if receivedBody.ClientSecret != "client-secret" {
+		t.Errorf("client_secret = %q, expected client-secret", receivedBody.ClientSecret)
+	}
+	if receivedBody.Audience != server.URL {
+		t.Errorf("audience = %q, expected %q", receivedBody.Audience, server.URL)
+	}
+}
+
+func TestGetTokenLocalhostURL(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"localhost-token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	parsedURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse server URL: %v", err)
+	}
+	localhostURL := "http://localhost" + parsedURL.Port()
+	if parsedURL.Port() != "" {
+		localhostURL = "http://localhost:" + parsedURL.Port()
+	}
+
+	token, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  localhostURL,
+	})
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if token != "localhost-token" {
+		t.Fatalf("GetToken returned %q, expected %q", token, "localhost-token")
+	}
+}
+
+func TestGetTokenLoopbackIP(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"loopback-token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	token, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if token != "loopback-token" {
+		t.Fatalf("GetToken returned %q, expected %q", token, "loopback-token")
+	}
+}
+
+func TestGetTokenGovDomain(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	var receivedContentType string
+	var receivedBody string
+	var requestedPath string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		receivedContentType = r.Header.Get("Content-Type")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"gov-token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	t.Setenv("CRIBL_OKTA_DOMAIN", server.URL)
+	t.Setenv("CRIBL_OKTA_AUTH_SERVER_ID", "auth-server-id")
+	t.Setenv("CRIBL_OKTA_DEFAULT_AUTH_SERVER_ID", "")
+
+	token, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "gov-client-id",
+		ClientSecret: "gov-client-secret",
+		CloudDomain:  "cribl-gov-staging.cloud",
+	})
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if token != "gov-token" {
+		t.Fatalf("GetToken returned %q, expected %q", token, "gov-token")
+	}
+	if requestedPath != "/oauth2/auth-server-id/v1/token" {
+		t.Errorf("requested path = %q, expected /oauth2/auth-server-id/v1/token", requestedPath)
+	}
+	if receivedContentType != "application/x-www-form-urlencoded" {
+		t.Errorf("content type = %q, expected application/x-www-form-urlencoded", receivedContentType)
+	}
+	if !strings.Contains(receivedBody, "grant_type=client_credentials") {
+		t.Errorf("form body missing grant_type: %s", receivedBody)
+	}
+	if !strings.Contains(receivedBody, "client_id=gov-client-id") {
+		t.Errorf("form body missing client_id: %s", receivedBody)
+	}
+	if !strings.Contains(receivedBody, "client_secret=gov-client-secret") {
+		t.Errorf("form body missing client_secret: %s", receivedBody)
+	}
+}
+
+func TestGetTokenGovDomainMissingAuthServerID(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+	t.Setenv("CRIBL_OKTA_DOMAIN", "")
+	t.Setenv("CRIBL_OKTA_AUTH_SERVER_ID", "")
+	t.Setenv("CRIBL_OKTA_DEFAULT_AUTH_SERVER_ID", "")
+
+	_, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "gov-client-id",
+		ClientSecret: "gov-client-secret",
+		CloudDomain:  "cribl-gov-staging.cloud",
+	})
+	if err == nil {
+		t.Fatal("GetToken returned nil error, expected missing auth server ID error")
+	}
+	if !strings.Contains(err.Error(), "CRIBL_OKTA_DEFAULT_AUTH_SERVER_ID") {
+		t.Fatalf("error = %q, expected CRIBL_OKTA_DEFAULT_AUTH_SERVER_ID", err.Error())
+	}
+}
+
+func TestGetTokenOnPrem(t *testing.T) {
+	ClearTokenCache()
+
+	var receivedBody struct {
+		Username string `json:"username"`
+		Password string `json:"password"`
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v1/auth/login" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&receivedBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"onprem-token","forcePasswordChange":false}`))
+	}))
+	defer server.Close()
+
+	token, err := GetToken(context.Background(), &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if token != "onprem-token" {
+		t.Fatalf("GetToken returned %q, expected %q", token, "onprem-token")
+	}
+	if receivedBody.Username != "admin" {
+		t.Errorf("username = %q, expected admin", receivedBody.Username)
+	}
+	if receivedBody.Password != "secret" {
+		t.Errorf("password = %q, expected secret", receivedBody.Password)
+	}
+}
+
+func TestOnPremTokenStripsBearer(t *testing.T) {
+	ClearTokenCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"Bearer stripped-token","forcePasswordChange":false}`))
+	}))
+	defer server.Close()
+
+	token, err := GetToken(context.Background(), &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if token != "stripped-token" {
+		t.Fatalf("GetToken returned %q, expected %q", token, "stripped-token")
+	}
+}
+
+func TestTokenCacheHit(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"cached-token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  server.URL,
+	}
+
+	for range 2 {
+		token, err := GetToken(context.Background(), config)
+		if err != nil {
+			t.Fatalf("GetToken returned error: %v", err)
+		}
+		if token != "cached-token" {
+			t.Fatalf("GetToken returned %q, expected %q", token, "cached-token")
+		}
+	}
+
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, expected 1", requestCount)
+	}
+}
+
+func TestTokenCacheExpiry(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"short-token","expires_in":10}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  server.URL,
+	}
+
+	for range 2 {
+		if _, err := GetToken(context.Background(), config); err != nil {
+			t.Fatalf("GetToken returned error: %v", err)
+		}
+	}
+
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, expected 2 because token expires inside buffer", requestCount)
+	}
+}
+
+func TestTokenCacheDistinctKeys(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var requestBody struct {
+			ClientID string `json:"client_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"` + requestBody.ClientID + `-token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	firstToken, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "first",
+		ClientSecret: "secret",
+		CloudDomain:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("first GetToken returned error: %v", err)
+	}
+
+	secondToken, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "second",
+		ClientSecret: "secret",
+		CloudDomain:  server.URL,
+	})
+	if err != nil {
+		t.Fatalf("second GetToken returned error: %v", err)
+	}
+
+	if firstToken != "first-token" {
+		t.Fatalf("first token = %q, expected first-token", firstToken)
+	}
+	if secondToken != "second-token" {
+		t.Fatalf("second token = %q, expected second-token", secondToken)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, expected 2", requestCount)
+	}
+}
+
+func TestInvalidateToken(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  server.URL,
+	}
+
+	if _, err := GetToken(context.Background(), config); err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	InvalidateToken(config)
+	if _, err := GetToken(context.Background(), config); err != nil {
+		t.Fatalf("GetToken after invalidation returned error: %v", err)
+	}
+
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, expected 2", requestCount)
+	}
+}
+
+func TestTokenNon200Error(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"error":"invalid credentials"}`))
+	}))
+	defer server.Close()
+
+	_, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  server.URL,
+	})
+	if err == nil {
+		t.Fatal("GetToken returned nil error, expected non-200 error")
+	}
+	if !strings.Contains(err.Error(), "status=401") {
+		t.Fatalf("error = %q, expected status=401", err.Error())
+	}
+}
+
+func TestIsOnPremAndIsGov(t *testing.T) {
+	if !IsOnPrem(&CriblConfig{OnpremServerURL: "http://localhost:9000"}) {
+		t.Fatal("IsOnPrem returned false, expected true")
+	}
+	if IsOnPrem(&CriblConfig{}) {
+		t.Fatal("IsOnPrem returned true, expected false")
+	}
+	if !IsGov("cribl-gov-staging.cloud") {
+		t.Fatal("IsGov returned false, expected true")
+	}
+	if IsGov("cribl.cloud") {
+		t.Fatal("IsGov returned true, expected false")
+	}
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -119,6 +119,47 @@ func TestGetTokenLoopbackIP(t *testing.T) {
 	}
 }
 
+func TestCloudAuthSettingsStandardDomains(t *testing.T) {
+	testCases := []struct {
+		name         string
+		domain       string
+		expectedURL  string
+		expectedAud  string
+		expectedForm bool
+	}{
+		{
+			name:        "cloud",
+			domain:      "cribl.cloud",
+			expectedURL: "https://login.cribl.cloud/oauth/token",
+			expectedAud: "https://api.cribl.cloud",
+		},
+		{
+			name:        "playground",
+			domain:      "cribl-playground.cloud",
+			expectedURL: "https://login.cribl-playground.cloud/oauth/token",
+			expectedAud: "https://api.cribl-playground.cloud",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			authURL, audience, useFormEncoded, err := cloudAuthSettings(test.domain)
+			if err != nil {
+				t.Fatalf("cloudAuthSettings returned error: %v", err)
+			}
+			if authURL != test.expectedURL {
+				t.Fatalf("auth URL = %q, expected %q", authURL, test.expectedURL)
+			}
+			if audience != test.expectedAud {
+				t.Fatalf("audience = %q, expected %q", audience, test.expectedAud)
+			}
+			if useFormEncoded != test.expectedForm {
+				t.Fatalf("useFormEncoded = %v, expected %v", useFormEncoded, test.expectedForm)
+			}
+		})
+	}
+}
+
 func TestGetTokenGovDomain(t *testing.T) {
 	ClearTokenCache()
 	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
@@ -362,6 +403,20 @@ func TestTokenCacheDistinctKeys(t *testing.T) {
 	}
 }
 
+func TestTokenCacheCloudKeyMatchesHook(t *testing.T) {
+	key, err := tokenCacheKey(&CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  "cribl-playground.cloud",
+	})
+	if err != nil {
+		t.Fatalf("tokenCacheKey returned error: %v", err)
+	}
+	if key != "client-id:client-secret" {
+		t.Fatalf("cloud cache key = %q, expected current hook format", key)
+	}
+}
+
 func TestInvalidateToken(t *testing.T) {
 	ClearTokenCache()
 	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
@@ -386,6 +441,36 @@ func TestInvalidateToken(t *testing.T) {
 	InvalidateToken(config)
 	if _, err := GetToken(context.Background(), config); err != nil {
 		t.Fatalf("GetToken after invalidation returned error: %v", err)
+	}
+
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, expected 2", requestCount)
+	}
+}
+
+func TestRefreshTokenInvalidatesCache(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"token","expires_in":3600}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  server.URL,
+	}
+
+	if _, err := GetToken(context.Background(), config); err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if _, err := RefreshToken(context.Background(), config); err != nil {
+		t.Fatalf("RefreshToken returned error: %v", err)
 	}
 
 	if requestCount != 2 {

--- a/internal/auth/credentials.go
+++ b/internal/auth/credentials.go
@@ -1,0 +1,155 @@
+// Package auth provides shared Cribl credential loading from environment
+// and ~/.cribl/credentials. Used by the SDK hooks and the import CLI.
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/ini.v1"
+)
+
+func checkLocalConfigDir() ([]byte, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Printf("[ERROR] Failed to get home directory: %v", err)
+		return []byte{}, fmt.Errorf("failed to get home directory: %v", err)
+	}
+	configDir := filepath.Join(homeDir, ".cribl")
+	configPath := filepath.Join(configDir, "credentials")
+	var filePath string
+
+	_, err = os.Stat(configPath)
+	if err != nil {
+		log.Printf("[DEBUG] No config file found %s", configPath)
+		legacyPath := filepath.Join(homeDir, ".cribl")
+		_, err := os.Stat(legacyPath)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				log.Printf("[DEBUG] No config file found %s", legacyPath)
+				return []byte{}, err
+			}
+			return []byte{}, err
+		}
+		filePath = legacyPath
+	} else {
+		filePath = configPath
+	}
+
+	log.Printf("[DEBUG] Reading credentials from: %s", filePath)
+	file, err := os.ReadFile(filePath)
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to read credentials file: %v", err)
+	}
+	return file, nil
+}
+
+func checkConfigFileFormat(input []byte) (string, error) {
+	var data interface{}
+	if err := json.Unmarshal(input, &data); err == nil {
+		return "json", nil
+	}
+	if _, err := ini.Load(input); err == nil {
+		return "ini", nil
+	}
+	return "", errors.New("config file type not recognized")
+}
+
+func parseJSONConfig(file []byte) (*CriblConfig, error) {
+	log.Printf("[DEBUG] parsing JSON config")
+	var config CriblConfig
+	if err := json.Unmarshal(file, &config); err != nil {
+		log.Printf("[ERROR] Failed to parse config file: %v", err)
+		return nil, fmt.Errorf("failed to parse config file: %v", err)
+	}
+	return &config, nil
+}
+
+func parseIniConfig(file []byte) (*CriblConfig, error) {
+	config := CriblConfig{}
+	profileName := os.Getenv("CRIBL_PROFILE")
+	if profileName == "" {
+		profileName = "default"
+	}
+	log.Printf("[DEBUG] Using profile: %s", profileName)
+
+	cfg, err := ini.Load(file)
+	if err != nil {
+		log.Printf("[ERROR] Failed to parse config file: %v", err)
+		return nil, fmt.Errorf("failed to parse config file: %v", err)
+	}
+	if err := cfg.Section(profileName).MapTo(&config); err != nil {
+		log.Printf("[ERROR] Failed to parse config file profile: %v", err)
+		return nil, fmt.Errorf("failed to parse config file profile: %v", err)
+	}
+	log.Printf("[DEBUG] Selected profile values - clientID=%s, orgID=%s, workspace=%s, domain=%s",
+		config.ClientID, config.OrganizationID, config.Workspace, config.CloudDomain)
+	return &config, nil
+}
+
+// GetCredentials reads credentials from environment variables or ~/.cribl/credentials.
+// Env takes precedence; file is used when env is not set.
+func GetCredentials() (*CriblConfig, error) {
+	clientID := os.Getenv("CRIBL_CLIENT_ID")
+	clientSecret := os.Getenv("CRIBL_CLIENT_SECRET")
+	organizationID := os.Getenv("CRIBL_ORGANIZATION_ID")
+	workspace := os.Getenv("CRIBL_WORKSPACE_ID")
+	cloudDomain := os.Getenv("CRIBL_CLOUD_DOMAIN")
+	onpremServerURL := os.Getenv("CRIBL_ONPREM_SERVER_URL")
+	onpremUsername := os.Getenv("CRIBL_ONPREM_USERNAME")
+	onpremPassword := os.Getenv("CRIBL_ONPREM_PASSWORD")
+
+	log.Printf("[DEBUG] Environment variables - clientID=%s, orgID=%s, workspace=%s, domain=%s, onpremURL=%s",
+		clientID, organizationID, workspace, cloudDomain, onpremServerURL)
+
+	if clientID != "" && clientSecret != "" {
+		log.Printf("[DEBUG] Using cloud credentials from environment variables")
+		return &CriblConfig{
+			ClientID:       clientID,
+			ClientSecret:   clientSecret,
+			OrganizationID: organizationID,
+			Workspace:      workspace,
+			CloudDomain:    cloudDomain,
+		}, nil
+	}
+	if onpremServerURL != "" {
+		log.Printf("[DEBUG] Using on-prem credentials from environment variables")
+		return &CriblConfig{
+			OnpremServerURL: onpremServerURL,
+			OnpremUsername:  onpremUsername,
+			OnpremPassword:  onpremPassword,
+		}, nil
+	}
+
+	file, err := checkLocalConfigDir()
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("[DEBUG] No configuration file found, continuing")
+			return &CriblConfig{
+				ClientID:       clientID,
+				ClientSecret:   clientSecret,
+				OrganizationID: organizationID,
+				Workspace:      workspace,
+				CloudDomain:    cloudDomain,
+			}, nil
+		}
+		return nil, err
+	}
+
+	format, err := checkConfigFileFormat(file)
+	if err != nil {
+		log.Printf("[DEBUG] No configuration file found, continuing - error: %v", err)
+		return nil, err
+	}
+	switch format {
+	case "json":
+		return parseJSONConfig(file)
+	case "ini":
+		return parseIniConfig(file)
+	}
+	return nil, nil
+}

--- a/internal/auth/credentials_test.go
+++ b/internal/auth/credentials_test.go
@@ -1,0 +1,472 @@
+package auth
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func setTestHome(t *testing.T) string {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func clearCredentialEnv(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("CRIBL_CLIENT_ID", "")
+	t.Setenv("CRIBL_CLIENT_SECRET", "")
+	t.Setenv("CRIBL_ORGANIZATION_ID", "")
+	t.Setenv("CRIBL_WORKSPACE_ID", "")
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+	t.Setenv("CRIBL_ONPREM_SERVER_URL", "")
+	t.Setenv("CRIBL_ONPREM_USERNAME", "")
+	t.Setenv("CRIBL_ONPREM_PASSWORD", "")
+}
+
+func TestGetCredentialsEnvConfig(t *testing.T) {
+	client := "test-client"
+	secret := "test-secret"
+	org := "test-org"
+	workspace := "test-workspace"
+
+	clearCredentialEnv(t)
+	t.Setenv("CRIBL_CLIENT_ID", client)
+	t.Setenv("CRIBL_CLIENT_SECRET", secret)
+	t.Setenv("CRIBL_ORGANIZATION_ID", org)
+	t.Setenv("CRIBL_WORKSPACE_ID", workspace)
+
+	cfg, err := GetCredentials()
+	if err != nil {
+		t.Errorf("GetCredentials threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != client {
+		t.Errorf("GetCredentials returned incorrect ClientID, expected %s got %s", client, cfg.ClientID)
+	} else if cfg.ClientSecret != secret {
+		t.Errorf("GetCredentials returned incorrect ClientSecret, expected %s got %s", secret, cfg.ClientSecret)
+	} else if cfg.OrganizationID != org {
+		t.Errorf("GetCredentials returned incorrect OrganizationID, expected %s got %s", org, cfg.OrganizationID)
+	} else if cfg.Workspace != workspace {
+		t.Errorf("GetCredentials returned incorrect Workspace, expected %s got %s", workspace, cfg.Workspace)
+	}
+}
+
+func TestCheckLocalConfigDirHomeDirError(t *testing.T) {
+	t.Setenv("HOME", "")
+
+	readCreds, err := checkLocalConfigDir()
+	if err == nil {
+		t.Errorf("GetCredentials error was not returned, but expected")
+	}
+
+	if string(readCreds) != string([]byte{}) {
+		t.Errorf("checkLocalConfigDir unexpected return - want []byte{}, got %s", readCreds)
+	}
+}
+
+func TestGetCredentialsNoFile(t *testing.T) {
+	clearCredentialEnv(t)
+	setTestHome(t)
+
+	_, err := checkLocalConfigDir()
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("GetCredentials error os.ErrNotExist was expected, but returned \"%s\"", err)
+	}
+}
+
+func TestGetCredentialsIniFile(t *testing.T) {
+	clearCredentialEnv(t)
+	home := setTestHome(t)
+
+	creds := `[default]
+		  client_id = your-client-id
+		  client_secret = your-client-secret
+		  organization_id = your-organization-id
+		  workspace = your-workspace-id`
+
+	path := filepath.Join(home, ".cribl")
+
+	err := os.Mkdir(path, 0777)
+	if err != nil {
+		t.Errorf("Could not write temporary config directory: %s", err)
+	}
+
+	err = os.WriteFile(filepath.Join(path, "credentials"), []byte(creds), 0644)
+	if err != nil {
+		t.Errorf("Could not write temporary config file: %s", err)
+	}
+
+	cfg, err := GetCredentials()
+	if err != nil {
+		t.Errorf("GetCredentials threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "your-client-id" {
+		t.Errorf("parseIniConfig returned incorrect ClientID, expected %s got %s", "your-client-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "your-client-secret" {
+		t.Errorf("parseIniConfig returned incorrect ClientSecret, expected %s got %s", "your-client-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "your-organization-id" {
+		t.Errorf("parseIniConfig returned incorrect OrganizationID, expected %s got %s", "your-organization-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "your-workspace-id" {
+		t.Errorf("parseIniConfig returned incorrect Workspace, expected %s got %s", "your-workspace-id", cfg.Workspace)
+	}
+
+	err = os.RemoveAll(path)
+	if err != nil {
+		t.Errorf("Could not remove temporary config directory: %s", err)
+	}
+}
+
+func TestParseIniConfigLoadFailure(t *testing.T) {
+	// Reset profile to default for this test
+	t.Setenv("CRIBL_PROFILE", "")
+
+	creds := `default
+                 client_id = your-client-id
+                 client_secret = your-client-secret
+                 organization_id = your-organization-id
+                 workspace = your-workspace-id
+                 cloud_domain = cribl-playground.cloud`
+
+	_, err := parseIniConfig([]byte(creds))
+	if err == nil {
+		t.Errorf("parseIniConfig did not throw expected error in operation")
+	} else {
+		if !strings.Contains(err.Error(), "failed to parse config file") {
+			t.Errorf("parseIniConfig did not return expected error, got: %s", err)
+		}
+	}
+}
+
+func TestGetCredentialsJSONFile(t *testing.T) {
+	clearCredentialEnv(t)
+	home := setTestHome(t)
+
+	creds := `{"client_id": "your-client-id", 
+	   "client_secret": "your-client-secret",
+	   "organization_id": "your-organization-id",
+	   "workspace": "your-workspace-id"}`
+
+	path := filepath.Join(home, ".cribl")
+
+	err := os.Mkdir(path, 0777)
+	if err != nil {
+		t.Errorf("Could not write temporary config directory: %s", err)
+	}
+
+	err = os.WriteFile(filepath.Join(path, "credentials"), []byte(creds), 0644)
+	if err != nil {
+		t.Errorf("Could not write temporary config file: %s", err)
+	}
+
+	cfg, err := GetCredentials()
+	if err != nil {
+		t.Errorf("GetCredentials threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "your-client-id" {
+		t.Errorf("parseIniConfig returned incorrect ClientID, expected %s got %s", "your-client-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "your-client-secret" {
+		t.Errorf("parseIniConfig returned incorrect ClientSecret, expected %s got %s", "your-client-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "your-organization-id" {
+		t.Errorf("parseIniConfig returned incorrect OrganizationID, expected %s got %s", "your-organization-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "your-workspace-id" {
+		t.Errorf("parseIniConfig returned incorrect Workspace, expected %s got %s", "your-workspace-id", cfg.Workspace)
+	}
+
+	err = os.RemoveAll(path)
+	if err != nil {
+		t.Errorf("Could not remove temporary config directory: %s", err)
+	}
+}
+
+func TestCheckLocalConfigDirRegularFilePath(t *testing.T) {
+	clearCredentialEnv(t)
+	home := setTestHome(t)
+
+	creds := []byte("hello\ngo\n")
+	path := filepath.Join(home, ".cribl")
+
+	err := os.Mkdir(path, 0777)
+	if err != nil {
+		t.Errorf("Could not write temporary config directory: %s", err)
+	}
+
+	err = os.WriteFile(filepath.Join(path, "credentials"), creds, 0644)
+	if err != nil {
+		t.Errorf("Could not write temporary config file: %s", err)
+	}
+
+	readCreds, err := checkLocalConfigDir()
+	if err != nil {
+		t.Errorf("GetCredentials error was not expected, but returned: %s", err)
+	}
+
+	if string(creds) != string(readCreds) {
+		t.Errorf("GetCredentials returned \"%s\", expected \"%s\"", creds, readCreds)
+	}
+
+	err = os.RemoveAll(path)
+	if err != nil {
+		t.Errorf("Could not remove temporary config directory: %s", err)
+	}
+}
+
+func TestCheckLocalConfigDirLegacyFilePath(t *testing.T) {
+	clearCredentialEnv(t)
+	home := setTestHome(t)
+
+	creds := []byte("hello\ngo\n")
+	path := filepath.Join(home, ".cribl")
+
+	err := os.WriteFile(path, creds, 0644)
+	if err != nil {
+		t.Errorf("Could not write temporary config file: %s", err)
+	}
+
+	readCreds, err := checkLocalConfigDir()
+	if err != nil {
+		t.Errorf("GetCredentials error was not expected, but returned: %s", err)
+	}
+
+	if string(creds) != string(readCreds) {
+		t.Errorf("GetCredentials returned '%s', expected '%s'", creds, readCreds)
+	}
+
+	err = os.RemoveAll(path)
+	if err != nil {
+		t.Errorf("Could not remove temporary config directory: %s", err)
+	}
+}
+
+func TestCheckConfigFileFormatIni(t *testing.T) {
+	creds := `
+	                [default]
+			client_id = your-client-id
+			client_secret = your-client-secret
+			organization_id = your-organization-id
+			workspace = your-workspace-id`
+
+	fileType, err := checkConfigFileFormat([]byte(creds))
+	if err != nil {
+		t.Errorf("checkConfigFileFormat error was not expected, but returned: %s", err)
+	}
+
+	if fileType != "ini" {
+		t.Errorf("checkConfigFileFormat returned '%s', expected 'ini'", fileType)
+	}
+}
+
+func TestCheckConfigFileFormatJSON(t *testing.T) {
+	creds := `{"client_id": "your-client-id", 
+		   "client_secret": "your-client-secret",
+		   "organization_id": "your-organization-id",
+		   "workspace": "your-workspace-id"}`
+
+	fileType, err := checkConfigFileFormat([]byte(creds))
+	if err != nil {
+		t.Errorf("checkConfigFileFormat error was not expected, but returned: %s", err)
+	}
+
+	if fileType != "json" {
+		t.Errorf("checkConfigFileFormat returned '%s', expected 'json'", fileType)
+	}
+}
+
+func TestCheckConfigFileFormatBusted(t *testing.T) {
+	creds := `"client_id"-=---"your-client-id", 
+		   "client_secret""your-client-secret",
+		   "organization_id"& "your-organization-id",
+		   "workspace": "your-workspace-id"}`
+
+	fileType, err := checkConfigFileFormat([]byte(creds))
+	if err == nil {
+		t.Errorf("checkConfigFileFormat error was expected, but not returned")
+	}
+
+	if fileType != "" {
+		t.Errorf("checkConfigFileFormat returned '%s', expected ''", fileType)
+	}
+}
+
+func TestParseJSONConfig(t *testing.T) {
+	creds := `{"client_id": "your-client-id", 
+	   "client_secret": "your-client-secret",
+	   "organization_id": "your-organization-id",
+	   "workspace": "your-workspace-id"}`
+
+	cfg, err := parseJSONConfig([]byte(creds))
+	if err != nil {
+		t.Errorf("parseJSONConfig threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "your-client-id" {
+		t.Errorf("parseJSONConfig returned incorrect ClientID, expected %s got %s", "your-client-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "your-client-secret" {
+		t.Errorf("parseJSONConfig returned incorrect ClientSecret, expected %s got %s", "your-client-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "your-organization-id" {
+		t.Errorf("parseJSONConfig returned incorrect OrganizationID, expected %s got %s", "your-organization-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "your-workspace-id" {
+		t.Errorf("parseJSONConfig returned incorrect Workspace, expected %s got %s", "your-workspace-id", cfg.Workspace)
+	}
+}
+
+func TestParseJSONConfigBusted(t *testing.T) {
+	creds := `{"client_id":fdsffds "your-client-id", 
+	   "client_secret": "your-client-secret",
+	   "organization_id": "your-organization-id",
+	   "workspace": "your-workspace-id"}`
+
+	_, err := parseJSONConfig([]byte(creds))
+	if err == nil {
+		t.Errorf("parseJSONConfig did not throw expected error")
+	}
+}
+
+func TestParseIniConfig(t *testing.T) {
+	creds := `[default]
+		  client_id = your-client-id
+		  client_secret = your-client-secret
+		  organization_id = your-organization-id
+		  workspace = your-workspace-id`
+
+	cfg, err := parseIniConfig([]byte(creds))
+	if err != nil {
+		t.Errorf("parseIniConfig threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "your-client-id" {
+		t.Errorf("parseIniConfig returned incorrect ClientID, expected %s got %s", "your-client-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "your-client-secret" {
+		t.Errorf("parseIniConfig returned incorrect ClientSecret, expected %s got %s", "your-client-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "your-organization-id" {
+		t.Errorf("parseIniConfig returned incorrect OrganizationID, expected %s got %s", "your-organization-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "your-workspace-id" {
+		t.Errorf("parseIniConfig returned incorrect Workspace, expected %s got %s", "your-workspace-id", cfg.Workspace)
+	}
+}
+
+func TestParseIniConfigMultiProfile(t *testing.T) {
+	t.Setenv("CRIBL_PROFILE", "secondary")
+	creds := `[default]
+		  client_id = your-client-id
+		  client_secret = your-client-secret
+		  organization_id = your-organization-id
+		  workspace = your-workspace-id
+                  [secondary]
+		  client_id = your-secondary-id
+		  client_secret = your-secondary-secret
+		  organization_id = your-secondary-id
+		  workspace = your-secondary-id
+		  `
+
+	cfg, err := parseIniConfig([]byte(creds))
+	if err != nil {
+		t.Errorf("parseIniConfig threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "your-secondary-id" {
+		t.Errorf("parseIniConfig returned incorrect ClientID, expected %s got %s", "your-secondary-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "your-secondary-secret" {
+		t.Errorf("parseIniConfig returned incorrect ClientSecret, expected %s got %s", "your-secondary-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "your-secondary-id" {
+		t.Errorf("parseIniConfig returned incorrect OrganizationID, expected %s got %s", "your-secondary-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "your-secondary-id" {
+		t.Errorf("parseIniConfig returned incorrect Workspace, expected %s got %s", "your-secondary-id", cfg.Workspace)
+	}
+}
+
+func TestParseIniConfigWithCloudDomain(t *testing.T) {
+	// Reset profile to default for this test
+	t.Setenv("CRIBL_PROFILE", "")
+
+	creds := `[default]
+		  client_id = your-client-id
+		  client_secret = your-client-secret
+		  organization_id = your-organization-id
+		  workspace = your-workspace-id
+		  cloud_domain = cribl-playground.cloud`
+
+	cfg, err := parseIniConfig([]byte(creds))
+	if err != nil {
+		t.Errorf("parseIniConfig threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "your-client-id" {
+		t.Errorf("parseIniConfig returned incorrect ClientID, expected %s got %s", "your-client-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "your-client-secret" {
+		t.Errorf("parseIniConfig returned incorrect ClientSecret, expected %s got %s", "your-client-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "your-organization-id" {
+		t.Errorf("parseIniConfig returned incorrect OrganizationID, expected %s got %s", "your-organization-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "your-workspace-id" {
+		t.Errorf("parseIniConfig returned incorrect Workspace, expected %s got %s", "your-workspace-id", cfg.Workspace)
+	} else if cfg.CloudDomain != "cribl-playground.cloud" {
+		t.Errorf("parseIniConfig returned incorrect CloudDomain, expected %s got %s", "cribl-playground.cloud", cfg.CloudDomain)
+	}
+}
+
+func TestParseJSONConfigWithCloudDomain(t *testing.T) {
+	creds := `{"client_id": "your-client-id", 
+	   "client_secret": "your-client-secret",
+	   "organization_id": "your-organization-id",
+	   "workspace": "your-workspace-id",
+	   "cloud_domain": "cribl-staging.cloud"}`
+
+	cfg, err := parseJSONConfig([]byte(creds))
+	if err != nil {
+		t.Errorf("parseJSONConfig threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "your-client-id" {
+		t.Errorf("parseJSONConfig returned incorrect ClientID, expected %s got %s", "your-client-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "your-client-secret" {
+		t.Errorf("parseJSONConfig returned incorrect ClientSecret, expected %s got %s", "your-client-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "your-organization-id" {
+		t.Errorf("parseJSONConfig returned incorrect OrganizationID, expected %s got %s", "your-organization-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "your-workspace-id" {
+		t.Errorf("parseJSONConfig returned incorrect Workspace, expected %s got %s", "your-workspace-id", cfg.Workspace)
+	} else if cfg.CloudDomain != "cribl-staging.cloud" {
+		t.Errorf("parseJSONConfig returned incorrect CloudDomain, expected %s got %s", "cribl-staging.cloud", cfg.CloudDomain)
+	}
+}
+
+func TestParseIniConfigMultiProfileWithCloudDomain(t *testing.T) {
+	t.Setenv("CRIBL_PROFILE", "playground")
+	creds := `[default]
+		  client_id = default-client-id
+		  client_secret = default-client-secret
+		  organization_id = default-organization-id
+		  workspace = default-workspace-id
+		  cloud_domain = cribl.cloud
+                  [playground]
+		  client_id = playground-client-id
+		  client_secret = playground-client-secret
+		  organization_id = playground-organization-id
+		  workspace = playground-workspace-id
+		  cloud_domain = cribl-playground.cloud
+		  `
+
+	cfg, err := parseIniConfig([]byte(creds))
+	if err != nil {
+		t.Errorf("parseIniConfig threw an error in operation: %s", err)
+	}
+
+	if cfg.ClientID != "playground-client-id" {
+		t.Errorf("parseIniConfig returned incorrect ClientID, expected %s got %s", "playground-client-id", cfg.ClientID)
+	} else if cfg.ClientSecret != "playground-client-secret" {
+		t.Errorf("parseIniConfig returned incorrect ClientSecret, expected %s got %s", "playground-client-secret", cfg.ClientSecret)
+	} else if cfg.OrganizationID != "playground-organization-id" {
+		t.Errorf("parseIniConfig returned incorrect OrganizationID, expected %s got %s", "playground-organization-id", cfg.OrganizationID)
+	} else if cfg.Workspace != "playground-workspace-id" {
+		t.Errorf("parseIniConfig returned incorrect Workspace, expected %s got %s", "playground-workspace-id", cfg.Workspace)
+	} else if cfg.CloudDomain != "cribl-playground.cloud" {
+		t.Errorf("parseIniConfig returned incorrect CloudDomain, expected %s got %s", "cribl-playground.cloud", cfg.CloudDomain)
+	}
+
+}

--- a/internal/auth/routing.go
+++ b/internal/auth/routing.go
@@ -1,0 +1,174 @@
+package auth
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// TrimPath removes leading slashes and the api/v1 prefix from path.
+func TrimPath(path string) string {
+	path = strings.TrimLeft(path, "/")
+	path = strings.TrimPrefix(path, "api/v1/")
+	path = strings.TrimPrefix(path, "api/v1")
+
+	return path
+}
+
+// IsGatewayPath reports whether path is a gateway management endpoint.
+func IsGatewayPath(path string) bool {
+	cleanPath := strings.TrimLeft(path, "/")
+	cleanPath = strings.TrimPrefix(cleanPath, "api/")
+	cleanPath = strings.TrimPrefix(cleanPath, "v1/")
+
+	return strings.HasPrefix(cleanPath, "organizations/")
+}
+
+// IsGatewayHost reports whether host is a gateway host.
+func IsGatewayHost(host string) bool {
+	return strings.Contains(host, "gateway.")
+}
+
+// IsLocalHost reports whether host is localhost or a loopback IP.
+func IsLocalHost(host string) bool {
+	if strings.Contains(host, "localhost") {
+		return true
+	}
+
+	if strings.Contains(host, "http") {
+		re := regexp.MustCompile(`https?:\/\/?`)
+		host = re.ReplaceAllString(host, "")
+	}
+
+	if strings.Contains(host, ":") {
+		host = strings.Split(host, ":")[0]
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+
+	return ip.IsLoopback()
+}
+
+// ConstructGatewayURL builds the gateway URL using Provider > Environment > Credentials > Default precedence.
+func ConstructGatewayURL(providerCloudDomain string, config *CriblConfig) string {
+	var output string
+
+	switch {
+	case providerCloudDomain != "":
+		output = providerCloudDomain
+	case os.Getenv("CRIBL_CLOUD_DOMAIN") != "":
+		output = os.Getenv("CRIBL_CLOUD_DOMAIN")
+	case config != nil && config.CloudDomain != "":
+		output = config.CloudDomain
+	default:
+		output = "cribl.cloud"
+	}
+
+	return fmt.Sprintf("https://gateway.%s", output)
+}
+
+// ConstructBaseURL builds a workspace URL from credentials when needed.
+func ConstructBaseURL(input ConstructBaseURLInput, config *CriblConfig) string {
+	workspaceEnv := os.Getenv("CRIBL_WORKSPACE_ID")
+	orgEnv := os.Getenv("CRIBL_ORGANIZATION_ID")
+	domainEnv := os.Getenv("CRIBL_CLOUD_DOMAIN")
+
+	baseURL := input.BaseURL
+
+	if baseURL != "" && IsLocalHost(baseURL) {
+		log.Printf("[DEBUG] Localhost URL detected, keeping as-is: %s", baseURL)
+		return baseURL
+	}
+
+	if workspaceEnv == "" && orgEnv == "" && domainEnv == "" &&
+		input.ProviderWorkspaceID == "" && input.ProviderOrgID == "" && input.ProviderCloudDomain == "" &&
+		baseURL != "" && !strings.Contains(baseURL, "{workspaceName}") && !strings.Contains(baseURL, "{organizationId}") {
+		log.Printf("[DEBUG] No environment or provider variables set, using provided concrete URL: %s", baseURL)
+		return baseURL
+	}
+
+	var workspace, workspaceSource string
+	switch {
+	case input.ProviderWorkspaceID != "":
+		workspace = input.ProviderWorkspaceID
+		workspaceSource = "provider"
+	case os.Getenv("CRIBL_WORKSPACE_ID") != "":
+		workspace = os.Getenv("CRIBL_WORKSPACE_ID")
+		workspaceSource = "environment"
+	case config != nil && config.Workspace != "":
+		workspace = config.Workspace
+		workspaceSource = "credentials"
+	default:
+		workspace = "main"
+		workspaceSource = "default"
+	}
+
+	if config != nil {
+		log.Printf("[DEBUG] Workspace selection: env='%s', config='%s', final='%s', source='%s'",
+			workspaceEnv, config.Workspace, workspace, workspaceSource)
+	} else {
+		log.Printf("[DEBUG] Workspace selection: env='%s', final='%s', source='%s'",
+			workspaceEnv, workspace, workspaceSource)
+	}
+
+	var orgSource, organizationID string
+	switch {
+	case input.ProviderOrgID != "":
+		organizationID = input.ProviderOrgID
+		orgSource = "provider"
+	case os.Getenv("CRIBL_ORGANIZATION_ID") != "":
+		organizationID = os.Getenv("CRIBL_ORGANIZATION_ID")
+		orgSource = "environment"
+	case config != nil && config.OrganizationID != "":
+		organizationID = config.OrganizationID
+		orgSource = "credentials"
+	default:
+		organizationID = "ian"
+		orgSource = "default"
+	}
+
+	if config != nil {
+		log.Printf("[DEBUG] Organization selection: env='%s', config='%s', final='%s', source='%s'",
+			orgEnv, config.OrganizationID, organizationID, orgSource)
+	} else {
+		log.Printf("[DEBUG] Organization selection: env='%s', final='%s', source='%s'",
+			orgEnv, organizationID, orgSource)
+	}
+
+	var cloudDomain, domainSource string
+	switch {
+	case input.ProviderCloudDomain != "":
+		cloudDomain = input.ProviderCloudDomain
+		domainSource = "provider"
+	case os.Getenv("CRIBL_CLOUD_DOMAIN") != "":
+		cloudDomain = os.Getenv("CRIBL_CLOUD_DOMAIN")
+		domainSource = "environment"
+	case config != nil && config.CloudDomain != "":
+		cloudDomain = config.CloudDomain
+		domainSource = "config"
+	default:
+		cloudDomain = "cribl.cloud"
+		domainSource = "default"
+	}
+
+	log.Printf("[DEBUG] Final precedence - Workspace: '%s' (from %s), Org: '%s' (from %s), Domain: '%s' (from %s)",
+		workspace, workspaceSource, organizationID, orgSource, cloudDomain, domainSource)
+
+	constructedURL := fmt.Sprintf("https://%s-%s.%s", workspace, organizationID, cloudDomain)
+	log.Printf("[DEBUG] Constructed URL: %s from workspace=%s, org=%s, domain=%s",
+		constructedURL, workspace, organizationID, cloudDomain)
+
+	return constructedURL
+}
+
+// IsRestrictedOnPremEndpoint reports whether path is unavailable on-prem.
+// This stub will be implemented after the Cribl OpenAPI spec is ported.
+func IsRestrictedOnPremEndpoint(string) bool {
+	return false
+}

--- a/internal/auth/routing_test.go
+++ b/internal/auth/routing_test.go
@@ -1,0 +1,207 @@
+package auth
+
+import "testing"
+
+func TestTrimPath(t *testing.T) {
+	example := "/api/v1/bar"
+	output := TrimPath(example)
+	expected := "bar"
+	if output != expected {
+		t.Errorf("got wrong output from TrimPath, expected %q and got %q", expected, output)
+	}
+}
+
+func TestIsGatewayPath(t *testing.T) {
+	gatewayPaths := []struct {
+		path     string
+		expected bool
+		desc     string
+	}{
+		{"/v1/organizations/my-org/workspaces", true, "workspace creation path"},
+		{"/api/v1/organizations/my-org/workspaces", true, "workspace creation path with api prefix"},
+		{"v1/organizations/my-org/workspaces/workspace-id", true, "workspace operations path"},
+		{"api/v1/organizations/my-org/workspaces/workspace-id", true, "workspace operations path with api prefix"},
+		{"/v1/workspaces/workspace-id/sources", false, "regular workspace API path"},
+		{"/api/v1/workspaces/workspace-id/destinations", false, "regular workspace API path"},
+		{"/v1/system/health", false, "system health path"},
+		{"", false, "empty path"},
+		{"/", false, "root path"},
+	}
+
+	for _, test := range gatewayPaths {
+		result := IsGatewayPath(test.path)
+		if result != test.expected {
+			t.Errorf("IsGatewayPath(%q) = %v, expected %v (%s)", test.path, result, test.expected, test.desc)
+		}
+	}
+}
+
+func TestIsGatewayHost(t *testing.T) {
+	gatewayHosts := []struct {
+		host     string
+		expected bool
+		desc     string
+	}{
+		{"foo.bar.com/api/v1/gateway", false, "plain URL path"},
+		{"foo.gateway.bar.com", true, "gateway subdomain"},
+		{"foo.gateway.com", true, "gateway domain"},
+	}
+
+	for _, test := range gatewayHosts {
+		result := IsGatewayHost(test.host)
+		if result != test.expected {
+			t.Errorf("IsGatewayHost(%q) = %v, expected %v (%s)", test.host, result, test.expected, test.desc)
+		}
+	}
+}
+
+func TestIsLocalHost(t *testing.T) {
+	gatewayHosts := []struct {
+		host     string
+		expected bool
+		desc     string
+	}{
+		{"foo.bar.com/api/v1/gateway", false, "plain URL path"},
+		{"foo.gateway.bar.com", false, "plain URL path"},
+		{"localhost", true, "localhost in words"},
+		{"127.0.0.1", true, "localhost in numbers"},
+		{"http://127.0.0.1:4344", true, "localhost in numbers with extra"},
+		{"http://127.0.0.1", true, "localhost in numbers with extra before"},
+		{"127.0.0.1:4344", true, "localhost in numbers with extra after"},
+		{"http://localhost:4344", true, "localhost with scheme and port"},
+		{"http://localhost", true, "localhost with scheme"},
+		{"localhost:4344", true, "localhost with port"},
+		{"locahost:4344", false, "misspelled localhost"},
+	}
+
+	for _, test := range gatewayHosts {
+		result := IsLocalHost(test.host)
+		if result != test.expected {
+			t.Errorf("IsLocalHost(%q) = %v, expected %v (%s)", test.host, result, test.expected, test.desc)
+		}
+	}
+}
+
+func TestConstructGatewayURL(t *testing.T) {
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	result := ConstructGatewayURL("", nil)
+	expected := "https://gateway.cribl.cloud"
+	if result != expected {
+		t.Errorf("ConstructGatewayURL('', nil) = %q, expected %q", result, expected)
+	}
+
+	result = ConstructGatewayURL("cribl-playground.cloud", nil)
+	expected = "https://gateway.cribl-playground.cloud"
+	if result != expected {
+		t.Errorf("ConstructGatewayURL('cribl-playground.cloud', nil) = %q, expected %q", result, expected)
+	}
+
+	config := &CriblConfig{
+		CloudDomain: "cribl-staging.cloud",
+	}
+	result = ConstructGatewayURL("", config)
+	expected = "https://gateway.cribl-staging.cloud"
+	if result != expected {
+		t.Errorf("ConstructGatewayURL('', config) = %q, expected %q", result, expected)
+	}
+
+	result = ConstructGatewayURL("cribl-prod.cloud", config)
+	expected = "https://gateway.cribl-prod.cloud"
+	if result != expected {
+		t.Errorf("ConstructGatewayURL('cribl-prod.cloud', config) = %q, expected %q", result, expected)
+	}
+
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "cribl-env.cloud")
+	result = ConstructGatewayURL("", config)
+	expected = "https://gateway.cribl-env.cloud"
+	if result != expected {
+		t.Errorf("ConstructGatewayURL('', config) with env = %q, expected %q", result, expected)
+	}
+}
+
+func TestConstructBaseURL(t *testing.T) {
+	t.Setenv("CRIBL_ORGANIZATION_ID", "")
+	t.Setenv("CRIBL_WORKSPACE_ID", "")
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	input := ConstructBaseURLInput{
+		BaseURL: "foo",
+	}
+	expected := "foo"
+	result := ConstructBaseURL(input, nil)
+	if result != expected {
+		t.Errorf("ConstructBaseURL returned %q, expected %q", result, expected)
+	}
+
+	input = ConstructBaseURLInput{
+		BaseURL: "127.0.0.1",
+	}
+	expected = "127.0.0.1"
+	result = ConstructBaseURL(input, nil)
+	if result != expected {
+		t.Errorf("ConstructBaseURL returned %q, expected %q", result, expected)
+	}
+
+	input = ConstructBaseURLInput{}
+	config := CriblConfig{
+		OrganizationID: "ConfigOrgID",
+		Workspace:      "ConfigWorkspaceID",
+		CloudDomain:    "ConfigCloudDomain",
+	}
+	expected = "https://ConfigWorkspaceID-ConfigOrgID.ConfigCloudDomain"
+	result = ConstructBaseURL(input, &config)
+	if result != expected {
+		t.Errorf("ConstructBaseURL returned %q, expected %q", result, expected)
+	}
+
+	t.Setenv("CRIBL_ORGANIZATION_ID", "EnvOrgID")
+	t.Setenv("CRIBL_WORKSPACE_ID", "EnvWorkspaceID")
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "EnvCloudDomain")
+	expected = "https://EnvWorkspaceID-EnvOrgID.EnvCloudDomain"
+	result = ConstructBaseURL(input, &config)
+	if result != expected {
+		t.Errorf("ConstructBaseURL returned %q, expected %q", result, expected)
+	}
+
+	input = ConstructBaseURLInput{
+		ProviderOrgID:       "ProviderOrgID",
+		ProviderWorkspaceID: "ProviderWorkspaceID",
+		ProviderCloudDomain: "ProviderCloudDomain",
+	}
+	expected = "https://ProviderWorkspaceID-ProviderOrgID.ProviderCloudDomain"
+	result = ConstructBaseURL(input, &config)
+	if result != expected {
+		t.Errorf("ConstructBaseURL returned %q, expected %q", result, expected)
+	}
+
+	t.Setenv("CRIBL_ORGANIZATION_ID", "")
+	t.Setenv("CRIBL_WORKSPACE_ID", "")
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	input = ConstructBaseURLInput{
+		ProviderCloudDomain: "ProviderCloudDomain",
+	}
+	expected = "https://main-ian.ProviderCloudDomain"
+	result = ConstructBaseURL(input, nil)
+	if result != expected {
+		t.Errorf("ConstructBaseURL returned %q, expected %q", result, expected)
+	}
+}
+
+func TestIsRestrictedOnPremEndpointAlwaysFalse(t *testing.T) {
+	restrictedInOldHook := []string{
+		"/products/search/jobs",
+		"/products/lake/lakes",
+		"/v1/organizations/org/workspaces",
+		"/api/v1/organizations/org/workspaces",
+		"/search/jobs",
+		"/m/default_search/search/dashboards",
+	}
+
+	for _, path := range restrictedInOldHook {
+		if IsRestrictedOnPremEndpoint(path) {
+			t.Errorf("IsRestrictedOnPremEndpoint(%q) = true, expected false while Phase 0.3b is deferred", path)
+		}
+	}
+}

--- a/internal/auth/types.go
+++ b/internal/auth/types.go
@@ -1,0 +1,30 @@
+package auth
+
+import "time"
+
+// CriblConfig holds Cribl auth and connection settings from the environment or credentials file.
+type CriblConfig struct {
+	ClientID       string `json:"client_id" ini:"client_id"`
+	ClientSecret   string `json:"client_secret" ini:"client_secret"`
+	OrganizationID string `json:"organization_id" ini:"organization_id"`
+	Workspace      string `json:"workspace" ini:"workspace"`
+	CloudDomain    string `json:"cloud_domain" ini:"cloud_domain"`
+
+	OnpremServerURL string `json:"onprem_server_url" ini:"onprem_server_url"`
+	OnpremUsername  string `json:"onprem_username" ini:"onprem_username"`
+	OnpremPassword  string `json:"onprem_password" ini:"onprem_password"`
+}
+
+// TokenInfo holds a bearer token and its expiration time.
+type TokenInfo struct {
+	Token     string
+	ExpiresAt time.Time
+}
+
+// ConstructBaseURLInput holds inputs for constructing a Cribl workspace base URL.
+type ConstructBaseURLInput struct {
+	BaseURL             string
+	ProviderOrgID       string
+	ProviderWorkspaceID string
+	ProviderCloudDomain string
+}


### PR DESCRIPTION
- Added new internal/auth package for Phase 0 auth migration, porting credential loading and routing helpers without depending on the Speakeasy SDK.
- Extracted cloud/playground/gov/on-prem token acquisition with token caching, cache invalidation, and refresh support for future 401 retry handling.
- Added auth/routing/credential unit tests and wired internal/auth into make unit-test for CI.