### PR TITLE
hardening auth package on concurrent token requests.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/zclconf/go-cty v1.18.1
 	go.yaml.in/yaml/v3 v3.0.4
+	golang.org/x/sync v0.20.0
 	gopkg.in/ini.v1 v1.67.2
 )
 
@@ -76,7 +77,6 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -3,6 +3,8 @@ package auth
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,27 +12,40 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/criblio/terraform-provider-criblio/internal/useragent"
 	"github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
 	defaultCloudDomain = "cribl.cloud"
 	tokenExpiryBuffer  = 30 * time.Second
 	onPremTokenTTL     = time.Hour
+	tokenRetryMax      = 5
+	maxErrorBodyLength = 512
 )
 
 var (
-	tokenCache sync.Map
-	timeNow    = time.Now
+	sensitiveTextPattern = regexp.MustCompile(`(?i)\b(client[_-]?secret|password|access[_-]?token|refresh[_-]?token|token)(\s*[:=]\s*)([^&\s,;]+)`)
+	tokenFetchTimeout    = 30 * time.Second
+	tokenRetryWaitMin    = 500 * time.Millisecond
+	tokenRetryWaitMax    = 1500 * time.Millisecond
+	tokenBackoffCap      = 5 * time.Second
+	tokenCache           sync.Map
+	tokenFetchGroup      singleflight.Group
+	timeNow              = time.Now
 )
 
 // GetToken returns an OAuth2 or on-prem auth token for the given config.
 func GetToken(ctx context.Context, config *CriblConfig) (string, error) {
+	if ctx == nil {
+		return "", fmt.Errorf("context is required for authentication")
+	}
 	if config == nil {
 		return "", fmt.Errorf("config is required for authentication")
 	}
@@ -40,25 +55,77 @@ func GetToken(ctx context.Context, config *CriblConfig) (string, error) {
 		return "", err
 	}
 
-	if cached, ok := tokenCache.Load(key); ok {
-		tokenInfo, ok := cached.(*TokenInfo)
-		if ok && tokenInfo.ExpiresAt.After(timeNow().Add(tokenExpiryBuffer)) {
-			return tokenInfo.Token, nil
-		}
+	if tokenInfo, ok := loadCachedToken(key); ok {
+		return tokenInfo.Token, nil
 	}
 
-	var tokenInfo *TokenInfo
+	ch := tokenFetchGroup.DoChan(key, func() (interface{}, error) {
+		if tokenInfo, ok := loadCachedToken(key); ok {
+			return tokenInfo, nil
+		}
+
+		fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), tokenFetchTimeout)
+		defer cancel()
+
+		tokenInfo, err := fetchToken(fetchCtx, config)
+		if err != nil {
+			return nil, err
+		}
+
+		tokenCache.Store(key, tokenInfo)
+		return tokenInfo, nil
+	})
+
+	var result interface{}
+	select {
+	case call := <-ch:
+		if call.Err != nil {
+			return "", call.Err
+		}
+		result = call.Val
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+	tokenInfo, ok := result.(*TokenInfo)
+	if !ok || tokenInfo == nil {
+		return "", fmt.Errorf("failed to fetch token: unexpected cache value")
+	}
+	return tokenInfo.Token, nil
+}
+
+func validCachedToken(cached interface{}) (*TokenInfo, bool) {
+	tokenInfo, ok := cached.(*TokenInfo)
+	if !ok || tokenInfo == nil {
+		return nil, false
+	}
+	if tokenInfo.Token == "" {
+		return nil, false
+	}
+	return tokenInfo, tokenInfo.ExpiresAt.After(timeNow().Add(tokenExpiryBuffer))
+}
+
+func loadCachedToken(key string) (*TokenInfo, bool) {
+	cached, ok := tokenCache.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return validCachedToken(cached)
+}
+
+func fetchToken(ctx context.Context, config *CriblConfig) (*TokenInfo, error) {
+	var (
+		tokenInfo *TokenInfo
+		err       error
+	)
 	if IsOnPrem(config) {
 		tokenInfo, err = getOnPremBearerToken(ctx, config)
 	} else {
 		tokenInfo, err = getCloudBearerToken(ctx, config)
 	}
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
-	tokenCache.Store(key, tokenInfo)
-	return tokenInfo.Token, nil
+	return tokenInfo, nil
 }
 
 // IsOnPrem reports whether config indicates an on-prem deployment.
@@ -88,6 +155,23 @@ func InvalidateToken(config *CriblConfig) {
 	tokenCache.Delete(key)
 }
 
+// InvalidateTokenValue removes the cached token for config only when it matches token.
+func InvalidateTokenValue(config *CriblConfig, token string) {
+	key, err := tokenCacheKey(config)
+	if err != nil {
+		return
+	}
+	cached, ok := tokenCache.Load(key)
+	if !ok {
+		return
+	}
+	tokenInfo, ok := cached.(*TokenInfo)
+	if !ok || tokenInfo == nil || tokenInfo.Token != token {
+		return
+	}
+	tokenCache.CompareAndDelete(key, tokenInfo)
+}
+
 // RefreshToken invalidates the cached token for config and fetches a fresh token.
 func RefreshToken(ctx context.Context, config *CriblConfig) (string, error) {
 	InvalidateToken(config)
@@ -102,12 +186,29 @@ func tokenCacheKey(config *CriblConfig) (string, error) {
 		if config.OnpremUsername == "" || config.OnpremPassword == "" {
 			return "", fmt.Errorf("on-prem authentication requires username and password")
 		}
-		return fmt.Sprintf("onprem:%s:%s:%s", config.OnpremServerURL, config.OnpremUsername, config.OnpremPassword), nil
+		return "onprem:" + cacheDigest(normalizedServerURL(config.OnpremServerURL), config.OnpremUsername, config.OnpremPassword), nil
 	}
 	if config.ClientID == "" || config.ClientSecret == "" {
 		return "", fmt.Errorf("cloud authentication requires client ID and client secret")
 	}
-	return fmt.Sprintf("%s:%s", config.ClientID, config.ClientSecret), nil
+	authURL, _, _, err := cloudAuthSettings(cloudDomain(config))
+	if err != nil {
+		return "", err
+	}
+	return "cloud:" + cacheDigest(authURL, config.ClientID, config.ClientSecret), nil
+}
+
+func cacheDigest(parts ...string) string {
+	hash := sha256.New()
+	for _, part := range parts {
+		_, _ = hash.Write([]byte(part))
+		_, _ = hash.Write([]byte{0})
+	}
+	return hex.EncodeToString(hash.Sum(nil))
+}
+
+func normalizedServerURL(serverURL string) string {
+	return strings.TrimRight(serverURL, "/")
 }
 
 func cloudDomain(config *CriblConfig) string {
@@ -122,7 +223,7 @@ func cloudDomain(config *CriblConfig) string {
 }
 
 func getOnPremBearerToken(ctx context.Context, config *CriblConfig) (*TokenInfo, error) {
-	authURL := fmt.Sprintf("%s/api/v1/auth/login", strings.TrimRight(config.OnpremServerURL, "/"))
+	authURL := fmt.Sprintf("%s/api/v1/auth/login", normalizedServerURL(config.OnpremServerURL))
 	log.Printf("[DEBUG] Getting on-prem bearer token from: %s", authURL)
 
 	requestBody := map[string]string{
@@ -147,9 +248,16 @@ func getOnPremBearerToken(ctx context.Context, config *CriblConfig) (*TokenInfo,
 	if err := json.Unmarshal(responseBody, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %v", err)
 	}
+	if result.ForcePasswordChange {
+		return nil, fmt.Errorf("on-prem authentication requires password change")
+	}
 
+	token := strings.TrimPrefix(result.Token, "Bearer ")
+	if token == "" {
+		return nil, fmt.Errorf("on-prem authentication response did not include a token")
+	}
 	return &TokenInfo{
-		Token:     strings.TrimPrefix(result.Token, "Bearer "),
+		Token:     token,
 		ExpiresAt: timeNow().Add(onPremTokenTTL),
 	}, nil
 }
@@ -198,6 +306,12 @@ func getCloudBearerToken(ctx context.Context, config *CriblConfig) (*TokenInfo, 
 	}
 	if err := json.Unmarshal(responseBody, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %v", err)
+	}
+	if result.AccessToken == "" {
+		return nil, fmt.Errorf("cloud authentication response did not include an access token")
+	}
+	if result.ExpiresIn <= 0 {
+		return nil, fmt.Errorf("cloud authentication response included invalid expires_in=%d", result.ExpiresIn)
 	}
 
 	return &TokenInfo{
@@ -266,18 +380,16 @@ func localBaseURL(input string) (string, bool, error) {
 }
 
 func doTokenRequest(ctx context.Context, method, requestURL, contentType string, body []byte) ([]byte, error) {
+	attempts := 0
 	retryClient := retryablehttp.NewClient()
-	retryClient.RetryMax = 3
-	retryClient.RetryWaitMin = 500 * time.Millisecond
-	retryClient.RetryWaitMax = 5 * time.Second
-	retryClient.Backoff = retryablehttp.DefaultBackoff
+	retryClient.RetryMax = tokenRetryMax
+	retryClient.RetryWaitMin = tokenRetryWaitMin
+	retryClient.RetryWaitMax = tokenRetryWaitMax
+	retryClient.Backoff = tokenBackoff
 	retryClient.Logger = &retryableLogger{}
-	retryClient.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
-		if resp != nil && resp.StatusCode == http.StatusTooManyRequests {
-			log.Printf("[DEBUG] 429 Too Many Requests, will retry")
-			return true, nil
-		}
-		return retryablehttp.DefaultRetryPolicy(ctx, resp, err)
+	retryClient.CheckRetry = tokenRetryPolicy
+	retryClient.RequestLogHook = func(_ retryablehttp.Logger, _ *http.Request, attempt int) {
+		attempts = attempt + 1
 	}
 
 	req, err := retryablehttp.NewRequest(method, requestURL, bytes.NewReader(body))
@@ -289,8 +401,11 @@ func doTokenRequest(ctx context.Context, method, requestURL, contentType string,
 	req.Header.Set("User-Agent", useragent.TerraformProvider)
 
 	resp, err := retryClient.Do(req)
+	if attempts == 0 {
+		attempts = 1
+	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to make request with retry: %v", err)
+		return nil, fmt.Errorf("failed to make token request after %d attempt(s): %s %s: %v", attempts, method, sanitizedRequestURL(requestURL), err)
 	}
 	defer resp.Body.Close()
 
@@ -303,7 +418,111 @@ func doTokenRequest(ctx context.Context, method, requestURL, contentType string,
 		return responseBody, nil
 	}
 
-	return nil, fmt.Errorf("failed to do request: status=%d, body=%s", resp.StatusCode, string(responseBody))
+	return nil, fmt.Errorf("token request failed after %d attempt(s): %s %s: status=%d body=%s", attempts, method, sanitizedRequestURL(requestURL), resp.StatusCode, conciseBody(responseBody))
+}
+
+func tokenRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+	if err != nil {
+		shouldRetry, retryErr := retryablehttp.ErrorPropagatedRetryPolicy(ctx, resp, err)
+		if retryErr != nil {
+			return false, retryErr
+		}
+		return shouldRetry, nil
+	}
+	if resp == nil {
+		return false, nil
+	}
+	switch resp.StatusCode {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests:
+		return true, nil
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden:
+		return false, nil
+	}
+	if resp.StatusCode >= 500 && resp.StatusCode != http.StatusNotImplemented {
+		return true, nil
+	}
+	return false, nil
+}
+
+func tokenBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+	wait := retryablehttp.RateLimitLinearJitterBackoff(min, max, attemptNum, resp)
+	if wait > tokenBackoffCap {
+		return tokenBackoffCap
+	}
+	return wait
+}
+
+func sanitizedRequestURL(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return "<invalid-url>"
+	}
+	parsedURL.RawQuery = ""
+	parsedURL.User = nil
+	return parsedURL.String()
+}
+
+func conciseBody(body []byte) string {
+	value := strings.TrimSpace(string(body))
+	if redacted, ok := redactedJSONBody([]byte(value)); ok {
+		value = redacted
+	} else {
+		value = redactSensitiveText(value)
+	}
+	if len(value) > maxErrorBodyLength {
+		return value[:maxErrorBodyLength] + "...(truncated)"
+	}
+	if value == "" {
+		return "<empty>"
+	}
+	return value
+}
+
+func redactSensitiveText(value string) string {
+	return sensitiveTextPattern.ReplaceAllString(value, `${1}${2}(sensitive)`)
+}
+
+func redactedJSONBody(body []byte) (string, bool) {
+	if len(body) == 0 {
+		return "", false
+	}
+	var value interface{}
+	if err := json.Unmarshal(body, &value); err != nil {
+		return "", false
+	}
+	redactJSONValue(value)
+	redacted, err := json.Marshal(value)
+	if err != nil {
+		return "", false
+	}
+	return string(redacted), true
+}
+
+func redactJSONValue(value interface{}) {
+	switch typed := value.(type) {
+	case map[string]interface{}:
+		for key, child := range typed {
+			if isSensitiveResponseKey(key) {
+				typed[key] = "(sensitive)"
+				continue
+			}
+			redactJSONValue(child)
+		}
+	case []interface{}:
+		for _, child := range typed {
+			redactJSONValue(child)
+		}
+	}
+}
+
+func isSensitiveResponseKey(key string) bool {
+	lowerKey := strings.ToLower(key)
+	return strings.Contains(lowerKey, "token") ||
+		strings.Contains(lowerKey, "secret") ||
+		strings.Contains(lowerKey, "password")
 }
 
 type retryableLogger struct{}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -242,14 +242,10 @@ func getOnPremBearerToken(ctx context.Context, config *CriblConfig) (*TokenInfo,
 	}
 
 	var result struct {
-		Token               string `json:"token"`
-		ForcePasswordChange bool   `json:"forcePasswordChange"`
+		Token string `json:"token"`
 	}
 	if err := json.Unmarshal(responseBody, &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response: %v", err)
-	}
-	if result.ForcePasswordChange {
-		return nil, fmt.Errorf("on-prem authentication requires password change")
 	}
 
 	token := strings.TrimPrefix(result.Token, "Bearer ")

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -802,10 +802,6 @@ func TestInvalidTokenResponsesAreNotCached(t *testing.T) {
 			name:      "empty on-prem token",
 			firstBody: `{"token":"","forcePasswordChange":false}`,
 		},
-		{
-			name:      "password change required",
-			firstBody: `{"token":"token","forcePasswordChange":true}`,
-		},
 	}
 
 	for _, test := range testCases {
@@ -843,6 +839,37 @@ func TestInvalidTokenResponsesAreNotCached(t *testing.T) {
 				t.Fatalf("request count = %d, expected 2", requestCount)
 			}
 		})
+	}
+}
+
+func TestOnPremTokenAllowsForcePasswordChangeWhenTokenPresent(t *testing.T) {
+	ClearTokenCache()
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"password-change-token","forcePasswordChange":true}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	}
+
+	for range 2 {
+		token, err := GetToken(context.Background(), config)
+		if err != nil {
+			t.Fatalf("GetToken returned error: %v", err)
+		}
+		if token != "password-change-token" {
+			t.Fatalf("token = %q, expected password-change-token", token)
+		}
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, expected cached token after first login", requestCount)
 	}
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -3,12 +3,16 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/criblio/terraform-provider-criblio/internal/useragent"
 )
@@ -334,6 +338,179 @@ func TestTokenCacheHit(t *testing.T) {
 	}
 }
 
+func TestGetTokenOnPremConcurrentSingleflight(t *testing.T) {
+	ClearTokenCache()
+
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"concurrent-token","forcePasswordChange":false}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 25)
+	for range 25 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			token, err := GetToken(context.Background(), config)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if token != "concurrent-token" {
+				errs <- fmt.Errorf("token = %q, expected concurrent-token", token)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent GetToken returned error: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Fatalf("login request count = %d, expected 1", got)
+	}
+}
+
+func TestOnPremCacheKeyNormalizesTrailingSlash(t *testing.T) {
+	ClearTokenCache()
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"normalized-token","forcePasswordChange":false}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	}
+	slashedConfig := &CriblConfig{
+		OnpremServerURL: server.URL + "/",
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	}
+
+	if _, err := GetToken(context.Background(), config); err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if _, err := GetToken(context.Background(), slashedConfig); err != nil {
+		t.Fatalf("GetToken with trailing slash returned error: %v", err)
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, expected 1", requestCount)
+	}
+}
+
+func TestOnPremCacheKeySeparatesCredentials(t *testing.T) {
+	ClearTokenCache()
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		var requestBody struct {
+			Username string `json:"username"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&requestBody); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"` + requestBody.Username + `-token","forcePasswordChange":false}`))
+	}))
+	defer server.Close()
+
+	first, err := GetToken(context.Background(), &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "first",
+		OnpremPassword:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("first GetToken returned error: %v", err)
+	}
+	second, err := GetToken(context.Background(), &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "second",
+		OnpremPassword:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("second GetToken returned error: %v", err)
+	}
+
+	if first != "first-token" {
+		t.Fatalf("first token = %q, expected first-token", first)
+	}
+	if second != "second-token" {
+		t.Fatalf("second token = %q, expected second-token", second)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, expected 2", requestCount)
+	}
+}
+
+func TestCloudCacheKeySeparatesDomains(t *testing.T) {
+	ClearTokenCache()
+	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+	firstCount := 0
+	firstServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		firstCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"first-domain-token","expires_in":3600}`))
+	}))
+	defer firstServer.Close()
+
+	secondCount := 0
+	secondServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		secondCount++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":"second-domain-token","expires_in":3600}`))
+	}))
+	defer secondServer.Close()
+
+	first, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  firstServer.URL,
+	})
+	if err != nil {
+		t.Fatalf("first GetToken returned error: %v", err)
+	}
+	second, err := GetToken(context.Background(), &CriblConfig{
+		ClientID:     "client-id",
+		ClientSecret: "client-secret",
+		CloudDomain:  secondServer.URL,
+	})
+	if err != nil {
+		t.Fatalf("second GetToken returned error: %v", err)
+	}
+
+	if first != "first-domain-token" {
+		t.Fatalf("first token = %q, expected first-domain-token", first)
+	}
+	if second != "second-domain-token" {
+		t.Fatalf("second token = %q, expected second-domain-token", second)
+	}
+	if firstCount != 1 || secondCount != 1 {
+		t.Fatalf("request counts = %d, %d; expected 1, 1", firstCount, secondCount)
+	}
+}
+
 func TestTokenCacheExpiry(t *testing.T) {
 	ClearTokenCache()
 	t.Setenv("CRIBL_CLOUD_DOMAIN", "")
@@ -419,8 +596,28 @@ func TestTokenCacheCloudKeyMatchesHook(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tokenCacheKey returned error: %v", err)
 	}
-	if key != "client-id:client-secret" {
-		t.Fatalf("cloud cache key = %q, expected current hook format", key)
+	if strings.Contains(key, "client-id") || strings.Contains(key, "client-secret") {
+		t.Fatalf("cloud cache key = %q, expected no raw credential material", key)
+	}
+	if !strings.HasPrefix(key, "cloud:") {
+		t.Fatalf("cloud cache key = %q, expected cloud prefix", key)
+	}
+}
+
+func TestTokenCacheOnPremKeyDoesNotExposeCredentials(t *testing.T) {
+	key, err := tokenCacheKey(&CriblConfig{
+		OnpremServerURL: "https://example.local",
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("tokenCacheKey returned error: %v", err)
+	}
+	if strings.Contains(key, "admin") || strings.Contains(key, "secret") || strings.Contains(key, "example.local") {
+		t.Fatalf("on-prem cache key = %q, expected no raw credential material", key)
+	}
+	if !strings.HasPrefix(key, "onprem:") {
+		t.Fatalf("on-prem cache key = %q, expected onprem prefix", key)
 	}
 }
 
@@ -452,6 +649,35 @@ func TestInvalidateToken(t *testing.T) {
 
 	if requestCount != 2 {
 		t.Fatalf("request count = %d, expected 2", requestCount)
+	}
+}
+
+func TestInvalidateTokenValueOnlyRemovesMatchingToken(t *testing.T) {
+	ClearTokenCache()
+
+	key, err := tokenCacheKey(&CriblConfig{
+		OnpremServerURL: "https://example.local",
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("tokenCacheKey returned error: %v", err)
+	}
+	config := &CriblConfig{
+		OnpremServerURL: "https://example.local",
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	}
+
+	tokenCache.Store(key, &TokenInfo{Token: "fresh-token", ExpiresAt: timeNow().Add(time.Hour)})
+	InvalidateTokenValue(config, "stale-token")
+	if _, ok := loadCachedToken(key); !ok {
+		t.Fatal("InvalidateTokenValue removed non-matching token")
+	}
+
+	InvalidateTokenValue(config, "fresh-token")
+	if _, ok := loadCachedToken(key); ok {
+		t.Fatal("InvalidateTokenValue kept matching token")
 	}
 }
 
@@ -508,6 +734,277 @@ func TestTokenNon200Error(t *testing.T) {
 	}
 }
 
+func TestTokenRequestRetriesTransientFailures(t *testing.T) {
+	ClearTokenCache()
+	fastTokenRetry(t)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount < 3 {
+			http.Error(w, "temporary", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"retry-token","forcePasswordChange":false}`))
+	}))
+	defer server.Close()
+
+	token, err := GetToken(context.Background(), &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err != nil {
+		t.Fatalf("GetToken returned error: %v", err)
+	}
+	if token != "retry-token" {
+		t.Fatalf("token = %q, expected retry-token", token)
+	}
+	if requestCount != 3 {
+		t.Fatalf("request count = %d, expected 3", requestCount)
+	}
+}
+
+func TestTokenRequestDoesNotRetryUnauthorized(t *testing.T) {
+	ClearTokenCache()
+	fastTokenRetry(t)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		http.Error(w, "invalid credentials", http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	_, err := GetToken(context.Background(), &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err == nil {
+		t.Fatal("GetToken returned nil error, expected unauthorized error")
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, expected 1", requestCount)
+	}
+	if !strings.Contains(err.Error(), "after 1 attempt") {
+		t.Fatalf("error = %q, expected actual attempt count", err.Error())
+	}
+}
+
+func TestInvalidTokenResponsesAreNotCached(t *testing.T) {
+	testCases := []struct {
+		name      string
+		firstBody string
+	}{
+		{
+			name:      "empty on-prem token",
+			firstBody: `{"token":"","forcePasswordChange":false}`,
+		},
+		{
+			name:      "password change required",
+			firstBody: `{"token":"token","forcePasswordChange":true}`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			ClearTokenCache()
+
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.WriteHeader(http.StatusOK)
+				if requestCount == 1 {
+					_, _ = w.Write([]byte(test.firstBody))
+					return
+				}
+				_, _ = w.Write([]byte(`{"token":"valid-token","forcePasswordChange":false}`))
+			}))
+			defer server.Close()
+
+			config := &CriblConfig{
+				OnpremServerURL: server.URL,
+				OnpremUsername:  "admin",
+				OnpremPassword:  "secret",
+			}
+			if _, err := GetToken(context.Background(), config); err == nil {
+				t.Fatal("first GetToken returned nil error, expected invalid response error")
+			}
+			token, err := GetToken(context.Background(), config)
+			if err != nil {
+				t.Fatalf("second GetToken returned error: %v", err)
+			}
+			if token != "valid-token" {
+				t.Fatalf("token = %q, expected valid-token", token)
+			}
+			if requestCount != 2 {
+				t.Fatalf("request count = %d, expected 2", requestCount)
+			}
+		})
+	}
+}
+
+func TestInvalidCloudTokenResponsesAreNotCached(t *testing.T) {
+	testCases := []struct {
+		name      string
+		firstBody string
+	}{
+		{
+			name:      "empty access token",
+			firstBody: `{"access_token":"","expires_in":3600}`,
+		},
+		{
+			name:      "invalid expiry",
+			firstBody: `{"access_token":"token","expires_in":0}`,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			ClearTokenCache()
+			t.Setenv("CRIBL_CLOUD_DOMAIN", "")
+
+			requestCount := 0
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount++
+				w.WriteHeader(http.StatusOK)
+				if requestCount == 1 {
+					_, _ = w.Write([]byte(test.firstBody))
+					return
+				}
+				_, _ = w.Write([]byte(`{"access_token":"valid-token","expires_in":3600}`))
+			}))
+			defer server.Close()
+
+			config := &CriblConfig{
+				ClientID:     "client-id",
+				ClientSecret: "client-secret",
+				CloudDomain:  server.URL,
+			}
+			if _, err := GetToken(context.Background(), config); err == nil {
+				t.Fatal("first GetToken returned nil error, expected invalid response error")
+			}
+			token, err := GetToken(context.Background(), config)
+			if err != nil {
+				t.Fatalf("second GetToken returned error: %v", err)
+			}
+			if token != "valid-token" {
+				t.Fatalf("token = %q, expected valid-token", token)
+			}
+			if requestCount != 2 {
+				t.Fatalf("request count = %d, expected 2", requestCount)
+			}
+		})
+	}
+}
+
+func TestTokenRequestRespectsContextCancellation(t *testing.T) {
+	ClearTokenCache()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "temporary", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := GetToken(ctx, &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err == nil {
+		t.Fatal("GetToken returned nil error, expected context cancellation")
+	}
+	if !strings.Contains(err.Error(), context.Canceled.Error()) {
+		t.Fatalf("error = %q, expected context cancellation", err.Error())
+	}
+}
+
+func TestSharedTokenFetchSurvivesLeadingCallerCancellation(t *testing.T) {
+	ClearTokenCache()
+
+	var requestCount int32
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		started <- struct{}{}
+		<-release
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token":"shared-token","forcePasswordChange":false}`))
+	}))
+	defer server.Close()
+
+	config := &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	}
+	leaderCtx, cancelLeader := context.WithCancel(context.Background())
+	leaderErr := make(chan error, 1)
+	go func() {
+		_, err := GetToken(leaderCtx, config)
+		leaderErr <- err
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for token request to start")
+	}
+
+	cancelLeader()
+	select {
+	case err := <-leaderErr:
+		if err == nil || !strings.Contains(err.Error(), context.Canceled.Error()) {
+			t.Fatalf("leader error = %v, expected context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for leader cancellation")
+	}
+
+	followerDone := make(chan struct{})
+	var followerToken string
+	var followerErr error
+	go func() {
+		defer close(followerDone)
+		followerToken, followerErr = GetToken(context.Background(), config)
+	}()
+
+	close(release)
+	select {
+	case <-followerDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for follower token")
+	}
+	if followerErr != nil {
+		t.Fatalf("follower GetToken returned error: %v", followerErr)
+	}
+	if followerToken != "shared-token" {
+		t.Fatalf("follower token = %q, expected shared-token", followerToken)
+	}
+	if got := atomic.LoadInt32(&requestCount); got != 1 {
+		t.Fatalf("request count = %d, expected 1 shared request", got)
+	}
+}
+
+func TestConciseBodyRedactsNonJSONSecrets(t *testing.T) {
+	body := []byte("client_secret=super-secret&password=hunter2 token:abc123 access_token=xyz")
+	got := conciseBody(body)
+
+	for _, leaked := range []string{"super-secret", "hunter2", "abc123", "xyz"} {
+		if strings.Contains(got, leaked) {
+			t.Fatalf("conciseBody leaked %q in %q", leaked, got)
+		}
+	}
+	if !strings.Contains(got, "(sensitive)") {
+		t.Fatalf("conciseBody = %q, expected redacted markers", got)
+	}
+}
+
 func TestIsOnPremAndIsGov(t *testing.T) {
 	if !IsOnPrem(&CriblConfig{OnpremServerURL: "http://localhost:9000"}) {
 		t.Fatal("IsOnPrem returned false, expected true")
@@ -521,4 +1018,20 @@ func TestIsOnPremAndIsGov(t *testing.T) {
 	if IsGov("cribl.cloud") {
 		t.Fatal("IsGov returned true, expected false")
 	}
+}
+
+func fastTokenRetry(t *testing.T) {
+	t.Helper()
+
+	oldMin := tokenRetryWaitMin
+	oldMax := tokenRetryWaitMax
+	oldCap := tokenBackoffCap
+	tokenRetryWaitMin = time.Millisecond
+	tokenRetryWaitMax = time.Millisecond
+	tokenBackoffCap = time.Millisecond
+	t.Cleanup(func() {
+		tokenRetryWaitMin = oldMin
+		tokenRetryWaitMax = oldMax
+		tokenBackoffCap = oldCap
+	})
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -188,8 +188,9 @@ func (p *CriblioProvider) Configure(ctx context.Context, req provider.ConfigureR
 		Transport:  http.DefaultTransport,
 	}
 
-	httpClient := http.DefaultClient
-	httpClient.Transport = NewProviderHTTPTransport(providerHTTPTransportOpts)
+	httpClient := &http.Client{
+		Transport: NewProviderHTTPTransport(providerHTTPTransportOpts),
+	}
 
 	restCredentials := providerRestCredentials(clientOauth, serverUrlParams, explicitServerUrlParams)
 

--- a/internal/restclient/client.go
+++ b/internal/restclient/client.go
@@ -208,7 +208,7 @@ func do(ctx context.Context, c *Client, method, path, contentType string, body [
 		return nil, fmt.Errorf("restclient client is required")
 	}
 
-	responseBody, statusCode, err := c.send(ctx, method, path, contentType, body)
+	responseBody, statusCode, token, err := c.send(ctx, method, path, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -216,18 +216,18 @@ func do(ctx context.Context, c *Client, method, path, contentType string, body [
 		return responseBody, responseError(path, statusCode, responseBody)
 	}
 
-	auth.InvalidateToken(c.credentials)
-	responseBody, statusCode, err = c.send(ctx, method, path, contentType, body)
+	auth.InvalidateTokenValue(c.credentials, token)
+	responseBody, statusCode, _, err = c.send(ctx, method, path, contentType, body)
 	if err != nil {
 		return nil, err
 	}
 	return responseBody, responseError(path, statusCode, responseBody)
 }
 
-func (c *Client) send(ctx context.Context, method, path, contentType string, body []byte) ([]byte, int, error) {
+func (c *Client) send(ctx context.Context, method, path, contentType string, body []byte) ([]byte, int, string, error) {
 	requestURL, err := c.requestURL(path)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, "", err
 	}
 
 	var reader io.Reader
@@ -237,7 +237,7 @@ func (c *Client) send(ctx context.Context, method, path, contentType string, bod
 
 	req, err := http.NewRequestWithContext(ctx, method, requestURL, reader)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to create request: %v", err)
+		return nil, 0, "", fmt.Errorf("failed to create request: %v", err)
 	}
 	if contentType != "" {
 		req.Header.Set("Content-Type", contentType)
@@ -249,22 +249,22 @@ func (c *Client) send(ctx context.Context, method, path, contentType string, bod
 
 	token, err := c.token(ctx)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, "", fmt.Errorf("failed to authenticate for %s %s: %v", method, path, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to send request: %v", err)
+		return nil, 0, "", fmt.Errorf("failed to send request: %v", err)
 	}
 	defer resp.Body.Close()
 
 	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, 0, fmt.Errorf("failed to read response body: %v", err)
+		return nil, 0, "", fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	return responseBody, resp.StatusCode, nil
+	return responseBody, resp.StatusCode, token, nil
 }
 
 func (c *Client) requestURL(path string) (string, error) {

--- a/internal/restclient/client_test.go
+++ b/internal/restclient/client_test.go
@@ -11,8 +11,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/criblio/terraform-provider-criblio/internal/auth"
 	"github.com/criblio/terraform-provider-criblio/internal/useragent"
 )
 
@@ -440,6 +443,139 @@ func TestAuthenticationRequired(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "authentication requires bearer token or credentials") {
 		t.Fatalf("error = %q, expected authentication message", err.Error())
+	}
+}
+
+func TestUnauthorizedInvalidatesTokenAndRetriesRequest(t *testing.T) {
+	auth.ClearTokenCache()
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	loginCount := 0
+	apiCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/auth/login":
+			loginCount++
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"token":"token-%d","forcePasswordChange":false}`, loginCount)))
+		case "/api/v1/system/certificates/cert-1":
+			apiCount++
+			switch r.Header.Get("Authorization") {
+			case "Bearer token-1":
+				http.Error(w, "stale token", http.StatusUnauthorized)
+			case "Bearer token-2":
+				writeJSON(t, w, testItem{ID: "cert-1", Name: "fresh-token"})
+			default:
+				t.Errorf("unexpected Authorization = %q", r.Header.Get("Authorization"))
+			}
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		Credentials: &auth.CriblConfig{
+			OnpremServerURL: server.URL,
+			OnpremUsername:  "admin",
+			OnpremPassword:  "secret",
+		},
+	})
+
+	got, err := Get[testItem](context.Background(), client, "/system/certificates/cert-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got.Name != "fresh-token" {
+		t.Fatalf("name = %q, expected fresh-token", got.Name)
+	}
+	if loginCount != 2 {
+		t.Fatalf("login count = %d, expected 2", loginCount)
+	}
+	if apiCount != 2 {
+		t.Fatalf("api count = %d, expected 2", apiCount)
+	}
+}
+
+func TestConcurrentUnauthorizedRefreshesTokenOnce(t *testing.T) {
+	auth.ClearTokenCache()
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+
+	var mu sync.Mutex
+	loginCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/auth/login":
+			mu.Lock()
+			loginCount++
+			token := "stale-token"
+			if loginCount > 1 {
+				token = "fresh-token"
+			}
+			mu.Unlock()
+			if token == "fresh-token" {
+				time.Sleep(50 * time.Millisecond)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"token":"%s","forcePasswordChange":false}`, token)))
+		case "/api/v1/system/certificates/cert-1":
+			switch r.Header.Get("Authorization") {
+			case "Bearer stale-token":
+				http.Error(w, "stale token", http.StatusUnauthorized)
+			case "Bearer fresh-token":
+				writeJSON(t, w, testItem{ID: "cert-1", Name: "fresh-token"})
+			default:
+				t.Errorf("unexpected Authorization = %q", r.Header.Get("Authorization"))
+			}
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	credentials := &auth.CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	}
+	if token, err := auth.GetToken(context.Background(), credentials); err != nil {
+		t.Fatalf("preload GetToken returned error: %v", err)
+	} else if token != "stale-token" {
+		t.Fatalf("preload token = %q, expected stale-token", token)
+	}
+
+	client := New(Config{Credentials: credentials})
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 20)
+	for range 20 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			got, err := Get[testItem](context.Background(), client, "/system/certificates/cert-1")
+			if err != nil {
+				errs <- err
+				return
+			}
+			if got.Name != "fresh-token" {
+				errs <- fmt.Errorf("name = %q, expected fresh-token", got.Name)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent Get returned error: %v", err)
+		}
+	}
+
+	mu.Lock()
+	gotLoginCount := loginCount
+	mu.Unlock()
+	if gotLoginCount != 2 {
+		t.Fatalf("login count = %d, expected 2", gotLoginCount)
 	}
 }
 


### PR DESCRIPTION
- Coalesced concurrent auth token fetches to prevent login stampedes during large plans/imports.
- Hardened token caching, retry behavior, stale-token invalidation, and auth error redaction.
- Preserved on-prem forcePasswordChange compatibility when a valid token is returned.