### PR TITLE
regression fixes with in-house provider.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.4"
+      version = "1.25.5"
     }
   }
 }

--- a/internal/provider/collector_types.go
+++ b/internal/provider/collector_types.go
@@ -2860,6 +2860,7 @@ func (m CollectorModel) MarshalJSON() ([]byte, error) {
 			output[key] = item
 		}
 	}
+	output["type"] = "collection"
 	return json.Marshal(output)
 }
 

--- a/internal/provider/collector_types_test.go
+++ b/internal/provider/collector_types_test.go
@@ -1,0 +1,35 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestCollectorMarshalJSONIncludesSavedJobType(t *testing.T) {
+	model := CollectorModel{
+		GroupID: types.StringValue("default"),
+		ID:      types.StringValue("rest-api-demo-collector"),
+		InputCollectorRest: &InputCollectorRestModel{
+			ID: types.StringValue("rest-api-demo-collector"),
+		},
+	}
+
+	data, err := json.Marshal(model)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+
+	if got["type"] != "collection" {
+		t.Fatalf("expected saved job type collection, got %#v in %s", got["type"], data)
+	}
+	if got["id"] != "rest-api-demo-collector" {
+		t.Fatalf("expected collector id in body, got %#v in %s", got["id"], data)
+	}
+}

--- a/tools/codegen/render_test.go
+++ b/tools/codegen/render_test.go
@@ -910,6 +910,33 @@ func TestResourceSchemaUsesPlanModifierHook(t *testing.T) {
 	assertNotContains(t, got, `PlanModifiers: []planmodifier.String{`)
 }
 
+func TestCollectorMarshalIncludesSavedJobType(t *testing.T) {
+	resource := parser.ResourceDef{
+		Name:       "collector",
+		FileStem:   "collector",
+		TypeName:   "criblio_collector",
+		StructName: "Collector",
+		Fields: []parser.FieldDef{
+			{
+				APIName:       "id",
+				TerraformName: "id",
+				GoName:        "ID",
+				Type:          "string",
+				Required:      true,
+				RequestField:  true,
+			},
+		},
+	}
+
+	content, err := executeTemplate("types", resource)
+	if err != nil {
+		t.Fatalf("executeTemplate returned error: %v", err)
+	}
+	got := string(content)
+
+	assertContains(t, got, `output["type"] = "collection"`)
+}
+
 func TestPrimitiveArrayFieldsPreserveElementTypes(t *testing.T) {
 	resource := parser.ResourceDef{
 		Name:       "array_resource",

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -663,6 +663,9 @@ func (m {{ .StructName }}Model) MarshalJSON() ([]byte, error) {
 {{- if eq .StructName "MappingRuleset" }}
 	output["id"] = mappingRulesetID(m)
 {{- end }}
+{{- if eq .StructName "Collector" }}
+	output["type"] = "collection"
+{{- end }}
 	return json.Marshal(output)
 }
 

--- a/tools/import-cli/internal/export/export_test.go
+++ b/tools/import-cli/internal/export/export_test.go
@@ -331,6 +331,9 @@ func TestSkipResourceByID(t *testing.T) {
 	t.Run("skip criblio_source in default_search group", func(t *testing.T) {
 		assert.True(t, skipResourceByID("criblio_source", map[string]string{"group_id": "default_search", "id": "in_open_telemetry"}))
 	})
+	t.Run("skip criblio_collector in default_search group", func(t *testing.T) {
+		assert.True(t, skipResourceByID("criblio_collector", map[string]string{"group_id": "default_search", "id": "scheduledSearch_test_saved_query"}))
+	})
 	t.Run("skip criblio_routes in default_search group", func(t *testing.T) {
 		assert.True(t, skipResourceByID("criblio_routes", map[string]string{"group_id": "default_search", "id": "default_search"}))
 	})
@@ -339,6 +342,9 @@ func TestSkipResourceByID(t *testing.T) {
 	})
 	t.Run("not skip criblio_source in other groups when same id", func(t *testing.T) {
 		assert.False(t, skipResourceByID("criblio_source", map[string]string{"group_id": "default", "id": "in_open_telemetry"}))
+	})
+	t.Run("not skip criblio_collector in other groups", func(t *testing.T) {
+		assert.False(t, skipResourceByID("criblio_collector", map[string]string{"group_id": "default", "id": "collector_rest"}))
 	})
 	t.Run("not skip criblio_routes in worker group", func(t *testing.T) {
 		assert.False(t, skipResourceByID("criblio_routes", map[string]string{"group_id": "default", "id": "default"}))
@@ -423,6 +429,18 @@ func TestDefaultResource(t *testing.T) {
 		override := ParseIncludeDefaultIDs([]string{"devnull"})
 		assert.False(t, DefaultResource("criblio_pipeline", map[string]string{"id": "devnull"}, attrs, override))
 		assert.False(t, DefaultResource("criblio_destination", map[string]string{"id": "devnull"}, attrs, override))
+	})
+	t.Run("include override matches criblio_routes group id", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		idMap := map[string]string{"group_id": "stream-leaders", "id": "default"}
+		override := ParseIncludeDefaultIDs([]string{"criblio_routes:stream-leaders"})
+		assert.False(t, DefaultResource("criblio_routes", idMap, attrs, override))
+	})
+	t.Run("include override does not match criblio_routes group id for other types", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		idMap := map[string]string{"group_id": "stream-leaders", "id": "default"}
+		override := ParseIncludeDefaultIDs([]string{"criblio_source:stream-leaders"})
+		assert.True(t, DefaultResource("criblio_routes", idMap, attrs, override))
 	})
 }
 
@@ -557,6 +575,47 @@ func TestFlattenItemsListToTopLevel(t *testing.T) {
 	})
 }
 
+func TestNormalizeRoutesForExport(t *testing.T) {
+	t.Run("removes null clone entries and omits empty clones", func(t *testing.T) {
+		routes := hcl.Value{Kind: hcl.KindList, List: []hcl.Value{
+			{Kind: hcl.KindMap, Map: map[string]hcl.Value{
+				"name":        {Kind: hcl.KindString, String: "raw"},
+				"description": {Kind: hcl.KindString, String: ""},
+				"clones": {Kind: hcl.KindList, List: []hcl.Value{
+					{Kind: hcl.KindNull},
+				}},
+			}},
+		}}
+
+		got := normalizeRoutesForExport(routes)
+
+		route := got.List[0].Map
+		assert.NotContains(t, route, "clones")
+		assert.Equal(t, hcl.KindNull, route["description"].Kind)
+	})
+	t.Run("keeps valid clone maps and drops null clone entries", func(t *testing.T) {
+		clone := hcl.Value{Kind: hcl.KindMap, Map: map[string]hcl.Value{
+			"__cloneId": {Kind: hcl.KindString, String: "audit"},
+		}}
+		routes := hcl.Value{Kind: hcl.KindList, List: []hcl.Value{
+			{Kind: hcl.KindMap, Map: map[string]hcl.Value{
+				"name": {Kind: hcl.KindString, String: "with clones"},
+				"clones": {Kind: hcl.KindList, List: []hcl.Value{
+					{Kind: hcl.KindNull},
+					clone,
+				}},
+			}},
+		}}
+
+		got := normalizeRoutesForExport(routes)
+
+		clones := got.List[0].Map["clones"]
+		require.Equal(t, hcl.KindList, clones.Kind)
+		require.Len(t, clones.List, 1)
+		assert.Equal(t, clone, clones.List[0])
+	})
+}
+
 func TestFilterAttrsBySchema(t *testing.T) {
 	t.Run("allowed attrs kept", func(t *testing.T) {
 		allowed := converter.AllAttributeNamesFromModel("SourceResourceModel")
@@ -598,6 +657,15 @@ func TestRawJSONToItemMap(t *testing.T) {
 		require.NotNil(t, got)
 		assert.Equal(t, `"x"`, got["id"]) // values are JSON-encoded
 		assert.Equal(t, `"y"`, got["name"])
+	})
+	t.Run("does not escape HTML characters", func(t *testing.T) {
+		raw := []byte(`{"regex":"(?<vendor>[^|]+)","conf":{"query":"a\u003cb\u003ec"}}`)
+		got := rawJSONToItemMap(raw)
+		require.NotNil(t, got)
+		assert.Equal(t, `"(?<vendor>[^|]+)"`, got["regex"])
+		assert.Contains(t, got["conf"], `"a<b>c"`)
+		assert.NotContains(t, got["regex"], `\u003c`)
+		assert.NotContains(t, got["conf"], `\u003e`)
 	})
 	t.Run("invalid JSON returns nil", func(t *testing.T) {
 		got := rawJSONToItemMap([]byte(`{invalid`))

--- a/tools/import-cli/internal/export/filters.go
+++ b/tools/import-cli/internal/export/filters.go
@@ -81,6 +81,11 @@ func skipResourceByID(typeName string, idMap map[string]string) bool {
 	if typeName == "criblio_source" && idMap["group_id"] == "default_search" {
 		return true
 	}
+	// Search collectors are saved searches/jobs exposed from default_search, not
+	// importable collector inputs.
+	if typeName == "criblio_collector" && idMap["group_id"] == "default_search" {
+		return true
+	}
 	// Stream routes are one singleton per worker group. default_search has Search UI
 	// resources, but exporting criblio_routes there produces an invalid PATCH payload
 	// for the stream routes endpoint.
@@ -206,7 +211,13 @@ func DefaultResource(typeName string, idMap map[string]string, attrs map[string]
 		return custom.DefaultPackIDs[pack]
 	case "criblio_pack_vars":
 		return custom.DefaultPackIDs[pack]
-	case "criblio_routes", "criblio_pack_routes":
+	case "criblio_routes":
+		// Routes are a singleton per group/pack; users modify but don't create them from scratch.
+		if includeOverride.Includes(typeName, idMap["group_id"]) {
+			return false
+		}
+		return true
+	case "criblio_pack_routes":
 		// Routes are a singleton per group/pack; users modify but don't create them from scratch.
 		return true
 	case "criblio_search_dataset_ruleset":

--- a/tools/import-cli/internal/export/items.go
+++ b/tools/import-cli/internal/export/items.go
@@ -43,22 +43,8 @@ func convertOneResource(ctx context.Context, client *importclient.Client, r disc
 	if r.TypeName == "criblio_pack" {
 		delete(attrs, "exports")
 	}
-	// normalizeRouteDescriptions sets description to null when empty string so config matches provider state (null vs "" drift).
-	normalizeRouteDescriptions := func(routesVal hcl.Value) hcl.Value {
-		if routesVal.Kind != hcl.KindList {
-			return routesVal
-		}
-		for i := range routesVal.List {
-			if routesVal.List[i].Kind == hcl.KindMap && routesVal.List[i].Map != nil {
-				if v, ok := routesVal.List[i].Map["description"]; ok && v.Kind == hcl.KindString && v.String == "" {
-					routesVal.List[i].Map["description"] = hcl.Value{Kind: hcl.KindNull}
-				}
-			}
-		}
-		return routesVal
-	}
 	if (r.TypeName == "criblio_routes" || r.TypeName == "criblio_pack_routes") && attrs["routes"].Kind != hcl.KindNull {
-		attrs["routes"] = normalizeRouteDescriptions(attrs["routes"])
+		attrs["routes"] = normalizeRoutesForExport(attrs["routes"])
 	}
 	if r.TypeName == "criblio_appscope_config" {
 		custom.ApplyAppscopeConfigDefaults(attrs)
@@ -133,6 +119,44 @@ func convertOneResource(ctx context.Context, client *importclient.Client, r disc
 	}
 	it.LifecycleIgnoreChanges = lifecycleIgnoreChangesForConvertedResource(r.TypeName, attrs)
 	return &it, ""
+}
+
+// normalizeRoutesForExport removes route values that are valid in state but invalid in config.
+func normalizeRoutesForExport(routesVal hcl.Value) hcl.Value {
+	if routesVal.Kind != hcl.KindList {
+		return routesVal
+	}
+	for i := range routesVal.List {
+		if routesVal.List[i].Kind != hcl.KindMap || routesVal.List[i].Map == nil {
+			continue
+		}
+		route := routesVal.List[i].Map
+		if v, ok := route["description"]; ok && v.Kind == hcl.KindString && v.String == "" {
+			route["description"] = hcl.Value{Kind: hcl.KindNull}
+		}
+		if v, ok := route["clones"]; ok && v.Kind == hcl.KindList {
+			route["clones"] = removeNullListItems(v)
+			if len(route["clones"].List) == 0 {
+				delete(route, "clones")
+			}
+		}
+	}
+	return routesVal
+}
+
+func removeNullListItems(v hcl.Value) hcl.Value {
+	if v.Kind != hcl.KindList {
+		return v
+	}
+	list := make([]hcl.Value, 0, len(v.List))
+	for _, item := range v.List {
+		if item.Kind == hcl.KindNull {
+			continue
+		}
+		list = append(list, item)
+	}
+	v.List = list
+	return v
 }
 
 func lifecycleIgnoreChangesForConvertedResource(typeName string, attrs map[string]hcl.Value) []string {

--- a/tools/import-cli/internal/export/util.go
+++ b/tools/import-cli/internal/export/util.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/hcl"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
 )
 
@@ -92,7 +93,7 @@ func rawJSONToItemMap(itemJSON []byte) map[string]string {
 	}
 	out := make(map[string]string, len(m))
 	for k, v := range m {
-		b, err := json.Marshal(v)
+		b, err := hcl.MarshalJSONNoEscape(v)
 		if err != nil {
 			continue
 		}

--- a/tools/import-cli/internal/hcl/destination.go
+++ b/tools/import-cli/internal/hcl/destination.go
@@ -35,7 +35,7 @@ func TFBlockModelToAPIItemMap(block map[string]Value, keysToSkip []string) (map[
 			continue
 		}
 		camel := snakeToCamel(k)
-		raw, err := json.Marshal(valueToJSONableForAPI(v))
+		raw, err := MarshalJSONNoEscape(valueToJSONableForAPI(v))
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", k, err)
 		}

--- a/tools/import-cli/internal/hcl/destination_test.go
+++ b/tools/import-cli/internal/hcl/destination_test.go
@@ -77,6 +77,26 @@ func TestItemMapToBlock_generic(t *testing.T) {
 	assert.Equal(t, "rest", value.Map["type"].String)
 }
 
+func TestTFBlockModelToAPIItemMapDoesNotEscapeHTMLCharacters(t *testing.T) {
+	block := map[string]Value{
+		"type": {Kind: KindString, String: "regex"},
+		"conf": {Kind: KindMap, Map: map[string]Value{
+			"regex_list": {Kind: KindList, List: []Value{
+				{Kind: KindMap, Map: map[string]Value{
+					"regex": {Kind: KindString, String: `(?<vendor>[^|]+)`},
+				}},
+			}},
+		}},
+	}
+
+	got, err := TFBlockModelToAPIItemMap(block, nil)
+	require.NoError(t, err)
+
+	assert.Contains(t, got["conf"], `(?<vendor>[^|]+)`)
+	assert.NotContains(t, got["conf"], `\u003c`)
+	assert.NotContains(t, got["conf"], `\u003e`)
+}
+
 func TestItemMapToBlock_collector_collection_alias(t *testing.T) {
 	// API returns type "collection" for REST-style collectors; provider expects input_collector_rest.
 	item := map[string]string{

--- a/tools/import-cli/internal/hcl/json.go
+++ b/tools/import-cli/internal/hcl/json.go
@@ -1,0 +1,30 @@
+package hcl
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// MarshalJSONNoEscape returns compact JSON without escaping HTML characters.
+func MarshalJSONNoEscape(v any) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return []byte(strings.TrimSuffix(buf.String(), "\n")), nil
+}
+
+func normalizeJSONNoEscape(raw string) (string, error) {
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return "", err
+	}
+	out, err := MarshalJSONNoEscape(v)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/tools/import-cli/internal/hcl/value.go
+++ b/tools/import-cli/internal/hcl/value.go
@@ -484,9 +484,13 @@ func attrToValue(av attr.Value, path string, sensitive bool, opts *Options) (Val
 func normalizedJSONToValue(v jsontypes.Normalized) (Value, error) {
 	raw := v.ValueString()
 	if isValidJSON(raw) {
+		normalized, err := normalizeJSONNoEscape(raw)
+		if err == nil {
+			return Value{Kind: KindString, String: normalized}, nil
+		}
 		return Value{Kind: KindString, String: raw}, nil
 	}
-	encoded, err := json.Marshal(raw)
+	encoded, err := MarshalJSONNoEscape(raw)
 	if err != nil {
 		return Value{}, err
 	}
@@ -624,7 +628,7 @@ func MaskSensitiveValuesInJSON(jsonStr, resourceName, attrPath string) (string, 
 	if len(varNames) == 0 {
 		return jsonStr, nil
 	}
-	masked, err := json.Marshal(data)
+	masked, err := MarshalJSONNoEscape(data)
 	if err != nil {
 		return jsonStr, nil
 	}

--- a/tools/import-cli/internal/hcl/value_test.go
+++ b/tools/import-cli/internal/hcl/value_test.go
@@ -146,6 +146,30 @@ func TestModelToValue_nestedNormalizedScalarStringIsJSONEncoded(t *testing.T) {
 	assert.JSONEq(t, `{"query":"status"}`, config["object"].String)
 }
 
+func TestModelToValue_normalizedJSONDoesNotEscapeHTMLCharacters(t *testing.T) {
+	type modelWithConfig struct {
+		Config types.Map `tfsdk:"config"`
+	}
+	model := &modelWithConfig{
+		Config: types.MapValueMust(jsontypes.NormalizedType{}, map[string]attr.Value{
+			"regex":  jsontypes.NewNormalizedValue(`{"regex":"(?<vendor>[^|]+)"}`),
+			"scalar": jsontypes.NewNormalizedValue(`"a\u003cb\u003ec"`),
+			"raw":    jsontypes.NewNormalizedValue(`(?<product>[^|]+)`),
+		}),
+	}
+
+	out, err := ModelToValue(model, nil)
+	require.NoError(t, err)
+
+	config := out["config"].Map
+	assert.Equal(t, `{"regex":"(?<vendor>[^|]+)"}`, config["regex"].String)
+	assert.Equal(t, `"a<b>c"`, config["scalar"].String)
+	assert.Equal(t, `"(?<product>[^|]+)"`, config["raw"].String)
+	assert.NotContains(t, config["regex"].String, `\u003c`)
+	assert.NotContains(t, config["scalar"].String, `\u003e`)
+	assert.NotContains(t, config["raw"].String, `\u003c`)
+}
+
 func TestToHCLExpr_null_empty_sensitive(t *testing.T) {
 	assert.Equal(t, "null", Value{Kind: KindNull}.ToHCLExpr())
 	assert.Equal(t, `""`, Value{Kind: KindString, String: ""}.ToHCLExpr())


### PR DESCRIPTION
- Fixed collector create/update payloads from the in-house generator so API requests include top-level "type":"collection" alongside collector and input.
- Skipped default_search criblio_collector resources during export, preventing Search saved jobs from being emitted as collector resources.
- Fixed exporter regressions for routes, including criblio_routes:<group_id> default inclusion and invalid clones = [null] output.
- Improved exported JSON readability by preserving regex characters like < and > instead of emitting \u003c / \u003e.