### PR TITLE
release(1.23.35): update docs/index for new release

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.23.34"
+      version = "1.23.35"
     }
   }
 }


### PR DESCRIPTION
bump `docs/index.md` before tagging and triggering a new release