### PR TITLE
adding internal client library and merge-spec tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work*
 dist/*
 .speakeasy-*
 upstream-openapi.yml
+merged-spec.yml

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,13 @@ test-cleanup:
 	@cd tests/e2e; rm -rf local-plugins .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup
 
 unit-test: 
-	go test -v ./internal/auth/... ./internal/sdk/credentials ./internal/sdk/internal/hooks ./tools/sync-openapi
+	go test -v ./internal/auth/... ./internal/restclient/... ./internal/sdk/credentials ./internal/sdk/internal/hooks ./tools/sync-openapi ./tools/merge-spec/...
 
 sync-openapi:
 	go run ./tools/sync-openapi
+
+merge:
+	go run ./tools/merge-spec
 
 unit-test-import-cli:
 	go test -v ./tools/import-cli/...

--- a/internal/restclient/client.go
+++ b/internal/restclient/client.go
@@ -1,0 +1,334 @@
+// Package restclient provides the generic HTTP client used by migrated resources.
+package restclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"reflect"
+	"strings"
+
+	"github.com/criblio/terraform-provider-criblio/internal/auth"
+)
+
+// Config holds REST client settings.
+type Config struct {
+	BaseURL             string
+	ProviderOrgID       string
+	ProviderWorkspaceID string
+	ProviderCloudDomain string
+	Credentials         *auth.CriblConfig
+	BearerToken         string
+	HTTPClient          *http.Client
+}
+
+// Client sends authenticated requests to Cribl APIs.
+type Client struct {
+	baseURL             string
+	providerCloudDomain string
+	credentials         *auth.CriblConfig
+	bearerToken         string
+	httpClient          *http.Client
+}
+
+// HTTPError is returned for non-2xx responses other than 404.
+type HTTPError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	return fmt.Sprintf("cribl API returned HTTP %d: %s", e.StatusCode, e.Body)
+}
+
+// NotFoundError is returned for 404 responses.
+type NotFoundError struct {
+	Path string
+	Body string
+}
+
+func (e *NotFoundError) Error() string {
+	if e.Body == "" {
+		return fmt.Sprintf("cribl API path %q was not found", e.Path)
+	}
+	return fmt.Sprintf("cribl API path %q was not found: %s", e.Path, e.Body)
+}
+
+// New creates a REST client.
+func New(config Config) *Client {
+	httpClient := config.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	baseURL := config.BaseURL
+	if baseURL == "" {
+		baseURL = auth.ConstructBaseURL(auth.ConstructBaseURLInput{
+			ProviderOrgID:       config.ProviderOrgID,
+			ProviderWorkspaceID: config.ProviderWorkspaceID,
+			ProviderCloudDomain: config.ProviderCloudDomain,
+		}, config.Credentials)
+	}
+
+	return &Client{
+		baseURL:             strings.TrimRight(baseURL, "/"),
+		providerCloudDomain: config.ProviderCloudDomain,
+		credentials:         config.Credentials,
+		bearerToken:         config.BearerToken,
+		httpClient:          httpClient,
+	}
+}
+
+// Get sends a GET request and decodes the response.
+func Get[T any](ctx context.Context, c *Client, path string) (*T, error) {
+	body, err := do(ctx, c, http.MethodGet, path, "", nil)
+	if err != nil {
+		return nil, err
+	}
+	return decodeResponse[T](body)
+}
+
+// Post sends a POST request with a JSON body and decodes the response.
+func Post[Req, Resp any](ctx context.Context, c *Client, path string, body Req) (*Resp, error) {
+	responseBody, err := doJSON(ctx, c, http.MethodPost, path, body)
+	if err != nil {
+		return nil, err
+	}
+	return decodeResponse[Resp](responseBody)
+}
+
+// Patch sends a PATCH request with a JSON body and decodes the response.
+func Patch[Req, Resp any](ctx context.Context, c *Client, path string, body Req) (*Resp, error) {
+	responseBody, err := doJSON(ctx, c, http.MethodPatch, path, body)
+	if err != nil {
+		return nil, err
+	}
+	return decodeResponse[Resp](responseBody)
+}
+
+// Put sends a PUT request with a JSON body and decodes the response.
+func Put[Req, Resp any](ctx context.Context, c *Client, path string, body Req) (*Resp, error) {
+	responseBody, err := doJSON(ctx, c, http.MethodPut, path, body)
+	if err != nil {
+		return nil, err
+	}
+	return decodeResponse[Resp](responseBody)
+}
+
+// Delete sends a DELETE request.
+func Delete(ctx context.Context, c *Client, path string) error {
+	_, err := do(ctx, c, http.MethodDelete, path, "", nil)
+	return err
+}
+
+// Upload sends multipart file content to path.
+func Upload(ctx context.Context, c *Client, path, filename string, content []byte) error {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		return fmt.Errorf("failed to create multipart file: %v", err)
+	}
+	if _, err := part.Write(content); err != nil {
+		return fmt.Errorf("failed to write multipart file: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to close multipart writer: %v", err)
+	}
+
+	_, err = do(ctx, c, http.MethodPost, path, writer.FormDataContentType(), body.Bytes())
+	return err
+}
+
+// IsNotFound reports whether err is a NotFoundError.
+func IsNotFound(err error) bool {
+	var notFound *NotFoundError
+	return errors.As(err, &notFound)
+}
+
+func doJSON[Req any](ctx context.Context, c *Client, method, path string, body Req) ([]byte, error) {
+	requestBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %v", err)
+	}
+	return do(ctx, c, method, path, "application/json", requestBody)
+}
+
+func do(ctx context.Context, c *Client, method, path, contentType string, body []byte) ([]byte, error) {
+	if c == nil {
+		return nil, fmt.Errorf("restclient client is required")
+	}
+
+	responseBody, statusCode, err := c.send(ctx, method, path, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	if statusCode != http.StatusUnauthorized || c.bearerToken != "" || os.Getenv("CRIBL_BEARER_TOKEN") != "" || c.credentials == nil {
+		return responseBody, responseError(path, statusCode, responseBody)
+	}
+
+	auth.InvalidateToken(c.credentials)
+	responseBody, statusCode, err = c.send(ctx, method, path, contentType, body)
+	if err != nil {
+		return nil, err
+	}
+	return responseBody, responseError(path, statusCode, responseBody)
+}
+
+func (c *Client) send(ctx context.Context, method, path, contentType string, body []byte) ([]byte, int, error) {
+	requestURL, err := c.requestURL(path)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, reader)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to create request: %v", err)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	if body != nil {
+		req.Header.Set("Accept", "application/json")
+	}
+
+	token, err := c.token(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to send request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, 0, fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	return responseBody, resp.StatusCode, nil
+}
+
+func (c *Client) requestURL(path string) (string, error) {
+	trimmedPath := auth.TrimPath(path)
+
+	if auth.IsOnPrem(c.credentials) {
+		if auth.IsRestrictedOnPremEndpoint(trimmedPath) {
+			return "", fmt.Errorf("endpoint %q is not supported for on-prem deployments", trimmedPath)
+		}
+		return joinBasePath(c.credentials.OnpremServerURL, "api/v1", trimmedPath), nil
+	}
+
+	if auth.IsGatewayPath(path) {
+		return joinBasePath(auth.ConstructGatewayURL(c.providerCloudDomain, c.credentials), "", gatewayRequestPath(path)), nil
+	}
+
+	if c.baseURL == "" {
+		return "", fmt.Errorf("base URL is required")
+	}
+	return joinBasePath(c.baseURL, "api/v1", trimmedPath), nil
+}
+
+func (c *Client) token(ctx context.Context) (string, error) {
+	switch {
+	case c.bearerToken != "":
+		return c.bearerToken, nil
+	case os.Getenv("CRIBL_BEARER_TOKEN") != "":
+		return os.Getenv("CRIBL_BEARER_TOKEN"), nil
+	case c.credentials != nil:
+		return auth.GetToken(ctx, c.credentials)
+	default:
+		return "", fmt.Errorf("authentication requires bearer token or credentials")
+	}
+}
+
+func responseError(path string, statusCode int, body []byte) error {
+	switch {
+	case statusCode >= 200 && statusCode < 300:
+		return nil
+	case statusCode == http.StatusNotFound:
+		return &NotFoundError{
+			Path: path,
+			Body: string(body),
+		}
+	default:
+		return &HTTPError{
+			StatusCode: statusCode,
+			Body:       string(body),
+		}
+	}
+}
+
+func decodeResponse[T any](body []byte) (*T, error) {
+	if len(bytes.TrimSpace(body)) == 0 {
+		return nil, nil
+	}
+
+	var envelope struct {
+		Items json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(body, &envelope); err == nil && len(envelope.Items) > 0 && string(envelope.Items) != "null" {
+		return decodeEnvelope[T](envelope.Items)
+	}
+
+	var output T
+	if err := json.Unmarshal(body, &output); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %v", err)
+	}
+	return &output, nil
+}
+
+func decodeEnvelope[T any](items json.RawMessage) (*T, error) {
+	var output T
+	outputValue := reflect.ValueOf(&output).Elem()
+	if outputValue.Kind() == reflect.Slice {
+		if err := json.Unmarshal(items, &output); err != nil {
+			return nil, fmt.Errorf("failed to decode response envelope: %v", err)
+		}
+		return &output, nil
+	}
+
+	itemsValue := reflect.New(reflect.SliceOf(outputValue.Type()))
+	if err := json.Unmarshal(items, itemsValue.Interface()); err != nil {
+		return nil, fmt.Errorf("failed to decode response envelope: %v", err)
+	}
+
+	itemsSlice := itemsValue.Elem()
+	if itemsSlice.Len() == 0 {
+		return nil, fmt.Errorf("response envelope contained no items")
+	}
+
+	outputValue.Set(itemsSlice.Index(0))
+	return &output, nil
+}
+
+func joinBasePath(baseURL, prefix, path string) string {
+	parts := []string{strings.TrimRight(baseURL, "/")}
+	if prefix != "" {
+		parts = append(parts, strings.Trim(prefix, "/"))
+	}
+	if path != "" {
+		parts = append(parts, strings.TrimLeft(path, "/"))
+	}
+	return strings.Join(parts, "/")
+}
+
+func gatewayRequestPath(path string) string {
+	cleanPath := strings.TrimLeft(path, "/")
+	return strings.TrimPrefix(cleanPath, "api/")
+}

--- a/internal/restclient/client_test.go
+++ b/internal/restclient/client_test.go
@@ -1,0 +1,409 @@
+package restclient
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+type testItem struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestMethods(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer test-token" {
+			t.Errorf("Authorization = %q, expected Bearer test-token", r.Header.Get("Authorization"))
+		}
+
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.Path != "/api/v1/system/certificates/cert-1" {
+				t.Errorf("GET path = %q", r.URL.Path)
+			}
+			writeJSON(t, w, testItem{ID: "cert-1", Name: "from-get"})
+		case http.MethodPost:
+			switch r.URL.Path {
+			case "/api/v1/system/certificates":
+				assertJSONBody(t, r, "from-post")
+				writeJSON(t, w, testItem{ID: "cert-2", Name: "from-post"})
+			case "/api/v1/system/files":
+				mediaType, _, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+				if err != nil {
+					t.Errorf("failed to parse content type: %v", err)
+				}
+				if mediaType != "multipart/form-data" {
+					t.Errorf("upload content type = %q, expected multipart/form-data", mediaType)
+				}
+				if err := r.ParseMultipartForm(1024); err != nil {
+					t.Errorf("failed to parse multipart form: %v", err)
+				}
+				file, header, err := r.FormFile("file")
+				if err != nil {
+					t.Errorf("missing upload file: %v", err)
+					return
+				}
+				defer file.Close()
+				content, err := io.ReadAll(file)
+				if err != nil {
+					t.Errorf("failed to read upload file: %v", err)
+				}
+				if header.Filename != "lookup.csv" {
+					t.Errorf("upload filename = %q, expected lookup.csv", header.Filename)
+				}
+				if string(content) != "a,b\n" {
+					t.Errorf("upload content = %q, expected a,b\\n", string(content))
+				}
+				w.WriteHeader(http.StatusNoContent)
+			default:
+				t.Errorf("unexpected POST path %q", r.URL.Path)
+			}
+		case http.MethodPatch:
+			if r.URL.Path != "/api/v1/system/certificates/cert-1" {
+				t.Errorf("PATCH path = %q", r.URL.Path)
+			}
+			assertJSONBody(t, r, "from-patch")
+			writeJSON(t, w, testItem{ID: "cert-1", Name: "from-patch"})
+		case http.MethodPut:
+			if r.URL.Path != "/api/v1/system/certificates/cert-1" {
+				t.Errorf("PUT path = %q", r.URL.Path)
+			}
+			assertJSONBody(t, r, "from-put")
+			writeJSON(t, w, testItem{ID: "cert-1", Name: "from-put"})
+		case http.MethodDelete:
+			if r.URL.Path != "/api/v1/system/certificates/cert-1" {
+				t.Errorf("DELETE path = %q", r.URL.Path)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+	})
+
+	got, err := Get[testItem](context.Background(), client, "/system/certificates/cert-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got.Name != "from-get" {
+		t.Fatalf("Get name = %q, expected from-get", got.Name)
+	}
+
+	created, err := Post[testItem, testItem](context.Background(), client, "/system/certificates", testItem{Name: "from-post"})
+	if err != nil {
+		t.Fatalf("Post returned error: %v", err)
+	}
+	if created.ID != "cert-2" {
+		t.Fatalf("Post ID = %q, expected cert-2", created.ID)
+	}
+
+	patched, err := Patch[testItem, testItem](context.Background(), client, "/system/certificates/cert-1", testItem{Name: "from-patch"})
+	if err != nil {
+		t.Fatalf("Patch returned error: %v", err)
+	}
+	if patched.Name != "from-patch" {
+		t.Fatalf("Patch name = %q, expected from-patch", patched.Name)
+	}
+
+	put, err := Put[testItem, testItem](context.Background(), client, "/system/certificates/cert-1", testItem{Name: "from-put"})
+	if err != nil {
+		t.Fatalf("Put returned error: %v", err)
+	}
+	if put.Name != "from-put" {
+		t.Fatalf("Put name = %q, expected from-put", put.Name)
+	}
+
+	if err := Delete(context.Background(), client, "/system/certificates/cert-1"); err != nil {
+		t.Fatalf("Delete returned error: %v", err)
+	}
+
+	if err := Upload(context.Background(), client, "/system/files", "lookup.csv", []byte("a,b\n")); err != nil {
+		t.Fatalf("Upload returned error: %v", err)
+	}
+}
+
+func TestDecodeEnvelopeSingleAndSlice(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, map[string]any{
+			"count": 2,
+			"items": []testItem{
+				{ID: "one", Name: "first"},
+				{ID: "two", Name: "second"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+	})
+
+	single, err := Get[testItem](context.Background(), client, "/system/certificates/one")
+	if err != nil {
+		t.Fatalf("Get single returned error: %v", err)
+	}
+	if single.ID != "one" {
+		t.Fatalf("single ID = %q, expected one", single.ID)
+	}
+
+	list, err := Get[[]testItem](context.Background(), client, "/system/certificates")
+	if err != nil {
+		t.Fatalf("Get slice returned error: %v", err)
+	}
+	if len(*list) != 2 {
+		t.Fatalf("slice length = %d, expected 2", len(*list))
+	}
+	if (*list)[1].ID != "two" {
+		t.Fatalf("second ID = %q, expected two", (*list)[1].ID)
+	}
+}
+
+func TestDecodePlainJSONAndNoContent(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/empty") {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		writeJSON(t, w, testItem{ID: "plain", Name: "plain-json"})
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+	})
+
+	plain, err := Get[testItem](context.Background(), client, "/system/plain")
+	if err != nil {
+		t.Fatalf("Get plain returned error: %v", err)
+	}
+	if plain.ID != "plain" {
+		t.Fatalf("plain ID = %q, expected plain", plain.ID)
+	}
+
+	empty, err := Patch[testItem, testItem](context.Background(), client, "/system/plain/empty", testItem{Name: "empty"})
+	if err != nil {
+		t.Fatalf("Patch empty returned error: %v", err)
+	}
+	if empty != nil {
+		t.Fatalf("Patch empty = %#v, expected nil", empty)
+	}
+}
+
+func TestErrors(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/missing":
+			http.Error(w, "missing resource", http.StatusNotFound)
+		case "/api/v1/bad":
+			http.Error(w, "bad request", http.StatusBadRequest)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+	})
+
+	_, err := Get[testItem](context.Background(), client, "/missing")
+	if err == nil {
+		t.Fatal("Get missing returned nil error")
+	}
+	if !IsNotFound(err) {
+		t.Fatalf("IsNotFound = false, expected true for 404")
+	}
+
+	_, err = Get[testItem](context.Background(), client, "/bad")
+	if err == nil {
+		t.Fatal("Get bad returned nil error")
+	}
+	if IsNotFound(err) {
+		t.Fatalf("IsNotFound = true, expected false for non-404")
+	}
+
+	var httpErr *HTTPError
+	if !errors.As(err, &httpErr) {
+		t.Fatalf("error type = %T, expected HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, expected 400", httpErr.StatusCode)
+	}
+	if !strings.Contains(httpErr.Body, "bad request") {
+		t.Fatalf("body = %q, expected bad request", httpErr.Body)
+	}
+
+	if IsNotFound(fmt.Errorf("ordinary error")) {
+		t.Fatalf("IsNotFound = true, expected false for ordinary error")
+	}
+}
+
+func TestGatewayRouting(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "v1 path",
+			path: "/v1/organizations/org-id/workspaces",
+		},
+		{
+			name: "api v1 path",
+			path: "/api/v1/organizations/org-id/workspaces",
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != "gateway.cribl.cloud" {
+			t.Errorf("Host = %q, expected gateway.cribl.cloud", r.Host)
+		}
+		if r.URL.Path != "/v1/organizations/org-id/workspaces" {
+			t.Errorf("path = %q, expected /v1/organizations/org-id/workspaces", r.URL.Path)
+		}
+		writeJSON(t, w, testItem{ID: "workspace", Name: "gateway"})
+	}))
+	defer server.Close()
+
+	targetURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	client := New(Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+		HTTPClient: &http.Client{
+			Transport: rewriteTransport{target: targetURL},
+		},
+	})
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := Get[testItem](context.Background(), client, test.path)
+			if err != nil {
+				t.Fatalf("Get gateway returned error: %v", err)
+			}
+			if got.Name != "gateway" {
+				t.Fatalf("gateway name = %q, expected gateway", got.Name)
+			}
+		})
+	}
+}
+
+func TestProviderWorkspaceRouting(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+	t.Setenv("CRIBL_ORGANIZATION_ID", "")
+	t.Setenv("CRIBL_WORKSPACE_ID", "")
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Host != "provider-workspace-provider-org.cribl-playground.cloud" {
+			t.Errorf("Host = %q, expected provider-workspace-provider-org.cribl-playground.cloud", r.Host)
+		}
+		if r.URL.Path != "/api/v1/system/certificates/cert-1" {
+			t.Errorf("path = %q, expected /api/v1/system/certificates/cert-1", r.URL.Path)
+		}
+		writeJSON(t, w, testItem{ID: "cert-1", Name: "provider-config"})
+	}))
+	defer server.Close()
+
+	targetURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	client := New(Config{
+		ProviderOrgID:       "provider-org",
+		ProviderWorkspaceID: "provider-workspace",
+		ProviderCloudDomain: "cribl-playground.cloud",
+		BearerToken:         "test-token",
+		HTTPClient: &http.Client{
+			Transport: rewriteTransport{target: targetURL},
+		},
+	})
+
+	got, err := Get[testItem](context.Background(), client, "/system/certificates/cert-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got.Name != "provider-config" {
+		t.Fatalf("name = %q, expected provider-config", got.Name)
+	}
+}
+
+func TestAuthenticationRequired(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	client := New(Config{BaseURL: "http://127.0.0.1:1"})
+	_, err := Get[testItem](context.Background(), client, "/system/certificates")
+	if err == nil {
+		t.Fatal("Get returned nil error, expected authentication error")
+	}
+	if !strings.Contains(err.Error(), "authentication requires bearer token or credentials") {
+		t.Fatalf("error = %q, expected authentication message", err.Error())
+	}
+}
+
+type rewriteTransport struct {
+	target *url.URL
+}
+
+func (t rewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	out := req.Clone(req.Context())
+	out.URL.Scheme = t.target.Scheme
+	out.URL.Host = t.target.Host
+	out.Host = req.URL.Host
+	return http.DefaultTransport.RoundTrip(out)
+}
+
+func assertJSONBody(t *testing.T, r *http.Request, expectedName string) {
+	t.Helper()
+
+	if r.Header.Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, expected application/json", r.Header.Get("Content-Type"))
+	}
+	var body testItem
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		t.Errorf("failed to decode JSON body: %v", err)
+		return
+	}
+	if body.Name != expectedName {
+		t.Errorf("body name = %q, expected %q", body.Name, expectedName)
+	}
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("failed to write JSON response: %v", err)
+	}
+}

--- a/terraform-overlay.yml
+++ b/terraform-overlay.yml
@@ -1,0 +1,36 @@
+actions:
+  - target: "$.paths./m/{groupId}/system/certificates.post"
+    update:
+      x-terraform-resource: true
+      x-terraform-resource-name: certificate
+  - target: "$.paths./m/{groupId}/system/certificates/{id}.get"
+    update:
+      x-terraform-read: certificate
+  - target: "$.paths./m/{groupId}/system/certificates/{id}.patch"
+    update:
+      x-terraform-update: certificate
+  - target: "$.paths./m/{groupId}/system/certificates/{id}.delete"
+    update:
+      x-terraform-delete: certificate
+  - target: "$.components.schemas.Certificate.properties.privKey"
+    update:
+      x-terraform-sensitive: true
+      x-terraform-prefer-state: true
+  - target: "$.components.schemas.Certificate.properties.passphrase"
+    update:
+      x-terraform-sensitive: true
+      x-terraform-prefer-state: true
+  - target: "$.components.schemas.Certificate.properties.certExpiryDate"
+    update:
+      x-terraform-computed: true
+  - target: "$.components.schemas.Certificate.properties.id"
+    update:
+      x-terraform-force-new: true
+  - target: "$.components.schemas.Certificate.properties"
+    update:
+      inUse:
+        type: array
+        items:
+          type: string
+        x-terraform-computed: true
+        description: "List of configurations that reference this certificate."

--- a/tools/merge-spec/main.go
+++ b/tools/merge-spec/main.go
@@ -1,0 +1,503 @@
+// Command merge-spec applies Terraform provider overlays to the upstream Cribl OpenAPI spec.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+const (
+	defaultInput   = "upstream-openapi.yml"
+	defaultOverlay = "terraform-overlay.yml"
+	defaultOutput  = "merged-spec.yml"
+	groupPrefix    = "/m/{groupId}"
+)
+
+var httpMethods = map[string]bool{
+	"get":     true,
+	"put":     true,
+	"post":    true,
+	"delete":  true,
+	"options": true,
+	"head":    true,
+	"patch":   true,
+	"trace":   true,
+}
+
+func main() {
+	input := flag.String("input", defaultInput, "upstream OpenAPI YAML file")
+	overlay := flag.String("overlay", defaultOverlay, "Terraform overlay YAML file")
+	output := flag.String("output", defaultOutput, "merged OpenAPI YAML file")
+	flag.Parse()
+
+	if err := run(*input, *overlay, *output); err != nil {
+		fmt.Fprintf(os.Stderr, "merge spec: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(inputPath, overlayPath, outputPath string) error {
+	spec, err := readYAML(inputPath)
+	if err != nil {
+		return fmt.Errorf("read input spec: %v", err)
+	}
+
+	if err := prefixGroupScopedPaths(spec); err != nil {
+		return err
+	}
+	if err := applyOverlayFile(spec, overlayPath); err != nil {
+		return err
+	}
+	if err := unwrapCountedResponses(spec); err != nil {
+		return err
+	}
+
+	var output bytes.Buffer
+	encoder := yaml.NewEncoder(&output)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(spec); err != nil {
+		return fmt.Errorf("encode merged spec: %v", err)
+	}
+	if err := encoder.Close(); err != nil {
+		return fmt.Errorf("close YAML encoder: %v", err)
+	}
+
+	if err := os.WriteFile(outputPath, output.Bytes(), 0644); err != nil {
+		return fmt.Errorf("write output spec: %v", err)
+	}
+	return nil
+}
+
+func readYAML(filename string) (*yaml.Node, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return nil, err
+	}
+	return &root, nil
+}
+
+func applyOverlayFile(spec *yaml.Node, overlayPath string) error {
+	overlay, err := readYAML(overlayPath)
+	if err != nil {
+		return fmt.Errorf("read overlay: %v", err)
+	}
+
+	actions, ok := mappingValue(documentMapping(overlay), "actions")
+	if !ok || actions.Kind != yaml.SequenceNode {
+		return fmt.Errorf("overlay must contain an actions sequence")
+	}
+
+	for index, action := range actions.Content {
+		target, update, err := parseAction(action)
+		if err != nil {
+			return fmt.Errorf("overlay action %d: %v", index, err)
+		}
+		targetNode, err := lookupTarget(documentMapping(spec), target)
+		if err != nil {
+			return fmt.Errorf("overlay action %d target %q: %v", index, target, err)
+		}
+		mergeMapping(targetNode, update)
+	}
+
+	return nil
+}
+
+func parseAction(action *yaml.Node) (string, *yaml.Node, error) {
+	if action.Kind != yaml.MappingNode {
+		return "", nil, fmt.Errorf("action must be a mapping")
+	}
+
+	targetNode, ok := mappingValue(action, "target")
+	if !ok || targetNode.Kind != yaml.ScalarNode {
+		return "", nil, fmt.Errorf("target scalar is required")
+	}
+	updateNode, ok := mappingValue(action, "update")
+	if !ok || updateNode.Kind != yaml.MappingNode {
+		return "", nil, fmt.Errorf("update mapping is required")
+	}
+	return targetNode.Value, updateNode, nil
+}
+
+func lookupTarget(root *yaml.Node, target string) (*yaml.Node, error) {
+	const prefix = "$."
+	if !strings.HasPrefix(target, prefix) {
+		return nil, fmt.Errorf("must start with %q", prefix)
+	}
+
+	node := root
+	for _, segment := range strings.Split(strings.TrimPrefix(target, prefix), ".") {
+		if segment == "" {
+			return nil, fmt.Errorf("empty target segment")
+		}
+		next, ok := mappingValue(node, segment)
+		if !ok {
+			return nil, fmt.Errorf("segment %q not found", segment)
+		}
+		node = next
+	}
+	return node, nil
+}
+
+func prefixGroupScopedPaths(spec *yaml.Node) error {
+	paths, ok := mappingValue(documentMapping(spec), "paths")
+	if !ok || paths.Kind != yaml.MappingNode {
+		return fmt.Errorf("spec paths mapping not found")
+	}
+
+	var additions []*yaml.Node
+	var removeKeys []string
+	for index := 0; index < len(paths.Content); index += 2 {
+		key := paths.Content[index]
+		value := paths.Content[index+1]
+		if !shouldPrefixPath(key.Value) {
+			continue
+		}
+
+		prefixedPath := groupPrefix + key.Value
+		if _, exists := mappingValue(paths, prefixedPath); exists {
+			removeKeys = append(removeKeys, key.Value)
+			continue
+		}
+
+		keyCopy := cloneNode(key)
+		keyCopy.Value = prefixedPath
+		valueCopy := cloneNode(value)
+		ensureGroupIDParameter(valueCopy)
+		additions = append(additions, keyCopy, valueCopy)
+		removeKeys = append(removeKeys, key.Value)
+	}
+
+	for _, key := range removeKeys {
+		deleteMappingKey(paths, key)
+	}
+	paths.Content = append(paths.Content, additions...)
+	return nil
+}
+
+func shouldPrefixPath(apiPath string) bool {
+	if apiPath == "" || apiPath == "/" || strings.HasPrefix(apiPath, groupPrefix+"/") {
+		return false
+	}
+
+	excludedPrefixes := []string{
+		"/admin/",
+		"/master/",
+		"/products/",
+		"/health",
+	}
+	if slices.ContainsFunc(excludedPrefixes, func(prefix string) bool {
+		return strings.HasPrefix(apiPath, prefix)
+	}) {
+		return false
+	}
+
+	return strings.HasPrefix(apiPath, "/lib/") ||
+		strings.HasPrefix(apiPath, "/p/") ||
+		strings.HasPrefix(apiPath, "/pipelines") ||
+		strings.HasPrefix(apiPath, "/routes") ||
+		strings.HasPrefix(apiPath, "/search/") ||
+		strings.HasPrefix(apiPath, "/settings/") ||
+		strings.HasPrefix(apiPath, "/notification") ||
+		strings.HasPrefix(apiPath, "/collectors") ||
+		strings.HasPrefix(apiPath, "/executors") ||
+		strings.HasPrefix(apiPath, "/functions") ||
+		strings.HasPrefix(apiPath, "/system/")
+}
+
+func ensureGroupIDParameter(pathItem *yaml.Node) {
+	if pathItem.Kind != yaml.MappingNode {
+		return
+	}
+
+	for index := 0; index < len(pathItem.Content); index += 2 {
+		key := pathItem.Content[index]
+		if !httpMethods[key.Value] {
+			continue
+		}
+		operation := pathItem.Content[index+1]
+		if operation.Kind == yaml.MappingNode {
+			ensureOperationGroupIDParameter(operation)
+		}
+	}
+}
+
+func ensureOperationGroupIDParameter(operation *yaml.Node) {
+	parameters, ok := mappingValue(operation, "parameters")
+	if !ok {
+		parameters = &yaml.Node{Kind: yaml.SequenceNode}
+		setMappingValue(operation, scalar("parameters"), parameters)
+	}
+	if parameters.Kind != yaml.SequenceNode || hasNamedParameter(parameters, "groupId") {
+		return
+	}
+	parameters.Content = append([]*yaml.Node{groupIDParameter()}, parameters.Content...)
+}
+
+func hasNamedParameter(parameters *yaml.Node, name string) bool {
+	for _, parameter := range parameters.Content {
+		if parameter.Kind != yaml.MappingNode {
+			continue
+		}
+		nameNode, ok := mappingValue(parameter, "name")
+		if ok && nameNode.Value == name {
+			return true
+		}
+	}
+	return false
+}
+
+func groupIDParameter() *yaml.Node {
+	return mapping(
+		"name", scalar("groupId"),
+		"in", scalar("path"),
+		"required", boolScalar(true),
+		"schema", mapping("type", scalar("string")),
+		"description", scalar("Worker group ID."),
+	)
+}
+
+func unwrapCountedResponses(spec *yaml.Node) error {
+	root := documentMapping(spec)
+	paths, ok := mappingValue(root, "paths")
+	if !ok || paths.Kind != yaml.MappingNode {
+		return fmt.Errorf("spec paths mapping not found")
+	}
+	schemas, ok := lookupComponentsSchemas(root)
+	if !ok {
+		return fmt.Errorf("components schemas mapping not found")
+	}
+
+	for index := 0; index < len(paths.Content); index += 2 {
+		path := paths.Content[index].Value
+		pathItem := paths.Content[index+1]
+		if pathItem.Kind != yaml.MappingNode {
+			continue
+		}
+		for operationIndex := 0; operationIndex < len(pathItem.Content); operationIndex += 2 {
+			method := pathItem.Content[operationIndex].Value
+			if !httpMethods[method] {
+				continue
+			}
+			unwrapOperationCountedResponses(path, method, pathItem.Content[operationIndex+1], schemas)
+		}
+	}
+	return nil
+}
+
+func lookupComponentsSchemas(root *yaml.Node) (*yaml.Node, bool) {
+	components, ok := mappingValue(root, "components")
+	if !ok || components.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	schemas, ok := mappingValue(components, "schemas")
+	if !ok || schemas.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	return schemas, true
+}
+
+func unwrapOperationCountedResponses(path, method string, operation, schemas *yaml.Node) {
+	responses, ok := mappingValue(operation, "responses")
+	if !ok || responses.Kind != yaml.MappingNode {
+		return
+	}
+
+	for index := 0; index < len(responses.Content); index += 2 {
+		response := responses.Content[index+1]
+		content, ok := mappingValue(response, "content")
+		if !ok || content.Kind != yaml.MappingNode {
+			continue
+		}
+		for contentIndex := 0; contentIndex < len(content.Content); contentIndex += 2 {
+			mediaType := content.Content[contentIndex+1]
+			schema, ok := mappingValue(mediaType, "schema")
+			if ok {
+				unwrapCountedSchemaRef(mediaType, schema, schemas, countedResponseIsSingle(path, method, operation))
+			}
+		}
+	}
+}
+
+func unwrapCountedSchemaRef(mediaType, schema, schemas *yaml.Node, single bool) {
+	if schema.Kind != yaml.MappingNode {
+		return
+	}
+
+	ref, ok := mappingValue(schema, "$ref")
+	if !ok || ref.Kind != yaml.ScalarNode {
+		return
+	}
+
+	const countedPrefix = "#/components/schemas/Counted"
+	if !strings.HasPrefix(ref.Value, countedPrefix) {
+		return
+	}
+
+	schemaName := strings.TrimPrefix(ref.Value, "#/components/schemas/")
+	countedSchema, ok := mappingValue(schemas, schemaName)
+	if !ok {
+		return
+	}
+	itemsSchema, ok := countedItemsSchema(countedSchema)
+	if !ok {
+		return
+	}
+	if single {
+		setMappingValue(mediaType, scalar("schema"), cloneNode(itemsSchema))
+		return
+	}
+	setMappingValue(mediaType, scalar("schema"), arraySchema(itemsSchema))
+}
+
+func countedResponseIsSingle(path, method string, operation *yaml.Node) bool {
+	for _, key := range []string{
+		"x-terraform-resource",
+		"x-terraform-create",
+		"x-terraform-read",
+		"x-terraform-update",
+		"x-terraform-delete",
+	} {
+		if _, ok := mappingValue(operation, key); ok {
+			return true
+		}
+	}
+
+	if method != "get" {
+		return true
+	}
+
+	lastSegment := path[strings.LastIndex(path, "/")+1:]
+	return strings.HasPrefix(lastSegment, "{") && strings.HasSuffix(lastSegment, "}")
+}
+
+func countedItemsSchema(countedSchema *yaml.Node) (*yaml.Node, bool) {
+	properties, ok := mappingValue(countedSchema, "properties")
+	if !ok || properties.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	items, ok := mappingValue(properties, "items")
+	if !ok || items.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	itemSchema, ok := mappingValue(items, "items")
+	if !ok || itemSchema.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	return itemSchema, true
+}
+
+func documentMapping(root *yaml.Node) *yaml.Node {
+	if root.Kind == yaml.DocumentNode && len(root.Content) > 0 {
+		return root.Content[0]
+	}
+	return root
+}
+
+func mappingValue(node *yaml.Node, key string) (*yaml.Node, bool) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil, false
+	}
+	for index := 0; index < len(node.Content); index += 2 {
+		if node.Content[index].Value == key {
+			return node.Content[index+1], true
+		}
+	}
+	return nil, false
+}
+
+func setMappingValue(node, key, value *yaml.Node) {
+	for index := 0; index < len(node.Content); index += 2 {
+		if node.Content[index].Value == key.Value {
+			node.Content[index+1] = value
+			return
+		}
+	}
+	node.Content = append(node.Content, key, value)
+}
+
+func deleteMappingKey(node *yaml.Node, key string) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for index := 0; index < len(node.Content); index += 2 {
+		if node.Content[index].Value == key {
+			node.Content = append(node.Content[:index], node.Content[index+2:]...)
+			return
+		}
+	}
+}
+
+func mergeMapping(target, update *yaml.Node) {
+	if target.Kind != yaml.MappingNode || update.Kind != yaml.MappingNode {
+		*target = *cloneNode(update)
+		return
+	}
+
+	for index := 0; index < len(update.Content); index += 2 {
+		updateKey := update.Content[index]
+		updateValue := update.Content[index+1]
+		targetValue, ok := mappingValue(target, updateKey.Value)
+		if ok && targetValue.Kind == yaml.MappingNode && updateValue.Kind == yaml.MappingNode {
+			mergeMapping(targetValue, updateValue)
+			continue
+		}
+		setMappingValue(target, cloneNode(updateKey), cloneNode(updateValue))
+	}
+}
+
+func cloneNode(node *yaml.Node) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	copy := *node
+	copy.Content = make([]*yaml.Node, len(node.Content))
+	for index, child := range node.Content {
+		copy.Content[index] = cloneNode(child)
+	}
+	return &copy
+}
+
+func scalar(value string) *yaml.Node {
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: value}
+}
+
+func boolScalar(value bool) *yaml.Node {
+	if value {
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "true"}
+	}
+	return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!bool", Value: "false"}
+}
+
+func arraySchema(items *yaml.Node) *yaml.Node {
+	return mapping(
+		"type", scalar("array"),
+		"items", cloneNode(items),
+	)
+}
+
+func mapping(values ...any) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.MappingNode}
+	for index := 0; index < len(values); index += 2 {
+		key, ok := values[index].(string)
+		if !ok {
+			panic("mapping key must be string")
+		}
+		value, ok := values[index+1].(*yaml.Node)
+		if !ok {
+			panic("mapping value must be *yaml.Node")
+		}
+		node.Content = append(node.Content, scalar(key), value)
+	}
+	return node
+}

--- a/tools/merge-spec/main_test.go
+++ b/tools/merge-spec/main_test.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestRunPrefixesUnwrapsAndAppliesOverlay(t *testing.T) {
+	dir := t.TempDir()
+	input := filepath.Join(dir, "upstream-openapi.yml")
+	overlay := filepath.Join(dir, "terraform-overlay.yml")
+	output := filepath.Join(dir, "merged-spec.yml")
+
+	writeFile(t, input, `openapi: 3.1.0
+paths:
+  /system/certificates:
+    post:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CountedCertificate"
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CountedCertificate"
+  /system/certificates/{id}:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CountedCertificate"
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+  /system/strings:
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CountedString"
+  /master/groups:
+    get:
+      responses:
+        "200":
+          description: ok
+components:
+  schemas:
+    Certificate:
+      type: object
+      properties:
+        id:
+          type: string
+    CountedCertificate:
+      type: object
+      properties:
+        count:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Certificate"
+    CountedString:
+      type: object
+      properties:
+        count:
+          type: integer
+        items:
+          type: array
+          items:
+            type: string
+`)
+
+	writeFile(t, overlay, `actions:
+  - target: "$.paths./m/{groupId}/system/certificates.post"
+    update:
+      x-terraform-resource: true
+      x-terraform-resource-name: certificate
+  - target: "$.paths./m/{groupId}/system/certificates/{id}.get"
+    update:
+      x-terraform-read: certificate
+  - target: "$.components.schemas.Certificate.properties.id"
+    update:
+      x-terraform-force-new: true
+`)
+
+	if err := run(input, overlay, output); err != nil {
+		t.Fatalf("run returned error: %v", err)
+	}
+
+	merged := readFile(t, output)
+	assertContains(t, merged, "/m/{groupId}/system/certificates:")
+	assertContains(t, merged, "/m/{groupId}/system/strings:")
+	assertContains(t, merged, "/master/groups:")
+	assertNotContains(t, merged, "  /system/certificates:")
+	assertContains(t, merged, "name: groupId")
+	assertContains(t, merged, `$ref: "#/components/schemas/Certificate"`)
+	assertContains(t, merged, "type: string")
+	assertContains(t, merged, "x-terraform-resource-name: certificate")
+	assertContains(t, merged, "x-terraform-force-new: true")
+	assertNotContains(t, merged, `$ref: "#/components/schemas/CountedCertificate"`)
+	assertNotContains(t, merged, `$ref: "#/components/schemas/CountedString"`)
+
+	outputNode, err := readYAML(output)
+	if err != nil {
+		t.Fatalf("failed to parse merged output: %v", err)
+	}
+	assertSchemaRef(t, outputNode, "$.paths./m/{groupId}/system/certificates.post.responses.200.content.application/json.schema", "#/components/schemas/Certificate")
+	assertSchemaRef(t, outputNode, "$.paths./m/{groupId}/system/certificates/{id}.get.responses.200.content.application/json.schema", "#/components/schemas/Certificate")
+	assertArrayItemsRef(t, outputNode, "$.paths./m/{groupId}/system/certificates.get.responses.200.content.application/json.schema", "#/components/schemas/Certificate")
+	assertArrayItemsType(t, outputNode, "$.paths./m/{groupId}/system/strings.get.responses.200.content.application/json.schema", "string")
+}
+
+func writeFile(t *testing.T, filename, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(filename, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", filename, err)
+	}
+}
+
+func readFile(t *testing.T, filename string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", filename, err)
+	}
+	return string(content)
+}
+
+func assertContains(t *testing.T, s, want string) {
+	t.Helper()
+
+	if !strings.Contains(s, want) {
+		t.Fatalf("expected output to contain %q", want)
+	}
+}
+
+func assertNotContains(t *testing.T, s, want string) {
+	t.Helper()
+
+	if strings.Contains(s, want) {
+		t.Fatalf("expected output not to contain %q", want)
+	}
+}
+
+func assertSchemaRef(t *testing.T, root *yaml.Node, target, want string) {
+	t.Helper()
+
+	schema, err := lookupTarget(documentMapping(root), target)
+	if err != nil {
+		t.Fatalf("failed to look up %s: %v", target, err)
+	}
+	ref, ok := mappingValue(schema, "$ref")
+	if !ok {
+		t.Fatalf("%s missing $ref, expected %q", target, want)
+	}
+	if ref.Value != want {
+		t.Fatalf("%s $ref = %q, expected %q", target, ref.Value, want)
+	}
+}
+
+func assertArrayItemsRef(t *testing.T, root *yaml.Node, target, want string) {
+	t.Helper()
+
+	items := assertArraySchema(t, root, target)
+	ref, ok := mappingValue(items, "$ref")
+	if !ok {
+		t.Fatalf("%s items missing $ref, expected %q", target, want)
+	}
+	if ref.Value != want {
+		t.Fatalf("%s items $ref = %q, expected %q", target, ref.Value, want)
+	}
+}
+
+func assertArrayItemsType(t *testing.T, root *yaml.Node, target, want string) {
+	t.Helper()
+
+	items := assertArraySchema(t, root, target)
+	typ, ok := mappingValue(items, "type")
+	if !ok {
+		t.Fatalf("%s items missing type, expected %q", target, want)
+	}
+	if typ.Value != want {
+		t.Fatalf("%s items type = %q, expected %q", target, typ.Value, want)
+	}
+}
+
+func assertArraySchema(t *testing.T, root *yaml.Node, target string) *yaml.Node {
+	t.Helper()
+
+	schema, err := lookupTarget(documentMapping(root), target)
+	if err != nil {
+		t.Fatalf("failed to look up %s: %v", target, err)
+	}
+	typ, ok := mappingValue(schema, "type")
+	if !ok {
+		t.Fatalf("%s missing type, expected array", target)
+	}
+	if typ.Value != "array" {
+		t.Fatalf("%s type = %q, expected array", target, typ.Value)
+	}
+	items, ok := mappingValue(schema, "items")
+	if !ok {
+		t.Fatalf("%s missing items schema", target)
+	}
+	return items
+}


### PR DESCRIPTION
- Added internal/restclient with typed HTTP helpers, auth handling, gateway routing, envelope unwrap, and API error types.
- Added tools/merge-spec to apply terraform-overlay.yml, prefix group-scoped paths, and unwrap Counted* responses.
- Added initial root terraform-overlay.yml certificate annotations and make merge.
- Updated .gitignore and make unit-test so generated specs stay untracked and new tests run in CI.

**Testing:**
```
go test ./internal/restclient/...
go test ./tools/merge-spec/...
go build ./tools/merge-spec/...
make merge
go build ./...
make unit-test
```


Also verified generated merged-spec.yml contains:

- /m/{groupId}/system/certificates
- unwrapped Certificate response refs
- certificate x-terraform-* overlay annotations