### PR TITLE
DOC-5234: Add Terraform code examples for core Cribl Stream use cases

### DIFF
--- a/docs/examples/example-cloud-create-resources/main.tf
+++ b/docs/examples/example-cloud-create-resources/main.tf
@@ -1,0 +1,133 @@
+# Create Worker Group
+resource "criblio_group" "example" {
+  id                    = var.worker_group_id
+  name                  = var.worker_group_id
+  product               = "stream"
+  on_prem               = false
+  is_fleet              = false
+  worker_remote_access  = true
+  estimated_ingest_rate = 2048 # Equivalent to 24 MB/s with 9 Worker Processes
+  provisioned           = false
+  cloud = {
+    provider = "aws"
+    region   = "us-east-1" # Replace with a different AWS region if desired
+  }
+}
+
+# Create Syslog Source
+resource "criblio_source" "syslog" {
+  id       = "in-syslog-9021"
+  group_id = criblio_group.example.id
+
+  input_syslog = {
+    id             = "in-syslog-9021"
+    type           = "syslog"
+    host           = "0.0.0.0"
+    tcp_port       = 9021 # Replace with a different port number if desired
+    disabled       = false
+    send_to_routes = true
+    tls = {
+      disabled = true
+    }
+  }
+
+  depends_on = [criblio_group.example]
+}
+
+# Create S3 Destination
+resource "criblio_destination" "s3" {
+  id       = "out_s3"
+  group_id = criblio_group.example.id
+
+  output_s3 = {
+    id                    = "out_s3"
+    type                  = "s3"
+    bucket                = var.aws_bucket_name
+    region                = var.aws_region
+    aws_api_key           = var.aws_api_key
+    aws_secret_key        = var.aws_secret_key
+    stage_path            = "/tmp/cribl_stage"
+    compress              = "gzip"
+    compression_level     = "best_speed"
+    empty_dir_cleanup_sec = 300
+  }
+
+  depends_on = [criblio_group.example]
+}
+
+# Create Pipeline
+resource "criblio_pipeline" "filter" {
+  id       = "my_pipeline"
+  group_id = criblio_group.example.id
+
+  conf = {
+    async_func_timeout = 1000
+    functions = [
+      {
+        id       = "eval"
+        filter   = "true"
+        disabled = false
+        final    = true
+        conf = jsonencode({
+          remove = ["*"]
+          keep   = ["eventSource", "eventID"]
+        })
+      }
+    ]
+  }
+
+  depends_on = [criblio_group.example]
+}
+
+# Create Routes
+resource "criblio_routes" "main" {
+  group_id = criblio_group.example.id
+  id       = "default" # Routing table ID (do not change; the supported value is default)
+
+  routes = [
+    {
+      name        = "your_route"              # Replace with the name of the Route
+      description = "This is my new Route"    # Replace with the desired Route description
+      pipeline    = criblio_pipeline.filter.id
+      output      = criblio_destination.s3.id
+      filter      = "__inputId=='in-syslog-9021'"
+      final       = true
+      disabled    = false
+    },
+    {
+      name     = "default"
+      pipeline = "main"
+      output   = "default"
+      filter   = "true"
+      final    = false
+      disabled = false
+    }
+  ]
+
+  depends_on = [
+    criblio_source.syslog,
+    criblio_destination.s3,
+    criblio_pipeline.filter,
+  ]
+}
+
+# Commit configuration
+resource "criblio_commit" "example" {
+  effective = true
+  group     = criblio_group.example.id
+  message   = "Commit for Cribl Stream example"
+
+  depends_on = [criblio_routes.main]
+}
+
+# Read config version
+data "criblio_config_version" "latest" {
+  id         = criblio_group.example.id
+  depends_on = [criblio_commit.example]
+}
+
+# Deploy configuration
+resource "criblio_deploy" "example" {
+  id      = criblio_group.example.id
+  version = data.criblio_config_version.latest.items[0]
+}

--- a/docs/examples/example-cloud-create-resources/provider.tf
+++ b/docs/examples/example-cloud-create-resources/provider.tf
@@ -1,0 +1,23 @@
+# Configure provider
+#
+# Authenticates for Cribl.Cloud using organization_id, workspace_id, client_id,
+# and client_secret declared in variables.tf. Supply their values in terraform.tfvars.
+#
+# For other authentication methods, see:
+# https://docs.cribl.io/cribl-as-code/terraform-auth/
+
+terraform {
+  required_providers {
+    criblio = {
+      source  = "criblio/criblio"
+      version = ">= 1.20.138"
+    }
+  }
+}
+
+provider "criblio" {
+  organization_id = var.organization_id
+  workspace_id    = var.workspace_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+}

--- a/docs/examples/example-cloud-create-resources/terraform.tfvars.example
+++ b/docs/examples/example-cloud-create-resources/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# Copy this file to terraform.tfvars and replace each placeholder with the value
+# for your Cribl.Cloud deployment. Do not commit terraform.tfvars to version control.
+
+organization_id = "your-organization-id"
+workspace_id    = "your-workspace-name"
+client_id       = "client-id-from-your-api-credential"
+client_secret   = "client-secret-from-your-api-credential"
+worker_group_id = "id-for-new-worker-group-must-not-already-exist"
+aws_api_key     = "your-aws-access-key-id"
+aws_secret_key  = "your-aws-secret-access-key"
+aws_bucket_name = "your-s3-bucket-name"
+aws_region      = "your-s3-bucket-region-such-as-us-east-2"

--- a/docs/examples/example-cloud-create-resources/variables.tf
+++ b/docs/examples/example-cloud-create-resources/variables.tf
@@ -1,0 +1,70 @@
+# User-supplied parameters
+#
+# Supply values for the declared variables in this file in terraform.tfvars.
+#
+# Required for Cribl.Cloud authentication:
+# - organization_id: Organization ID
+# - workspace_id: Workspace name
+# - client_id: Client ID for your API Credential
+# - client_secret: Client Secret for your API Credential
+#
+# Required for the Worker Group:
+# - worker_group_id: ID for the new Worker Group (must not already exist)
+#
+# Required for the S3 Destination:
+# - aws_api_key: AWS Access Key ID
+# - aws_secret_key: AWS Secret Access Key
+# - aws_bucket_name: S3 bucket name
+# - aws_region: S3 bucket region, such as us-east-2
+#
+# To create an API Credential, see:
+# https://docs.cribl.io/cribl-as-code/terraform-auth/#terraform-auth-cloud
+
+variable "organization_id" {
+  type        = string
+  description = "Cribl.Cloud Organization ID"
+}
+
+variable "workspace_id" {
+  type        = string
+  description = "Cribl.Cloud Workspace name"
+}
+
+variable "worker_group_id" {
+  type        = string
+  description = "ID for the new Worker Group. Must not already exist in your deployment."
+}
+
+variable "aws_api_key" {
+  type        = string
+  description = "AWS Access Key ID for the S3 Destination"
+  sensitive   = true
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS Secret Access Key for the S3 Destination"
+  sensitive   = true
+}
+
+variable "aws_bucket_name" {
+  type        = string
+  description = "S3 bucket name for the S3 Destination"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region for the S3 bucket, such as us-east-2"
+}
+
+variable "client_id" {
+  type        = string
+  description = "Client ID from your Cribl API Credential"
+  sensitive   = true
+}
+
+variable "client_secret" {
+  type        = string
+  description = "Client Secret from your Cribl API Credential"
+  sensitive   = true
+}

--- a/docs/examples/example-cloud-create-worker-group/main.tf
+++ b/docs/examples/example-cloud-create-worker-group/main.tf
@@ -1,0 +1,37 @@
+# Create Worker Group
+resource "criblio_group" "example" {
+  id                    = var.worker_group_id
+  name                  = "my-worker-group"
+  description           = "Cribl.Cloud Worker Group"
+  product               = "stream"
+  on_prem               = false
+  is_fleet              = false
+  worker_remote_access  = true
+  estimated_ingest_rate = 2048 # Equivalent to 24 MB/s with 9 Worker Processes
+  provisioned           = false
+  cloud = {
+    provider = "aws"
+    region   = "us-west-2"
+  }
+}
+
+# Commit configuration
+resource "criblio_commit" "example" {
+  effective = true
+  group     = criblio_group.example.id
+  message   = "Commit for create Worker Group example"
+
+  depends_on = [criblio_group.example]
+}
+
+# Read config version
+data "criblio_config_version" "latest" {
+  id         = criblio_group.example.id
+  depends_on = [criblio_commit.example]
+}
+
+# Deploy configuration
+resource "criblio_deploy" "example" {
+  id      = criblio_group.example.id
+  version = data.criblio_config_version.latest.items[0]
+}

--- a/docs/examples/example-cloud-create-worker-group/provider.tf
+++ b/docs/examples/example-cloud-create-worker-group/provider.tf
@@ -1,0 +1,23 @@
+# Configure provider
+#
+# Authenticates for Cribl.Cloud using organization_id, workspace_id, client_id,
+# and client_secret declared in variables.tf. Supply their values in terraform.tfvars.
+#
+# For other authentication methods, see:
+# https://docs.cribl.io/cribl-as-code/terraform-auth/
+
+terraform {
+  required_providers {
+    criblio = {
+      source  = "criblio/criblio"
+      version = ">= 1.20.138"
+    }
+  }
+}
+
+provider "criblio" {
+  organization_id = var.organization_id
+  workspace_id    = var.workspace_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+}

--- a/docs/examples/example-cloud-create-worker-group/terraform.tfvars.example
+++ b/docs/examples/example-cloud-create-worker-group/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy this file to terraform.tfvars and replace each placeholder with the value
+# for your Cribl.Cloud deployment. Do not commit terraform.tfvars to version control.
+
+organization_id = "your-organization-id"
+workspace_id    = "your-workspace-name"
+client_id       = "client-id-from-your-api-credential"
+client_secret   = "client-secret-from-your-api-credential"
+worker_group_id = "id-for-new-worker-group-must-not-already-exist"

--- a/docs/examples/example-cloud-create-worker-group/variables.tf
+++ b/docs/examples/example-cloud-create-worker-group/variables.tf
@@ -1,0 +1,42 @@
+# User-supplied parameters
+#
+# Supply values for the declared variables in this file in terraform.tfvars.
+#
+# Required for Cribl.Cloud authentication:
+# - organization_id: Organization ID
+# - workspace_id: Workspace name
+# - client_id: Client ID for your API Credential
+# - client_secret: Client Secret for your API Credential
+#
+# Required for the Worker Group:
+# - worker_group_id: ID for the new Worker Group (must not already exist)
+#
+# To create an API Credential, see:
+# https://docs.cribl.io/cribl-as-code/terraform-auth/#terraform-auth-cloud
+
+variable "organization_id" {
+  type        = string
+  description = "Cribl.Cloud Organization ID"
+}
+
+variable "workspace_id" {
+  type        = string
+  description = "Cribl.Cloud Workspace name"
+}
+
+variable "worker_group_id" {
+  type        = string
+  description = "ID for the new Worker Group. Must not already exist in your deployment."
+}
+
+variable "client_id" {
+  type        = string
+  description = "Client ID from your Cribl API Credential"
+  sensitive   = true
+}
+
+variable "client_secret" {
+  type        = string
+  description = "Client Secret from your Cribl API Credential"
+  sensitive   = true
+}

--- a/docs/examples/example-cloud-scale-worker-group/main.tf
+++ b/docs/examples/example-cloud-scale-worker-group/main.tf
@@ -1,0 +1,40 @@
+# Scale Worker Group
+#
+# Before first apply, import the existing Worker Group into Terraform state:
+#   terraform import criblio_group.example <worker_group_id>
+resource "criblio_group" "example" {
+  id                    = var.worker_group_id
+  name                  = var.worker_group_name
+  description           = var.worker_group_description
+  product               = "stream"
+  on_prem               = false
+  is_fleet              = false
+  worker_remote_access  = true
+  estimated_ingest_rate = 4096 # Equivalent to 48 MB/s with 21 Worker Processes
+  provisioned           = true
+  cloud = {
+    provider = var.cloud_provider
+    region   = var.cloud_region
+  }
+}
+
+# Commit configuration
+resource "criblio_commit" "example" {
+  effective = true
+  group     = criblio_group.example.id
+  message   = "Commit for scale Worker Group example"
+
+  depends_on = [criblio_group.example]
+}
+
+# Read config version
+data "criblio_config_version" "latest" {
+  id         = criblio_group.example.id
+  depends_on = [criblio_commit.example]
+}
+
+# Deploy configuration
+resource "criblio_deploy" "example" {
+  id      = criblio_group.example.id
+  version = data.criblio_config_version.latest.items[0]
+}

--- a/docs/examples/example-cloud-scale-worker-group/provider.tf
+++ b/docs/examples/example-cloud-scale-worker-group/provider.tf
@@ -1,0 +1,23 @@
+# Configure provider
+#
+# Authenticates for Cribl.Cloud using organization_id, workspace_id, client_id,
+# and client_secret declared in variables.tf. Supply their values in terraform.tfvars.
+#
+# For other authentication methods, see:
+# https://docs.cribl.io/cribl-as-code/terraform-auth/
+
+terraform {
+  required_providers {
+    criblio = {
+      source  = "criblio/criblio"
+      version = ">= 1.20.138"
+    }
+  }
+}
+
+provider "criblio" {
+  organization_id = var.organization_id
+  workspace_id    = var.workspace_id
+  client_id       = var.client_id
+  client_secret   = var.client_secret
+}

--- a/docs/examples/example-cloud-scale-worker-group/terraform.tfvars.example
+++ b/docs/examples/example-cloud-scale-worker-group/terraform.tfvars.example
@@ -1,0 +1,12 @@
+# Copy this file to terraform.tfvars and replace each placeholder with the value
+# for your Cribl.Cloud deployment. Do not commit terraform.tfvars to version control.
+
+organization_id          = "your-organization-id"
+workspace_id             = "your-workspace-name"
+client_id                = "client-id-from-your-api-credential"
+client_secret            = "client-secret-from-your-api-credential"
+worker_group_id          = "existing-worker-group-id-to-scale"
+worker_group_name        = "my-worker-group"
+worker_group_description = "Cribl.Cloud Worker Group"
+cloud_provider           = "aws"
+cloud_region             = "us-west-2"

--- a/docs/examples/example-cloud-scale-worker-group/variables.tf
+++ b/docs/examples/example-cloud-scale-worker-group/variables.tf
@@ -1,0 +1,66 @@
+# User-supplied parameters
+#
+# Supply values for the declared variables in this file in terraform.tfvars.
+#
+# Required for Cribl.Cloud authentication:
+# - organization_id: Organization ID
+# - workspace_id: Workspace name
+# - client_id: Client ID for your API Credential
+# - client_secret: Client Secret for your API Credential
+#
+# Required for the Worker Group:
+# - worker_group_id: ID of the existing Worker Group to scale
+# - worker_group_name: Name of the existing Worker Group
+# - worker_group_description: Description of the existing Worker Group
+# - cloud_provider: Cloud provider for the Worker Group (aws or azure)
+# - cloud_region: Cloud region for the Worker Group
+#
+# To create an API Credential, see:
+# https://docs.cribl.io/cribl-as-code/terraform-auth/#terraform-auth-cloud
+
+variable "organization_id" {
+  type        = string
+  description = "Cribl.Cloud Organization ID"
+}
+
+variable "workspace_id" {
+  type        = string
+  description = "Cribl.Cloud Workspace name"
+}
+
+variable "worker_group_id" {
+  type        = string
+  description = "ID of the existing Worker Group to scale."
+}
+
+variable "worker_group_name" {
+  type        = string
+  description = "Name of the existing Worker Group."
+}
+
+variable "worker_group_description" {
+  type        = string
+  description = "Description of the existing Worker Group."
+}
+
+variable "cloud_provider" {
+  type        = string
+  description = "Cloud provider for the Worker Group (aws or azure)."
+}
+
+variable "cloud_region" {
+  type        = string
+  description = "Cloud region for the Worker Group."
+}
+
+variable "client_id" {
+  type        = string
+  description = "Client ID from your Cribl API Credential"
+  sensitive   = true
+}
+
+variable "client_secret" {
+  type        = string
+  description = "Client Secret from your Cribl API Credential"
+  sensitive   = true
+}

--- a/docs/examples/example-onprem-create-resources/main.tf
+++ b/docs/examples/example-onprem-create-resources/main.tf
@@ -1,0 +1,128 @@
+# Create Worker Group
+resource "criblio_group" "example" {
+  id                   = var.worker_group_id
+  name                 = var.worker_group_id
+  product              = "stream"
+  on_prem              = true
+  is_fleet             = false
+  worker_remote_access = true
+  provisioned          = false
+}
+
+# Create Syslog Source
+resource "criblio_source" "syslog" {
+  id       = "in-syslog-9021"
+  group_id = criblio_group.example.id
+
+  input_syslog = {
+    id             = "in-syslog-9021"
+    type           = "syslog"
+    host           = "0.0.0.0"
+    tcp_port       = 9021 # Replace with a different port number if desired
+    disabled       = false
+    send_to_routes = true
+    tls = {
+      disabled = true
+    }
+  }
+
+  depends_on = [criblio_group.example]
+}
+
+# Create S3 Destination
+resource "criblio_destination" "s3" {
+  id       = "out_s3"
+  group_id = criblio_group.example.id
+
+  output_s3 = {
+    id                    = "out_s3"
+    type                  = "s3"
+    bucket                = var.aws_bucket_name
+    region                = var.aws_region
+    aws_api_key           = var.aws_api_key
+    aws_secret_key        = var.aws_secret_key
+    stage_path            = "/tmp/cribl_stage"
+    compress              = "gzip"
+    compression_level     = "best_speed"
+    empty_dir_cleanup_sec = 300
+  }
+
+  depends_on = [criblio_group.example]
+}
+
+# Create Pipeline
+resource "criblio_pipeline" "filter" {
+  id       = "my_pipeline"
+  group_id = criblio_group.example.id
+
+  conf = {
+    async_func_timeout = 1000
+    functions = [
+      {
+        id       = "eval"
+        filter   = "true"
+        disabled = false
+        final    = true
+        conf = jsonencode({
+          remove = ["*"]
+          keep   = ["eventSource", "eventID"]
+        })
+      }
+    ]
+  }
+
+  depends_on = [criblio_group.example]
+}
+
+# Create Routes
+resource "criblio_routes" "main" {
+  group_id = criblio_group.example.id
+  id       = "default" # Routing table ID (do not change; the supported value is default)
+
+  routes = [
+    {
+      name        = "your_route"              # Replace with the name of the Route
+      description = "This is my new Route"    # Replace with the desired Route description
+      pipeline    = criblio_pipeline.filter.id
+      output      = criblio_destination.s3.id
+      filter      = "__inputId=='in-syslog-9021'"
+      final       = true
+      disabled    = false
+    },
+    {
+      name     = "default"
+      pipeline = "main"
+      output   = "default"
+      filter   = "true"
+      final    = false
+      disabled = false
+    }
+  ]
+
+  depends_on = [
+    criblio_source.syslog,
+    criblio_destination.s3,
+    criblio_pipeline.filter,
+  ]
+}
+
+# Commit configuration
+resource "criblio_commit" "example" {
+  effective = true
+  group     = criblio_group.example.id
+  message   = "Commit for Cribl Stream example"
+
+  depends_on = [criblio_routes.main]
+}
+
+# Read config version
+data "criblio_config_version" "latest" {
+  id         = criblio_group.example.id
+  depends_on = [criblio_commit.example]
+}
+
+# Deploy configuration
+resource "criblio_deploy" "example" {
+  id      = criblio_group.example.id
+  version = data.criblio_config_version.latest.items[0]
+}

--- a/docs/examples/example-onprem-create-resources/provider.tf
+++ b/docs/examples/example-onprem-create-resources/provider.tf
@@ -1,0 +1,17 @@
+# Configure provider
+#
+# The provider block is empty. Configure authentication using
+# environment variables or a credentials file as described in
+# https://docs.cribl.io/cribl-as-code/terraform-auth/#terraform-auth-on-prem.
+
+terraform {
+  required_providers {
+    criblio = {
+      source  = "criblio/criblio"
+      version = ">= 1.20.138"
+    }
+  }
+}
+
+provider "criblio" {
+}

--- a/docs/examples/example-onprem-create-resources/terraform.tfvars.example
+++ b/docs/examples/example-onprem-create-resources/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy this file to terraform.tfvars and replace each placeholder with the value
+# for your on-prem deployment. Do not commit terraform.tfvars to version control.
+
+worker_group_id = "id-for-new-worker-group-must-not-already-exist"
+aws_api_key     = "your-aws-access-key-id"
+aws_secret_key  = "your-aws-secret-access-key"
+aws_bucket_name = "your-s3-bucket-name"
+aws_region      = "your-s3-bucket-region-such-as-us-east-2"

--- a/docs/examples/example-onprem-create-resources/variables.tf
+++ b/docs/examples/example-onprem-create-resources/variables.tf
@@ -1,0 +1,39 @@
+# User-supplied parameters
+#
+# Supply values for the declared variables in this file in terraform.tfvars.
+#
+# Required for the Worker Group:
+# - worker_group_id: ID for the new Worker Group (must not already exist)
+#
+# Required for the S3 Destination:
+# - aws_api_key: AWS Access Key ID
+# - aws_secret_key: AWS Secret Access Key
+# - aws_bucket_name: S3 bucket name
+# - aws_region: S3 bucket region, such as us-east-2
+
+variable "worker_group_id" {
+  type        = string
+  description = "ID for the new Worker Group. Must not already exist in your deployment."
+}
+
+variable "aws_api_key" {
+  type        = string
+  description = "AWS Access Key ID for the S3 Destination"
+  sensitive   = true
+}
+
+variable "aws_secret_key" {
+  type        = string
+  description = "AWS Secret Access Key for the S3 Destination"
+  sensitive   = true
+}
+
+variable "aws_bucket_name" {
+  type        = string
+  description = "S3 bucket name for the S3 Destination"
+}
+
+variable "aws_region" {
+  type        = string
+  description = "AWS region for the S3 bucket, such as us-east-2"
+}

--- a/docs/examples/example-onprem-create-worker-group/main.tf
+++ b/docs/examples/example-onprem-create-worker-group/main.tf
@@ -1,0 +1,32 @@
+# Create Worker Group
+resource "criblio_group" "example" {
+  id                   = var.worker_group_id
+  name                 = "my-worker-group"
+  description          = "My Worker Group description"
+  product              = "stream"
+  on_prem              = true
+  is_fleet             = false
+  worker_remote_access = true
+  provisioned          = false
+}
+
+# Commit configuration
+resource "criblio_commit" "example" {
+  effective = true
+  group     = criblio_group.example.id
+  message   = "Commit for create Worker Group example"
+
+  depends_on = [criblio_group.example]
+}
+
+# Read config version
+data "criblio_config_version" "latest" {
+  id         = criblio_group.example.id
+  depends_on = [criblio_commit.example]
+}
+
+# Deploy configuration
+resource "criblio_deploy" "example" {
+  id      = criblio_group.example.id
+  version = data.criblio_config_version.latest.items[0]
+}

--- a/docs/examples/example-onprem-create-worker-group/provider.tf
+++ b/docs/examples/example-onprem-create-worker-group/provider.tf
@@ -1,0 +1,17 @@
+# Configure provider
+#
+# The provider block is empty. Configure authentication using
+# environment variables or a credentials file as described in
+# https://docs.cribl.io/cribl-as-code/terraform-auth/#terraform-auth-on-prem.
+
+terraform {
+  required_providers {
+    criblio = {
+      source  = "criblio/criblio"
+      version = ">= 1.20.138"
+    }
+  }
+}
+
+provider "criblio" {
+}

--- a/docs/examples/example-onprem-create-worker-group/terraform.tfvars.example
+++ b/docs/examples/example-onprem-create-worker-group/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy this file to terraform.tfvars and replace each placeholder with the value
+# for your on-prem deployment. Do not commit terraform.tfvars to version control.
+
+worker_group_id = "id-for-new-worker-group-must-not-already-exist"

--- a/docs/examples/example-onprem-create-worker-group/variables.tf
+++ b/docs/examples/example-onprem-create-worker-group/variables.tf
@@ -1,0 +1,11 @@
+# User-supplied parameters
+#
+# Supply values for the declared variables in this file in terraform.tfvars.
+#
+# Required for the Worker Group:
+# - worker_group_id: ID for the new Worker Group (must not already exist)
+
+variable "worker_group_id" {
+  type        = string
+  description = "ID for the new Worker Group. Must not already exist in your deployment."
+}

--- a/docs/examples/example-onprem-scale-worker-group/main.tf
+++ b/docs/examples/example-onprem-scale-worker-group/main.tf
@@ -1,0 +1,134 @@
+# Scale Worker Process settings
+#
+# Before first apply, import existing system settings into Terraform state:
+#   terraform import criblio_group_system_settings.scaled <worker_group_id>
+#
+# Replace the placeholder values in the api, ssl, and other blocks with values
+# that match your deployment. The criblio_group_system_settings resource requires
+# a complete representation of system settings.
+resource "criblio_group_system_settings" "scaled" {
+  group_id = var.worker_group_id
+
+  api = {
+    base_url          = "https://leader.example.com:9000"
+    disable_api_cache = false
+    disabled          = false
+    host              = "leader.example.com"
+    idle_session_ttl  = 3600
+    listen_on_port    = true
+    login_rate_limit  = "5/minute"
+    port              = 9000
+    protocol          = "https"
+    scripts           = false
+    sensitive_fields = [
+      "password",
+      "apiKey",
+      "secret",
+    ]
+    ssl = {
+      ca_path       = "/etc/ssl/certs/ca-bundle.crt"
+      cert_path     = "/etc/cribl/ssl/server.crt"
+      disabled      = false
+      passphrase    = "changeit"
+      priv_key_path = "/etc/cribl/ssl/server.key"
+    }
+    sso_rate_limit       = "10/minute"
+    worker_remote_access = false
+  }
+
+  backups = {
+    backup_persistence = "local"
+    backups_directory  = "/var/cribl/backups"
+  }
+
+  custom_logo = {
+    enabled          = false
+    logo_description = ""
+    logo_image       = ""
+  }
+
+  pii = {
+    enable_pii_detection = true
+  }
+
+  proxy = {
+    use_env_vars = false
+  }
+
+  rollback = {
+    rollback_enabled = true
+    rollback_retries = 3
+    rollback_timeout = 600
+  }
+
+  shutdown = {
+    drain_timeout = 30
+  }
+
+  sni = {
+    disable_sni_routing = false
+  }
+
+  sockets = {
+    directory = "/var/run/cribl"
+  }
+
+  system = {
+    intercom = false
+    upgrade  = "api"
+  }
+
+  tls = {
+    default_cipher_list = "HIGH:!aNULL:!MD5"
+    default_ecdh_curve  = "X25519:P-256"
+    max_version         = "TLSv1.3"
+    min_version         = "TLSv1.2"
+    reject_unauthorized = true
+  }
+
+  upgrade_group_settings = {
+    is_rolling  = true
+    quantity    = 5
+    retry_count = 3
+    retry_delay = 60
+  }
+
+  upgrade_settings = {
+    automatic_upgrade_check_period = "24h"
+    disable_automatic_upgrade      = false
+    enable_legacy_edge_upgrade     = false
+    upgrade_source                 = "cdn"
+  }
+
+  workers = {
+    count                    = -3 # Reserves cores for system/API overhead and load balancer
+    enable_heap_snapshots    = false
+    load_throttle_perc       = 85
+    memory                   = 2048
+    minimum                  = 2
+    startup_max_conns        = 1024
+    startup_throttle_timeout = 10000
+    v8_single_thread         = false
+  }
+}
+
+# Commit configuration
+resource "criblio_commit" "example" {
+  effective = true
+  group     = var.worker_group_id
+  message   = "Commit for scale Worker Group example"
+
+  depends_on = [criblio_group_system_settings.scaled]
+}
+
+# Read config version
+data "criblio_config_version" "latest" {
+  id         = var.worker_group_id
+  depends_on = [criblio_commit.example]
+}
+
+# Deploy configuration
+resource "criblio_deploy" "example" {
+  id      = var.worker_group_id
+  version = data.criblio_config_version.latest.items[0]
+}

--- a/docs/examples/example-onprem-scale-worker-group/provider.tf
+++ b/docs/examples/example-onprem-scale-worker-group/provider.tf
@@ -1,0 +1,17 @@
+# Configure provider
+#
+# The provider block is empty. Configure authentication using
+# environment variables or a credentials file as described in
+# https://docs.cribl.io/cribl-as-code/terraform-auth/#terraform-auth-on-prem.
+
+terraform {
+  required_providers {
+    criblio = {
+      source  = "criblio/criblio"
+      version = ">= 1.20.138"
+    }
+  }
+}
+
+provider "criblio" {
+}

--- a/docs/examples/example-onprem-scale-worker-group/terraform.tfvars.example
+++ b/docs/examples/example-onprem-scale-worker-group/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy this file to terraform.tfvars and replace each placeholder with the value
+# for your on-prem deployment. Do not commit terraform.tfvars to version control.
+
+worker_group_id = "existing-worker-group-id-to-scale"

--- a/docs/examples/example-onprem-scale-worker-group/variables.tf
+++ b/docs/examples/example-onprem-scale-worker-group/variables.tf
@@ -1,0 +1,17 @@
+# User-supplied parameters
+#
+# Supply values for the declared variables in this file in terraform.tfvars.
+#
+# Required for the Worker Group:
+# - worker_group_id: ID of the existing Worker Group to scale
+#
+# Before first apply, import existing system settings into Terraform state:
+#   terraform import criblio_group_system_settings.scaled <worker_group_id>
+#
+# Replace the placeholder values in the api, ssl, and other blocks in main.tf
+# with values that match your deployment.
+
+variable "worker_group_id" {
+  type        = string
+  description = "ID of the existing Worker Group to scale."
+}


### PR DESCRIPTION
In the `docs` directory, adds an `examples` subdirectory that contains example files for Cribl Stream use cases Create a Worker Group, Scale a Worker Group, and Configure Resources.

These files are needed so that I can incorporate them by link into the docs for these use cases. The PR to add the docs for these use cases is https://bitbucket.org/cribl/cribl-doc/pull-requests/7229.