### PR TITLE
INFRA-9948 Terraform criblio_mapping_ruleset cannot activate ruleset

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.2"
+      version = "1.25.3"
     }
   }
 }

--- a/internal/provider/mapping_ruleset_client.go
+++ b/internal/provider/mapping_ruleset_client.go
@@ -17,7 +17,24 @@ func newMappingRulesetAPI(client *restclient.Client) MappingRulesetAPI {
 }
 
 func (a MappingRulesetAPI) Create(ctx context.Context, model MappingRulesetModel) (*MappingRulesetModel, error) {
-	return restclient.Patch[MappingRulesetModel, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), model)
+	apiModel, err := restclient.Patch[MappingRulesetModel, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), model)
+	if err != nil {
+		return nil, err
+	}
+	if model.Active.IsNull() || model.Active.IsUnknown() {
+		return apiModel, nil
+	}
+	if err := a.patchActive(ctx, model); err != nil {
+		return nil, err
+	}
+	apiModel, err = a.Read(ctx, model)
+	if err != nil {
+		return nil, err
+	}
+	if apiModel.Active.IsNull() || apiModel.Active.IsUnknown() || apiModel.Active.ValueBool() != model.Active.ValueBool() {
+		return nil, fmt.Errorf("mapping ruleset %q in product %q did not reach active=%t", mappingRulesetID(model), model.Product.ValueString(), model.Active.ValueBool())
+	}
+	return apiModel, nil
 }
 
 func (a MappingRulesetAPI) Read(ctx context.Context, model MappingRulesetModel) (*MappingRulesetModel, error) {
@@ -25,7 +42,24 @@ func (a MappingRulesetAPI) Read(ctx context.Context, model MappingRulesetModel) 
 }
 
 func (a MappingRulesetAPI) Update(ctx context.Context, model MappingRulesetModel) (*MappingRulesetModel, error) {
-	return restclient.Patch[MappingRulesetModel, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), model)
+	apiModel, err := restclient.Patch[MappingRulesetModel, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), model)
+	if err != nil {
+		return nil, err
+	}
+	if model.Active.IsNull() || model.Active.IsUnknown() {
+		return apiModel, nil
+	}
+	if err := a.patchActive(ctx, model); err != nil {
+		return nil, err
+	}
+	apiModel, err = a.Read(ctx, model)
+	if err != nil {
+		return nil, err
+	}
+	if apiModel.Active.IsNull() || apiModel.Active.IsUnknown() || apiModel.Active.ValueBool() != model.Active.ValueBool() {
+		return nil, fmt.Errorf("mapping ruleset %q in product %q did not reach active=%t", mappingRulesetID(model), model.Product.ValueString(), model.Active.ValueBool())
+	}
+	return apiModel, nil
 }
 
 func (a MappingRulesetAPI) Delete(ctx context.Context, model MappingRulesetModel) error {
@@ -43,5 +77,19 @@ func (a MappingRulesetAPI) Delete(ctx context.Context, model MappingRulesetModel
 		},
 	}
 	_, err := restclient.Patch[emptyMappingRuleset, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/default", model.Product.ValueString()), body)
+	return err
+}
+
+type mappingRulesetActivePatch struct {
+	ID     string `json:"id"`
+	Active bool   `json:"active"`
+}
+
+func (a MappingRulesetAPI) patchActive(ctx context.Context, model MappingRulesetModel) error {
+	body := mappingRulesetActivePatch{
+		ID:     mappingRulesetID(model),
+		Active: model.Active.ValueBool(),
+	}
+	_, err := restclient.Patch[mappingRulesetActivePatch, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), body)
 	return err
 }

--- a/tests/acceptance/mapping_ruleset_test.go
+++ b/tests/acceptance/mapping_ruleset_test.go
@@ -12,9 +12,22 @@ func TestMappingRuleset(t *testing.T) {
 		t.Skip("Skipping mapping ruleset test for on-prem: mappings API returns 403")
 	}
 
+	testMappingRulesetForProduct(t, "edge")
+}
+
+func TestMappingRulesetStream(t *testing.T) {
+	if os.Getenv("DEPLOYMENT") == "onprem" {
+		t.Skip("Skipping mapping ruleset test for on-prem: mappings API returns 403")
+	}
+
+	testMappingRulesetForProduct(t, "stream")
+}
+
+func testMappingRulesetForProduct(t *testing.T, product string) {
+	t.Helper()
+
 	resourceName := "criblio_mapping_ruleset.my_mapping_ruleset"
 	id := "default"
-	product := "edge"
 	final := "true"
 
 	resource.Test(t, resource.TestCase{
@@ -26,6 +39,7 @@ func TestMappingRuleset(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceName, "product", product),
 					resource.TestCheckResourceAttr(resourceName, "id", id),
+					resource.TestCheckResourceAttr(resourceName, "active", "true"),
 					resource.TestCheckResourceAttr(resourceName, "conf.functions.#", "1"),
 					resource.TestCheckResourceAttr(resourceName, "conf.functions.0.description", "test mapping"),
 					resource.TestCheckResourceAttr(resourceName, "conf.functions.0.final", final),
@@ -44,6 +58,9 @@ func TestMappingRuleset(t *testing.T) {
 				ImportState:       true,
 				ImportStateId:     `{"product":"` + product + `","id":"` + id + `"}`,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"conf",
+				},
 			},
 		},
 	})

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -1026,6 +1026,25 @@ func (a {{ .StructName }}API) Create(ctx context.Context, model {{ .StructName }
 {{- else if .NoRead }}
 	err := restclient.{{ restWriteCall .Create }}NoResponse(ctx, a.client, {{ pathExpr . .Create }}, model)
 	return &model, err
+{{- else if eq .StructName "MappingRuleset" }}
+	apiModel, err := restclient.Patch[MappingRulesetModel, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), model)
+	if err != nil {
+		return nil, err
+	}
+	if model.Active.IsNull() || model.Active.IsUnknown() {
+		return apiModel, nil
+	}
+	if err := a.patchActive(ctx, model); err != nil {
+		return nil, err
+	}
+	apiModel, err = a.Read(ctx, model)
+	if err != nil {
+		return nil, err
+	}
+	if apiModel.Active.IsNull() || apiModel.Active.IsUnknown() || apiModel.Active.ValueBool() != model.Active.ValueBool() {
+		return nil, fmt.Errorf("mapping ruleset %q in product %q did not reach active=%t", mappingRulesetID(model), model.Product.ValueString(), model.Active.ValueBool())
+	}
+	return apiModel, nil
 {{- else if eq .StructName "Key" }}
 	id := model.ID.ValueString()
 	apiModel, err := restclient.Post[{{ .StructName }}Model, {{ .StructName }}Model](ctx, a.client, fmt.Sprintf("/m/%s/system/keys?id=%s", model.GroupID.ValueString(), url.QueryEscape(id)), model)
@@ -1164,6 +1183,25 @@ func (a {{ .StructName }}API) Update(ctx context.Context, model {{ .StructName }
 		lastErr = err
 	}
 	return nil, lastErr
+{{- else if eq .StructName "MappingRuleset" }}
+	apiModel, err := restclient.Patch[MappingRulesetModel, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), model)
+	if err != nil {
+		return nil, err
+	}
+	if model.Active.IsNull() || model.Active.IsUnknown() {
+		return apiModel, nil
+	}
+	if err := a.patchActive(ctx, model); err != nil {
+		return nil, err
+	}
+	apiModel, err = a.Read(ctx, model)
+	if err != nil {
+		return nil, err
+	}
+	if apiModel.Active.IsNull() || apiModel.Active.IsUnknown() || apiModel.Active.ValueBool() != model.Active.ValueBool() {
+		return nil, fmt.Errorf("mapping ruleset %q in product %q did not reach active=%t", mappingRulesetID(model), model.Product.ValueString(), model.Active.ValueBool())
+	}
+	return apiModel, nil
 {{- else }}
 {{- if .Update.ReadAfterWrite }}
 	body, err := model.updateBody()
@@ -1257,6 +1295,22 @@ func notificationGroupID(model NotificationModel) string {
 		return model.Group.ValueString()
 	}
 	return "default"
+}
+{{- end }}
+{{- if eq .StructName "MappingRuleset" }}
+
+type mappingRulesetActivePatch struct {
+	ID     string ` + "`json:\"id\"`" + `
+	Active bool   ` + "`json:\"active\"`" + `
+}
+
+func (a MappingRulesetAPI) patchActive(ctx context.Context, model MappingRulesetModel) error {
+	body := mappingRulesetActivePatch{
+		ID:     mappingRulesetID(model),
+		Active: model.Active.ValueBool(),
+	}
+	_, err := restclient.Patch[mappingRulesetActivePatch, MappingRulesetModel](ctx, a.client, fmt.Sprintf("/admin/products/%s/mappings/%s", model.Product.ValueString(), mappingRulesetID(model)), body)
+	return err
 }
 {{- end }}
 {{- if eq .StructName "Key" }}


### PR DESCRIPTION
The Terraform Resource criblio_mapping_ruleset cannot activate a ruleset. The “plan” command identifies that a change is required, but “apply” cannot actually do it.