### PR TITLE
Fix source model

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.2"
+      version = "1.25.4"
     }
   }
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -384,6 +384,15 @@ func doTokenRequest(ctx context.Context, method, requestURL, contentType string,
 	retryClient.Backoff = tokenBackoff
 	retryClient.Logger = &retryableLogger{}
 	retryClient.CheckRetry = tokenRetryPolicy
+	retryClient.ErrorHandler = func(resp *http.Response, err error, numTries int) (*http.Response, error) {
+		if numTries > attempts {
+			attempts = numTries
+		}
+		if resp != nil {
+			return resp, nil
+		}
+		return nil, err
+	}
 	retryClient.RequestLogHook = func(_ retryablehttp.Logger, _ *http.Request, attempt int) {
 		attempts = attempt + 1
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -766,6 +766,39 @@ func TestTokenRequestRetriesTransientFailures(t *testing.T) {
 	}
 }
 
+func TestTokenRequestReportsFinalRetriedHTTPResponse(t *testing.T) {
+	ClearTokenCache()
+	fastTokenRetry(t)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"leader is still starting"}`))
+	}))
+	defer server.Close()
+
+	_, err := GetToken(context.Background(), &CriblConfig{
+		OnpremServerURL: server.URL,
+		OnpremUsername:  "admin",
+		OnpremPassword:  "secret",
+	})
+	if err == nil {
+		t.Fatal("GetToken returned nil error, expected retry exhaustion")
+	}
+	if requestCount != tokenRetryMax+1 {
+		t.Fatalf("request count = %d, expected %d", requestCount, tokenRetryMax+1)
+	}
+	for _, want := range []string{"status=500", `body={"error":"leader is still starting"}`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, expected %q", err.Error(), want)
+		}
+	}
+	if strings.Contains(err.Error(), "giving up after") {
+		t.Fatalf("error = %q, expected auth-layer response details instead of retryablehttp exhaustion", err.Error())
+	}
+}
+
 func TestTokenRequestDoesNotRetryUnauthorized(t *testing.T) {
 	ClearTokenCache()
 	fastTokenRetry(t)

--- a/internal/restclient/client.go
+++ b/internal/restclient/client.go
@@ -13,9 +13,17 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/criblio/terraform-provider-criblio/internal/auth"
 	"github.com/criblio/terraform-provider-criblio/internal/useragent"
+)
+
+const apiRetryMax = 3
+
+var (
+	apiRetryWaitMin = 500 * time.Millisecond
+	apiRetryWaitMax = 2 * time.Second
 )
 
 // Config holds REST client settings.
@@ -208,20 +216,44 @@ func do(ctx context.Context, c *Client, method, path, contentType string, body [
 		return nil, fmt.Errorf("restclient client is required")
 	}
 
-	responseBody, statusCode, token, err := c.send(ctx, method, path, contentType, body)
-	if err != nil {
-		return nil, err
-	}
-	if statusCode != http.StatusUnauthorized || c.bearerToken != "" || os.Getenv("CRIBL_BEARER_TOKEN") != "" || c.credentials == nil {
-		return responseBody, responseError(path, statusCode, responseBody)
-	}
+	for attempt := 0; ; attempt++ {
+		responseBody, statusCode, token, err := c.send(ctx, method, path, contentType, body)
+		if err != nil {
+			if shouldRetryAPIRequest(method, 0, nil, err, attempt) {
+				if err := waitBeforeAPIRetry(ctx, attempt); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
 
-	auth.InvalidateTokenValue(c.credentials, token)
-	responseBody, statusCode, _, err = c.send(ctx, method, path, contentType, body)
-	if err != nil {
-		return nil, err
+		if statusCode == http.StatusUnauthorized && c.bearerToken == "" && os.Getenv("CRIBL_BEARER_TOKEN") == "" && c.credentials != nil {
+			auth.InvalidateTokenValue(c.credentials, token)
+			responseBody, statusCode, _, err = c.send(ctx, method, path, contentType, body)
+			if err != nil {
+				if shouldRetryAPIRequest(method, 0, nil, err, attempt) {
+					if err := waitBeforeAPIRetry(ctx, attempt); err != nil {
+						return nil, err
+					}
+					continue
+				}
+				return nil, err
+			}
+		}
+
+		err = responseError(path, statusCode, responseBody)
+		if err == nil {
+			return responseBody, nil
+		}
+		if shouldRetryAPIRequest(method, statusCode, responseBody, nil, attempt) {
+			if err := waitBeforeAPIRetry(ctx, attempt); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		return responseBody, err
 	}
-	return responseBody, responseError(path, statusCode, responseBody)
 }
 
 func (c *Client) send(ctx context.Context, method, path, contentType string, body []byte) ([]byte, int, string, error) {
@@ -314,6 +346,52 @@ func responseError(path string, statusCode int, body []byte) error {
 			StatusCode: statusCode,
 			Body:       string(body),
 		}
+	}
+}
+
+func shouldRetryAPIRequest(method string, statusCode int, body []byte, err error, attempt int) bool {
+	if attempt >= apiRetryMax || !isRetryableAPIMethod(method) {
+		return false
+	}
+	if err != nil {
+		message := strings.ToLower(err.Error())
+		return strings.Contains(message, "failed to send request") ||
+			strings.Contains(message, "failed to read response body")
+	}
+	switch statusCode {
+	case http.StatusRequestTimeout, http.StatusTooManyRequests, http.StatusBadGateway, http.StatusServiceUnavailable, http.StatusGatewayTimeout:
+		return true
+	case http.StatusInternalServerError:
+		return responseBodyHasTransientError(body)
+	default:
+		return false
+	}
+}
+
+func isRetryableAPIMethod(method string) bool {
+	return method == http.MethodGet || method == http.MethodHead
+}
+
+func responseBodyHasTransientError(body []byte) bool {
+	message := strings.ToLower(string(body))
+	return strings.Contains(message, "econnreset") ||
+		strings.Contains(message, "connection reset") ||
+		strings.Contains(message, "socket hang up")
+}
+
+func waitBeforeAPIRetry(ctx context.Context, attempt int) error {
+	wait := apiRetryWaitMin << attempt
+	if wait > apiRetryWaitMax {
+		wait = apiRetryWaitMax
+	}
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 

--- a/internal/restclient/client_test.go
+++ b/internal/restclient/client_test.go
@@ -338,6 +338,65 @@ func TestErrors(t *testing.T) {
 	}
 }
 
+func TestGetRetriesTransientECONNRESETResponse(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+	fastAPIRetry(t)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if requestCount == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(`{"status":"error","message":"Read ECONNRESET","error":{"errno":-104,"code":"ECONNRESET","syscall":"read"}}`))
+			return
+		}
+		writeJSON(t, w, testItem{ID: "pipeline-1", Name: "pipeline"})
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+	})
+
+	got, err := Get[testItem](context.Background(), client, "/pipelines/pipeline-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got.Name != "pipeline" {
+		t.Fatalf("name = %q, expected pipeline", got.Name)
+	}
+	if requestCount != 2 {
+		t.Fatalf("request count = %d, expected 2", requestCount)
+	}
+}
+
+func TestPostDoesNotRetryTransientECONNRESETResponse(t *testing.T) {
+	t.Setenv("CRIBL_BEARER_TOKEN", "")
+	fastAPIRetry(t)
+
+	requestCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"status":"error","message":"Read ECONNRESET","error":{"errno":-104,"code":"ECONNRESET","syscall":"read"}}`))
+	}))
+	defer server.Close()
+
+	client := New(Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+	})
+
+	_, err := Post[testItem, testItem](context.Background(), client, "/pipelines", testItem{Name: "pipeline"})
+	if err == nil {
+		t.Fatal("Post returned nil error, expected HTTP 500")
+	}
+	if requestCount != 1 {
+		t.Fatalf("request count = %d, expected 1", requestCount)
+	}
+}
+
 func TestGatewayRouting(t *testing.T) {
 	t.Setenv("CRIBL_BEARER_TOKEN", "")
 
@@ -636,4 +695,17 @@ func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
 	if err := json.NewEncoder(w).Encode(value); err != nil {
 		t.Fatalf("failed to write JSON response: %v", err)
 	}
+}
+
+func fastAPIRetry(t *testing.T) {
+	t.Helper()
+
+	oldMin := apiRetryWaitMin
+	oldMax := apiRetryWaitMax
+	apiRetryWaitMin = time.Millisecond
+	apiRetryWaitMax = time.Millisecond
+	t.Cleanup(func() {
+		apiRetryWaitMin = oldMin
+		apiRetryWaitMax = oldMax
+	})
 }


### PR DESCRIPTION
- Preserve final auth retry responses so exhausted token retries report the API status/body details instead of only retryablehttp’s generic exhaustion error.
- Add idempotent REST retry handling for GET/HEAD transient failures, including 500 responses whose body indicates ECONNRESET, connection reset, or socket hang up.
- Add focused regression coverage for auth retry error detail, GET retry success, and ensuring POST does not retry the transient ECONNRESET response.