### PR TITLE
Adding lookup file support within bulk exporter.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.5"
+      version = "1.25.9"
     }
   }
 }

--- a/internal/provider/lookup_file_client.go
+++ b/internal/provider/lookup_file_client.go
@@ -34,6 +34,11 @@ func (a LookupFileAPI) Read(ctx context.Context, model LookupFileModel) (*Lookup
 	for _, id := range lookupFileAPIIDs(configuredID) {
 		apiModel, err := restclient.Get[LookupFileModel](ctx, a.client, fmt.Sprintf("/m/%s/system/lookups/%s", model.GroupID.ValueString(), id))
 		if err == nil {
+			if content, contentErr := downloadLookupFileContent(ctx, a.client, model.GroupID.ValueString(), id); contentErr != nil {
+				return nil, contentErr
+			} else if content != nil {
+				apiModel.Content = types.StringValue(*content)
+			}
 			return normalizeLookupFileAPIModel(apiModel, configuredID), nil
 		}
 		if !restclient.IsNotFound(err) {
@@ -111,6 +116,19 @@ func uploadLookupFileContent(ctx context.Context, client *restclient.Client, mod
 	filename := lookupFileUploadFilename(id)
 	path := fmt.Sprintf("/m/%s/system/lookups?filename=%s", model.GroupID.ValueString(), url.QueryEscape(filename))
 	return restclient.PutRawNoResponse(ctx, client, path, "text/csv", []byte(model.Content.ValueString()))
+}
+
+func downloadLookupFileContent(ctx context.Context, client *restclient.Client, groupID, id string) (*string, error) {
+	filename := lookupFileUploadFilename(id)
+	body, err := restclient.GetRaw(ctx, client, fmt.Sprintf("/m/%s/system/lookups/%s/content?raw=true", url.PathEscape(groupID), url.PathEscape(filename)))
+	if err != nil {
+		if restclient.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	content := string(body)
+	return &content, nil
 }
 
 func normalizeLookupFileAPIModel(model *LookupFileModel, terraformID string) *LookupFileModel {

--- a/internal/provider/lookup_file_client_test.go
+++ b/internal/provider/lookup_file_client_test.go
@@ -98,6 +98,12 @@ func TestLookupFileReadFallsBackToCSVExtension(t *testing.T) {
 					},
 				},
 			})
+		case "/api/v1/m/default/system/lookups/my_id.csv/content":
+			if got := r.URL.Query().Get("raw"); got != "true" {
+				t.Fatalf("raw = %q, want true", got)
+			}
+			w.Header().Set("Content-Type", "text/csv")
+			_, _ = w.Write([]byte("column1,column2\nvalue1,value2\n"))
 		default:
 			http.NotFound(w, r)
 		}
@@ -119,8 +125,21 @@ func TestLookupFileReadFallsBackToCSVExtension(t *testing.T) {
 	if got := model.ID.ValueString(); got != "my_id" {
 		t.Fatalf("ID = %q, want configured ID", got)
 	}
-	if len(requestedPaths) != 2 {
-		t.Fatalf("requested paths = %#v, want raw ID then .csv fallback", requestedPaths)
+	if got := model.Content.ValueString(); got != "column1,column2\nvalue1,value2\n" {
+		t.Fatalf("Content = %q, want downloaded content", got)
+	}
+	wantPaths := []string{
+		"/api/v1/m/default/system/lookups/my_id",
+		"/api/v1/m/default/system/lookups/my_id.csv",
+		"/api/v1/m/default/system/lookups/my_id.csv/content",
+	}
+	if len(requestedPaths) != len(wantPaths) {
+		t.Fatalf("requested paths = %#v, want %#v", requestedPaths, wantPaths)
+	}
+	for i := range wantPaths {
+		if requestedPaths[i] != wantPaths[i] {
+			t.Fatalf("requested paths = %#v, want %#v", requestedPaths, wantPaths)
+		}
 	}
 }
 

--- a/internal/provider/lookup_file_resource.go
+++ b/internal/provider/lookup_file_resource.go
@@ -256,10 +256,8 @@ func applyLookupFileAPIToState(api *LookupFileModel, state *LookupFileModel, pre
 	if api == nil || state == nil {
 		return
 	}
-	if !preserveInputs || (fillMissingInputs && (state.Content.IsNull() || state.Content.IsUnknown())) {
-		if !api.Content.IsNull() && !api.Content.IsUnknown() {
-			state.Content = api.Content
-		}
+	if !api.Content.IsNull() && !api.Content.IsUnknown() {
+		state.Content = api.Content
 	}
 	if !preserveInputs || (fillMissingInputs && (state.Description.IsNull() || state.Description.IsUnknown())) {
 		if !api.Description.IsNull() && !api.Description.IsUnknown() {

--- a/internal/provider/lookup_file_types_test.go
+++ b/internal/provider/lookup_file_types_test.go
@@ -38,3 +38,53 @@ func TestApplyLookupFileAPIToStatePreservesOmittedFields(t *testing.T) {
 		t.Fatalf("version = %q", got)
 	}
 }
+
+func TestApplyLookupFileAPIToStateRefreshesDownloadedContent(t *testing.T) {
+	api := LookupFileModel{
+		Content: types.StringValue("a,b\nremote,value"),
+		GroupID: types.StringValue("default_search"),
+		ID:      types.StringValue("test_lookup.csv"),
+	}
+	state := LookupFileModel{
+		Content:     types.StringValue("a,b\nold,value"),
+		Description: types.StringValue("preserved"),
+		GroupID:     types.StringValue("default_search"),
+		ID:          types.StringValue("test_lookup.csv"),
+		PendingTask: types.ObjectNull(LookupFilePendingTaskAttrTypes()),
+	}
+
+	applyLookupFileAPIToState(&api, &state, true, false)
+
+	if got := state.Content.ValueString(); got != "a,b\nremote,value" {
+		t.Fatalf("content = %q", got)
+	}
+	if got := state.Description.ValueString(); got != "preserved" {
+		t.Fatalf("description = %q", got)
+	}
+}
+
+func TestApplyPackLookupsAPIToStateRefreshesDownloadedContent(t *testing.T) {
+	api := PackLookupsModel{
+		Content: types.StringValue("a,b\nremote,value"),
+		GroupID: types.StringValue("default"),
+		ID:      types.StringValue("pack_lookup.csv"),
+		Pack:    types.StringValue("knowledge"),
+	}
+	state := PackLookupsModel{
+		Content:     types.StringValue("a,b\nold,value"),
+		Description: types.StringValue("preserved"),
+		GroupID:     types.StringValue("default"),
+		ID:          types.StringValue("pack_lookup.csv"),
+		Pack:        types.StringValue("knowledge"),
+		PendingTask: types.ObjectNull(PackLookupsPendingTaskAttrTypes()),
+	}
+
+	applyPackLookupsAPIToState(&api, &state, true, false)
+
+	if got := state.Content.ValueString(); got != "a,b\nremote,value" {
+		t.Fatalf("content = %q", got)
+	}
+	if got := state.Description.ValueString(); got != "preserved" {
+		t.Fatalf("description = %q", got)
+	}
+}

--- a/internal/provider/pack_lookups_client.go
+++ b/internal/provider/pack_lookups_client.go
@@ -30,9 +30,15 @@ func (a PackLookupsAPI) Create(ctx context.Context, model PackLookupsModel) (*Pa
 func (a PackLookupsAPI) Read(ctx context.Context, model PackLookupsModel) (*PackLookupsModel, error) {
 	configuredID := model.ID.ValueString()
 	var lastErr error
+	packID := resolvePackIDForRestAPI(ctx, a.client, model.GroupID.ValueString(), model.Pack.ValueString())
 	for _, id := range lookupFileAPIIDs(configuredID) {
-		apiModel, err := restclient.Get[PackLookupsModel](ctx, a.client, fmt.Sprintf("/m/%s/p/%s/system/lookups/%s", model.GroupID.ValueString(), resolvePackIDForRestAPI(ctx, a.client, model.GroupID.ValueString(), model.Pack.ValueString()), id))
+		apiModel, err := restclient.Get[PackLookupsModel](ctx, a.client, fmt.Sprintf("/m/%s/p/%s/system/lookups/%s", model.GroupID.ValueString(), packID, id))
 		if err == nil {
+			if content, contentErr := downloadPackLookupFileContent(ctx, a.client, model.GroupID.ValueString(), packID, id); contentErr != nil {
+				return nil, contentErr
+			} else if content != nil {
+				apiModel.Content = types.StringValue(*content)
+			}
 			return normalizePackLookupsAPIModel(apiModel, configuredID), nil
 		}
 		if !restclient.IsNotFound(err) {
@@ -88,6 +94,19 @@ func uploadPackLookupFileContent(ctx context.Context, client *restclient.Client,
 	filename := lookupFileUploadFilename(id)
 	path := fmt.Sprintf("/m/%s/p/%s/system/lookups?filename=%s", model.GroupID.ValueString(), resolvePackIDForRestAPI(ctx, client, model.GroupID.ValueString(), model.Pack.ValueString()), url.QueryEscape(filename))
 	return restclient.PutRawNoResponse(ctx, client, path, "text/csv", []byte(model.Content.ValueString()))
+}
+
+func downloadPackLookupFileContent(ctx context.Context, client *restclient.Client, groupID, packID, id string) (*string, error) {
+	filename := lookupFileUploadFilename(id)
+	body, err := restclient.GetRaw(ctx, client, fmt.Sprintf("/m/%s/p/%s/system/lookups/%s/content?raw=true", url.PathEscape(groupID), url.PathEscape(packID), url.PathEscape(filename)))
+	if err != nil {
+		if restclient.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	content := string(body)
+	return &content, nil
 }
 
 func normalizePackLookupsAPIModel(model *PackLookupsModel, terraformID string) *PackLookupsModel {

--- a/internal/provider/pack_lookups_client_test.go
+++ b/internal/provider/pack_lookups_client_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/criblio/terraform-provider-criblio/internal/restclient"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestPackLookupsReadDownloadsContent(t *testing.T) {
+	var requestedPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedPaths = append(requestedPaths, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/api/v1/m/default/packs":
+			writePackLookupJSON(t, w, []map[string]any{
+				{"id": "knowledge"},
+			})
+		case "/api/v1/m/default/p/knowledge/system/lookups/pack_lookup.csv":
+			writePackLookupJSON(t, w, map[string]any{
+				"items": []map[string]any{
+					{
+						"id":   "pack_lookup.csv",
+						"mode": "memory",
+					},
+				},
+			})
+		case "/api/v1/m/default/p/knowledge/system/lookups/pack_lookup.csv/content":
+			if got := r.URL.Query().Get("raw"); got != "true" {
+				t.Fatalf("raw = %q, want true", got)
+			}
+			w.Header().Set("Content-Type", "text/csv")
+			_, _ = w.Write([]byte("key,value\nalpha,beta\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	api := newPackLookupsAPI(restclient.New(restclient.Config{
+		BaseURL:     server.URL,
+		BearerToken: "test-token",
+	}))
+
+	model, err := api.Read(context.Background(), PackLookupsModel{
+		GroupID: types.StringValue("default"),
+		Pack:    types.StringValue("knowledge"),
+		ID:      types.StringValue("pack_lookup.csv"),
+	})
+	if err != nil {
+		t.Fatalf("Read returned error: %v", err)
+	}
+	if got := model.ID.ValueString(); got != "pack_lookup.csv" {
+		t.Fatalf("ID = %q, want configured ID", got)
+	}
+	if got := model.Content.ValueString(); got != "key,value\nalpha,beta\n" {
+		t.Fatalf("Content = %q, want downloaded content", got)
+	}
+	wantPaths := []string{
+		"/api/v1/m/default/packs",
+		"/api/v1/m/default/p/knowledge/system/lookups/pack_lookup.csv",
+		"/api/v1/m/default/p/knowledge/system/lookups/pack_lookup.csv/content",
+	}
+	if len(requestedPaths) != len(wantPaths) {
+		t.Fatalf("requested paths = %#v, want %#v", requestedPaths, wantPaths)
+	}
+	for i := range wantPaths {
+		if requestedPaths[i] != wantPaths[i] {
+			t.Fatalf("requested paths = %#v, want %#v", requestedPaths, wantPaths)
+		}
+	}
+}
+
+func writePackLookupJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("write response: %v", err)
+	}
+}

--- a/internal/provider/pack_lookups_resource.go
+++ b/internal/provider/pack_lookups_resource.go
@@ -270,10 +270,8 @@ func applyPackLookupsAPIToState(api *PackLookupsModel, state *PackLookupsModel, 
 	if api == nil || state == nil {
 		return
 	}
-	if !preserveInputs || (fillMissingInputs && (state.Content.IsNull() || state.Content.IsUnknown())) {
-		if !api.Content.IsNull() && !api.Content.IsUnknown() {
-			state.Content = api.Content
-		}
+	if !api.Content.IsNull() && !api.Content.IsUnknown() {
+		state.Content = api.Content
 	}
 	if !preserveInputs || (fillMissingInputs && (state.Description.IsNull() || state.Description.IsUnknown())) {
 		if !api.Description.IsNull() && !api.Description.IsUnknown() {

--- a/internal/restclient/client.go
+++ b/internal/restclient/client.go
@@ -110,6 +110,11 @@ func Get[T any](ctx context.Context, c *Client, path string) (*T, error) {
 	return decodeResponse[T](path, body)
 }
 
+// GetRaw sends a GET request and returns the raw response body.
+func GetRaw(ctx context.Context, c *Client, path string) ([]byte, error) {
+	return do(ctx, c, http.MethodGet, path, "", nil)
+}
+
 // Post sends a POST request with a JSON body and decodes the response.
 func Post[Req, Resp any](ctx context.Context, c *Client, path string, body Req) (*Resp, error) {
 	responseBody, err := doJSON(ctx, c, http.MethodPost, path, body)

--- a/tools/codegen/render_test.go
+++ b/tools/codegen/render_test.go
@@ -557,6 +557,9 @@ func TestRenderedSnippets(t *testing.T) {
 	packLookups := parser.ResourceDef{
 		StructName: "PackLookups",
 		TypeName:   "criblio_pack_lookups",
+		Fields: []parser.FieldDef{
+			{APIName: "content", TerraformName: "content", GoName: "Content", Type: "string", Optional: true},
+		},
 		Create: parser.OperationDef{
 			Method: "POST",
 			Path:   "/m/{groupId}/p/{pack}/system/lookups",
@@ -597,9 +600,15 @@ func TestRenderedSnippets(t *testing.T) {
 	assertContains(t, packLookupsClient, `"net/url"`)
 	assertContains(t, packLookupsClient, `if err := uploadPackLookupFileContent(ctx, a.client, model, id); err != nil`)
 	assertContains(t, packLookupsClient, `for _, id := range lookupFileAPIIDs(configuredID)`)
+	assertContains(t, packLookupsClient, `downloadPackLookupFileContent(ctx, a.client, model.GroupID.ValueString(), packID, id)`)
 	assertContains(t, packLookupsClient, `return normalizePackLookupsAPIModel(apiModel, configuredID), nil`)
 	assertContains(t, packLookupsClient, `func uploadPackLookupFileContent(ctx context.Context, client *restclient.Client, model PackLookupsModel, id string) error`)
+	assertContains(t, packLookupsClient, `func downloadPackLookupFileContent(ctx context.Context, client *restclient.Client, groupID, packID, id string) (*string, error)`)
 	assertContains(t, packLookupsClient, `url.QueryEscape(filename)`)
+	packLookupsResource := renderTemplate(t, "resource", packLookups)
+	assertContains(t, packLookupsResource, `if !api.Content.IsNull() && !api.Content.IsUnknown() {`)
+	assertContains(t, packLookupsResource, `state.Content = api.Content`)
+	assertNotContains(t, packLookupsResource, `state.Content.IsNull() || state.Content.IsUnknown()`)
 
 	fixedAPIField := parser.ResourceDef{
 		Name:     "searchengine",

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -1083,6 +1083,11 @@ func (a {{ .StructName }}API) Read(ctx context.Context, model {{ .StructName }}M
 	for _, id := range lookupFileAPIIDs(configuredID) {
 		apiModel, err := restclient.Get[LookupFileModel](ctx, a.client, fmt.Sprintf("/m/%s/system/lookups/%s", model.GroupID.ValueString(), id))
 		if err == nil {
+			if content, contentErr := downloadLookupFileContent(ctx, a.client, model.GroupID.ValueString(), id); contentErr != nil {
+				return nil, contentErr
+			} else if content != nil {
+				apiModel.Content = types.StringValue(*content)
+			}
 			return normalizeLookupFileAPIModel(apiModel, configuredID), nil
 		}
 		if !restclient.IsNotFound(err) {
@@ -1094,9 +1099,15 @@ func (a {{ .StructName }}API) Read(ctx context.Context, model {{ .StructName }}M
 {{- else if eq .StructName "PackLookups" }}
 	configuredID := model.ID.ValueString()
 	var lastErr error
+	packID := resolvePackIDForRestAPI(ctx, a.client, model.GroupID.ValueString(), model.Pack.ValueString())
 	for _, id := range lookupFileAPIIDs(configuredID) {
-		apiModel, err := restclient.Get[PackLookupsModel](ctx, a.client, fmt.Sprintf("/m/%s/p/%s/system/lookups/%s", model.GroupID.ValueString(), resolvePackIDForRestAPI(ctx, a.client, model.GroupID.ValueString(), model.Pack.ValueString()), id))
+		apiModel, err := restclient.Get[PackLookupsModel](ctx, a.client, fmt.Sprintf("/m/%s/p/%s/system/lookups/%s", model.GroupID.ValueString(), packID, id))
 		if err == nil {
+			if content, contentErr := downloadPackLookupFileContent(ctx, a.client, model.GroupID.ValueString(), packID, id); contentErr != nil {
+				return nil, contentErr
+			} else if content != nil {
+				apiModel.Content = types.StringValue(*content)
+			}
 			return normalizePackLookupsAPIModel(apiModel, configuredID), nil
 		}
 		if !restclient.IsNotFound(err) {
@@ -1317,6 +1328,19 @@ func uploadLookupFileContent(ctx context.Context, client *restclient.Client, mod
 	return restclient.PutRawNoResponse(ctx, client, path, "text/csv", []byte(model.Content.ValueString()))
 }
 
+func downloadLookupFileContent(ctx context.Context, client *restclient.Client, groupID, id string) (*string, error) {
+	filename := lookupFileUploadFilename(id)
+	body, err := restclient.GetRaw(ctx, client, fmt.Sprintf("/m/%s/system/lookups/%s/content?raw=true", url.PathEscape(groupID), url.PathEscape(filename)))
+	if err != nil {
+		if restclient.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	content := string(body)
+	return &content, nil
+}
+
 func normalizeLookupFileAPIModel(model *LookupFileModel, terraformID string) *LookupFileModel {
 	if model == nil {
 		return nil
@@ -1336,6 +1360,19 @@ func uploadPackLookupFileContent(ctx context.Context, client *restclient.Client,
 	filename := lookupFileUploadFilename(id)
 	path := fmt.Sprintf("/m/%s/p/%s/system/lookups?filename=%s", model.GroupID.ValueString(), resolvePackIDForRestAPI(ctx, client, model.GroupID.ValueString(), model.Pack.ValueString()), url.QueryEscape(filename))
 	return restclient.PutRawNoResponse(ctx, client, path, "text/csv", []byte(model.Content.ValueString()))
+}
+
+func downloadPackLookupFileContent(ctx context.Context, client *restclient.Client, groupID, packID, id string) (*string, error) {
+	filename := lookupFileUploadFilename(id)
+	body, err := restclient.GetRaw(ctx, client, fmt.Sprintf("/m/%s/p/%s/system/lookups/%s/content?raw=true", url.PathEscape(groupID), url.PathEscape(packID), url.PathEscape(filename)))
+	if err != nil {
+		if restclient.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	content := string(body)
+	return &content, nil
 }
 
 func normalizePackLookupsAPIModel(model *PackLookupsModel, terraformID string) *PackLookupsModel {
@@ -1835,6 +1872,11 @@ func apply{{ .StructName }}APIToState(api *{{ .StructName }}Model, state *{{ .St
 	sync{{ .StructName }}LegacyItems(api, state)
 {{- end }}
 {{- range .Fields }}
+{{- if and (or (eq $.StructName "LookupFile") (eq $.StructName "PackLookups")) (eq .TerraformName "content") }}
+	if !api.{{ .GoName }}.IsNull() && !api.{{ .GoName }}.IsUnknown() {
+		state.{{ .GoName }} = api.{{ .GoName }}
+	}
+{{- else }}
 {{- if not .Computed }}
 	if !preserveInputs || (fillMissingInputs && (state.{{ .GoName }}.IsNull() || state.{{ .GoName }}.IsUnknown())){{- if nestedObjectList . }} || (!api.{{ .GoName }}.IsNull() && !api.{{ .GoName }}.IsUnknown() && !state.{{ .GoName }}.IsNull() && !state.{{ .GoName }}.IsUnknown() && len(state.{{ .GoName }}.Elements()) == 0){{- end }} {
 {{- end }}
@@ -1893,6 +1935,7 @@ func apply{{ .StructName }}APIToState(api *{{ .StructName }}Model, state *{{ .St
 {{- end }}
 {{- if not .Computed }}
 	}
+{{- end }}
 {{- end }}
 {{- if nestedObjectList . }}
 	if state.{{ .GoName }}.IsNull() || state.{{ .GoName }}.IsUnknown() {

--- a/tools/import-cli/cmd/export.go
+++ b/tools/import-cli/cmd/export.go
@@ -174,6 +174,7 @@ func NewExportCommand() *cobra.Command {
 				if exportErr != nil {
 					return fmt.Errorf("export: %w", exportErr)
 				}
+				printExportSummary(c, exportResult, verbose, onPrem)
 				fmt.Fprintln(c.OutOrStdout(), "No resources to export. Run with --dry-run to see resource counts by type.")
 				return nil
 			}

--- a/tools/import-cli/internal/converter/converter.go
+++ b/tools/import-cli/internal/converter/converter.go
@@ -204,6 +204,24 @@ func callRESTGetByID(ctx context.Context, client *importclient.Client, e registr
 	if itemErr != nil {
 		return nil, err
 	}
+	if rawItems, ok := (*item)["items"]; ok {
+		var items []json.RawMessage
+		if unmarshalErr := json.Unmarshal(rawItems, &items); unmarshalErr != nil {
+			return nil, fmt.Errorf("%s: decode REST response items: %w", e.TypeName, unmarshalErr)
+		}
+		if len(items) == 0 {
+			return nil, fmt.Errorf("%s: empty REST response", e.TypeName)
+		}
+		if id := requestParams["ID"]; id != "" {
+			for _, raw := range items {
+				var object map[string]any
+				if json.Unmarshal(raw, &object) == nil && rawString(object, "id", "ID", "Id", "keyID", "keyId", "name") == id {
+					return raw, nil
+				}
+			}
+		}
+		return items[0], nil
+	}
 	return json.Marshal(item)
 }
 

--- a/tools/import-cli/internal/converter/converter_test.go
+++ b/tools/import-cli/internal/converter/converter_test.go
@@ -66,6 +66,42 @@ func TestConvertUsesRESTGetPath(t *testing.T) {
 	assert.Equal(t, "default", pipeline.GroupID.ValueString())
 }
 
+func TestConvertLookupFileUsesWrappedGetItemContent(t *testing.T) {
+	const lookupID = "lookup dir/file.csv"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v1/m/default/system/lookups/lookup%20dir%2Ffile.csv", r.URL.EscapedPath())
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"id":"lookup dir/file.csv","content":"key,value\none,two","description":"from get","mode":"memory","version":"v1"}]}`))
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	e, ok := reg.ByTypeName("criblio_lookup_file")
+	require.True(t, ok)
+	require.NotEmpty(t, e.RESTGetPath)
+
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	model, err := Convert(context.Background(), client, e, map[string]string{
+		"GroupID": "default",
+		"ID":      lookupID,
+	})
+	require.NoError(t, err)
+	lookup, ok := model.(*provider.LookupFileResourceModel)
+	require.True(t, ok)
+	assert.Equal(t, lookupID, lookup.ID.ValueString())
+	assert.Equal(t, "default", lookup.GroupID.ValueString())
+	assert.Equal(t, "key,value\none,two", lookup.Content.ValueString())
+	assert.Equal(t, "from get", lookup.Description.ValueString())
+	assert.Equal(t, "memory", lookup.Mode.ValueString())
+	assert.Equal(t, "v1", lookup.Version.ValueString())
+}
+
 func TestConvertFromResponseBody_source(t *testing.T) {
 	ctx := context.Background()
 	reg := buildTestRegistry(t)

--- a/tools/import-cli/internal/custom/searchlist.go
+++ b/tools/import-cli/internal/custom/searchlist.go
@@ -96,6 +96,14 @@ var DefaultSearchSavedQueryIDs = map[string]bool{
 	"cribl_search_started_1h":  true,
 }
 
+// DefaultLookupFileIDs are built-in lookup files that ship with Cribl but are not
+// marked with lib/tags in the lookup API responses.
+var DefaultLookupFileIDs = map[string]bool{
+	"model_relative_entropy_top_domains.csv": true,
+	"service_names_port_numbers.csv":         true,
+	"xsiam_name_vendor_products.csv":         true,
+}
+
 // DefaultDestinationIDs are built-in destination IDs that are never imported.
 // We skip these when listing destinations so only user-created destinations are exported.
 var DefaultDestinationIDs = map[string]bool{

--- a/tools/import-cli/internal/discovery/engine.go
+++ b/tools/import-cli/internal/discovery/engine.go
@@ -374,6 +374,8 @@ func identifiersFromRawItems(items []json.RawMessage, scope map[string]string, e
 
 func shouldSkipRawID(typeName, id string, item map[string]any) bool {
 	switch {
+	case isLookupFileType(typeName) && (strings.HasPrefix(id, "cribl.") || rawHasCriblDefaultTag(item)):
+		return true
 	case typeName == "criblio_search_dataset" && rawHasCriblDefaultTag(item):
 		return true
 	case typeName == "criblio_search_dataset_provider" && custom.DefaultSearchDatasetProviderIDs[id]:
@@ -390,6 +392,10 @@ func shouldSkipRawID(typeName, id string, item map[string]any) bool {
 		return true
 	}
 	return false
+}
+
+func isLookupFileType(typeName string) bool {
+	return typeName == "criblio_lookup_file" || typeName == "criblio_pack_lookups"
 }
 
 func listLakehouseDatasetConnectionIdentifiers(ctx context.Context, client *importclient.Client) ([]map[string]string, error) {
@@ -520,13 +526,18 @@ func rawString(item map[string]any, keys ...string) string {
 }
 
 func rawHasCriblDefaultTag(item map[string]any) bool {
-	tags, ok := item["tags"].([]any)
+	tags, ok := item["tags"]
 	if !ok {
 		return false
 	}
-	for _, tag := range tags {
-		if s, ok := tag.(string); ok && strings.EqualFold(s, custom.CriblDefaultTag) {
-			return true
+	switch typed := tags.(type) {
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), custom.CriblDefaultTag)
+	case []any:
+		for _, tag := range typed {
+			if s, ok := tag.(string); ok && strings.EqualFold(strings.TrimSpace(s), custom.CriblDefaultTag) {
+				return true
+			}
 		}
 	}
 	return false

--- a/tools/import-cli/internal/discovery/engine_test.go
+++ b/tools/import-cli/internal/discovery/engine_test.go
@@ -170,6 +170,26 @@ func TestIdentifiersFromRawItems_skipsLibCribl(t *testing.T) {
 	assert.Equal(t, "default", ids[0]["group_id"])
 }
 
+func TestIdentifiersFromRawItems_skipsBuiltInLookupFiles(t *testing.T) {
+	reg := mustBuildRegistry(t, context.Background())
+	e, ok := reg.ByTypeName("criblio_lookup_file")
+	require.True(t, ok, "criblio_lookup_file must be in registry")
+
+	items := []json.RawMessage{
+		[]byte(`{"id":"lib_builtin.csv","lib":"cribl"}`),
+		[]byte(`{"id":"library_builtin.csv","library":"cribl"}`),
+		[]byte(`{"id":"tag_builtin.csv","tags":"cribl:default"}`),
+		[]byte(`{"id":"list_tag_builtin.csv","tags":["other","cribl:default"]}`),
+		[]byte(`{"id":"cribl.prefixed.csv"}`),
+		[]byte(`{"id":"user_lookup.csv"}`),
+	}
+	ids, err := identifiersFromRawItems(items, map[string]string{"group_id": "default"}, e)
+	require.NoError(t, err)
+	require.Len(t, ids, 1)
+	assert.Equal(t, "user_lookup.csv", ids[0]["id"])
+	assert.Equal(t, "default", ids[0]["group_id"])
+}
+
 func TestRegistryImportableEntriesHaveRESTGetPath(t *testing.T) {
 	for _, e := range mustBuildRegistry(t, context.Background()).Entries() {
 		if e.ImportIDFormat == "" || e.TypeName == "criblio_lakehouse_dataset_connection" {

--- a/tools/import-cli/internal/exclusions/exclusions.go
+++ b/tools/import-cli/internal/exclusions/exclusions.go
@@ -10,9 +10,7 @@ var NoExportTypes = []string{
 	"criblio_group_system_settings",        // Cloud rejects api host/port updates on default group; config/state drift causes apply failures.
 	"criblio_key",                          // Skipped from import; keys are sensitive.
 	"criblio_lakehouse_dataset_connection", // No list/get API; exporting synthesized lakehouse x dataset pairs creates phantom imports.
-	"criblio_lookup_file",                  // Control Plane API may not return content; UI uses different endpoint (knowledge/lookups).
 	"criblio_mapping_ruleset",              // List API is on root CriblIo (GetAdminProductsMappingsByProduct), not a service; no standard discovery.
-	"criblio_pack_lookups",                 // Same as lookup_file; content often missing from API response.
 	"criblio_search_usage_group",           // API returns null/empty for rules; required attr causes import/plan issues.
 	"criblio_workspace",                    // No list/get API in SDK; workspace is implicit from config.
 }

--- a/tools/import-cli/internal/exclusions/exclusions_test.go
+++ b/tools/import-cli/internal/exclusions/exclusions_test.go
@@ -13,9 +13,7 @@ func TestNoExportTypes_ContainsExpectedTypes(t *testing.T) {
 		"criblio_group_system_settings":        true,
 		"criblio_key":                          true,
 		"criblio_lakehouse_dataset_connection": true,
-		"criblio_lookup_file":                  true,
 		"criblio_mapping_ruleset":              true,
-		"criblio_pack_lookups":                 true,
 		"criblio_search_usage_group":           true,
 		"criblio_workspace":                    true,
 	}
@@ -23,6 +21,13 @@ func TestNoExportTypes_ContainsExpectedTypes(t *testing.T) {
 		assert.True(t, expected[typ], "NoExportTypes should contain %q", typ)
 	}
 	assert.Len(t, NoExportTypes, len(expected), "NoExportTypes count should match expected")
+}
+
+func TestNoExportTypes_AllowsLookupFileTypes(t *testing.T) {
+	for _, typ := range NoExportTypes {
+		assert.NotEqual(t, "criblio_lookup_file", typ)
+		assert.NotEqual(t, "criblio_pack_lookups", typ)
+	}
 }
 
 func TestSkipExportIDs_ContainsExpectedTypesAndIDs(t *testing.T) {

--- a/tools/import-cli/internal/export/export_test.go
+++ b/tools/import-cli/internal/export/export_test.go
@@ -3,9 +3,13 @@ package export
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/criblio/terraform-provider-criblio/internal/provider"
+	"github.com/criblio/terraform-provider-criblio/internal/restclient"
+	importclient "github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/client"
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/converter"
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/custom"
 	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/discovery"
@@ -43,6 +47,377 @@ func TestToResourceItems_nil_client_list_skipped(t *testing.T) {
 	// List fails (e.g. nil client) → recorded as list skip, not as returned error.
 	assert.Len(t, result.ListSkipped, 1, "list failure should be recorded in ListSkipped")
 	assert.Equal(t, "criblio_source", result.ListSkipped[0].TypeName)
+}
+
+func TestToResourceItemsLookupFileFetchesContentFromGet(t *testing.T) {
+	getCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/m/default/system/lookups":
+			_, _ = w.Write([]byte(`{"items":[{"id":"lookup.csv","description":"metadata only","version":"list-version"}]}`))
+		case "/api/v1/m/default/system/lookups/lookup.csv":
+			getCalled = true
+			_, _ = w.Write([]byte(`{"items":[{"id":"lookup.csv","content":"key,value\none,two","description":"from get","mode":"memory","version":"get-version","pendingTask":{"id":"task-1","type":"upload"}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	result, err := ToResourceItems(
+		context.Background(),
+		client,
+		reg,
+		[]discovery.Result{{TypeName: "criblio_lookup_file", Count: 1}},
+		[]string{"default"},
+		nil,
+		1,
+		false,
+		IncludeOverride{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, getCalled, "lookup file export should fetch the item by ID after list discovery")
+	require.Empty(t, result.ListSkipped)
+	require.Empty(t, result.ConvertSkipped)
+	require.Len(t, result.Items, 1)
+
+	item := result.Items[0]
+	assert.Equal(t, "criblio_lookup_file", item.TypeName)
+	assert.Equal(t, "default", item.GroupID)
+	assert.Equal(t, `{"group_id":"default","id":"lookup.csv"}`, item.ImportID)
+	require.Len(t, item.Files, 1)
+	assert.Equal(t, "files/lookup_file_default_lookup_csv/lookup.csv", item.Files[0].Path)
+	assert.Equal(t, []byte("key,value\none,two"), item.Files[0].Content)
+	require.Equal(t, hcl.KindExpression, item.Attrs["content"].Kind)
+	assert.Equal(t, `file("${path.module}/files/lookup_file_default_lookup_csv/lookup.csv")`, item.Attrs["content"].Expr)
+	assert.Equal(t, "from get", item.Attrs["description"].String)
+	assert.Equal(t, "memory", item.Attrs["mode"].String)
+	assert.NotContains(t, item.Attrs, "pending_task")
+	assert.NotContains(t, item.Attrs, "version")
+}
+
+func TestToResourceItemsLookupFileDownloadsRawContentWhenGetOmitsContent(t *testing.T) {
+	rawCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/m/default/system/lookups":
+			_, _ = w.Write([]byte(`{"items":[{"id":"lookup.csv","description":"metadata only","version":"list-version"}]}`))
+		case "/api/v1/m/default/system/lookups/lookup.csv":
+			_, _ = w.Write([]byte(`{"items":[{"id":"lookup.csv","description":"from get","mode":"memory","version":"get-version"}]}`))
+		case "/api/v1/m/default/system/lookups/lookup.csv/content":
+			if r.URL.Query().Get("raw") == "true" {
+				rawCalled = true
+				w.Header().Set("Content-Type", "text/csv")
+				_, _ = w.Write([]byte("key,value\nraw,content"))
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	result, err := ToResourceItems(
+		context.Background(),
+		client,
+		reg,
+		[]discovery.Result{{TypeName: "criblio_lookup_file", Count: 1}},
+		[]string{"default"},
+		nil,
+		1,
+		false,
+		IncludeOverride{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, rawCalled, "lookup export should fall back to raw content download")
+	require.Empty(t, result.ConvertSkipped)
+	require.Len(t, result.Items, 1)
+
+	item := result.Items[0]
+	require.Len(t, item.Files, 1)
+	assert.Equal(t, []byte("key,value\nraw,content"), item.Files[0].Content)
+	require.Equal(t, hcl.KindExpression, item.Attrs["content"].Kind)
+	assert.Equal(t, `file("${path.module}/files/lookup_file_default_lookup_csv/lookup.csv")`, item.Attrs["content"].Expr)
+}
+
+func TestToResourceItemsLookupFileSkipsBuiltIns(t *testing.T) {
+	defaultGetCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/m/default/system/lookups":
+			_, _ = w.Write([]byte(`{"items":[{"id":"builtin_lib.csv","lib":"cribl"},{"id":"builtin_tag.csv","tags":"cribl:default"},{"id":"cribl.prefixed.csv"},{"id":"service_names_port_numbers.csv"},{"id":"my_id.csv"}]}`))
+		case "/api/v1/m/default/system/lookups/my_id.csv":
+			_, _ = w.Write([]byte(`{"items":[{"id":"my_id.csv","content":"key,value\none,two","description":"user lookup","mode":"memory"}]}`))
+		case "/api/v1/m/default/system/lookups/service_names_port_numbers.csv":
+			defaultGetCalled = true
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	result, err := ToResourceItems(
+		context.Background(),
+		client,
+		reg,
+		[]discovery.Result{{TypeName: "criblio_lookup_file", Count: 3}},
+		[]string{"default"},
+		nil,
+		1,
+		false,
+		IncludeOverride{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.ListSkipped)
+	require.Len(t, result.Items, 1)
+	require.False(t, defaultGetCalled, "known default lookups should skip before per-item conversion")
+
+	item := result.Items[0]
+	assert.Equal(t, "my_id.csv", item.Attrs["id"].String)
+	assert.Equal(t, `{"group_id":"default","id":"my_id.csv"}`, item.ImportID)
+	require.Len(t, result.ConvertSkipped, 1)
+	assert.Contains(t, result.ConvertSkipped[0], "service_names_port_numbers.csv")
+	assert.Contains(t, result.ConvertSkipped[0], "built-in default lookup")
+}
+
+func TestToResourceItemsLookupFileIncludeDefaultIDOverride(t *testing.T) {
+	contentCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/m/default/system/lookups":
+			_, _ = w.Write([]byte(`{"items":[{"id":"service_names_port_numbers.csv","size":23156}]}`))
+		case "/api/v1/m/default/system/lookups/service_names_port_numbers.csv":
+			_, _ = w.Write([]byte(`{"items":[{"id":"service_names_port_numbers.csv","size":23156}]}`))
+		case "/api/v1/m/default/system/lookups/service_names_port_numbers.csv/content":
+			contentCalled = true
+			w.Header().Set("Content-Type", "text/csv")
+			_, _ = w.Write([]byte("name,port\nhttp,80"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	result, err := ToResourceItems(
+		context.Background(),
+		client,
+		reg,
+		[]discovery.Result{{TypeName: "criblio_lookup_file", Count: 1}},
+		[]string{"default"},
+		nil,
+		1,
+		false,
+		ParseIncludeDefaultIDs([]string{"criblio_lookup_file:service_names_port_numbers.csv"}),
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, contentCalled)
+	require.Empty(t, result.ConvertSkipped)
+	require.Len(t, result.Items, 1)
+
+	item := result.Items[0]
+	assert.Equal(t, "service_names_port_numbers.csv", item.Attrs["id"].String)
+	require.Len(t, item.Files, 1)
+	assert.Equal(t, []byte("name,port\nhttp,80"), item.Files[0].Content)
+}
+
+func TestToResourceItemsLookupFileSkipsCriblDefaultTag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/m/default/system/lookups":
+			_, _ = w.Write([]byte(`{"items":[{"id":"new_builtin.csv"}]}`))
+		case "/api/v1/m/default/system/lookups/new_builtin.csv":
+			_, _ = w.Write([]byte(`{"items":[{"id":"new_builtin.csv","tags":"cribl:default","mode":"memory"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	result, err := ToResourceItems(
+		context.Background(),
+		client,
+		reg,
+		[]discovery.Result{{TypeName: "criblio_lookup_file", Count: 1}},
+		[]string{"default"},
+		nil,
+		1,
+		false,
+		IncludeOverride{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Empty(t, result.Items)
+	require.Len(t, result.ConvertSkipped, 1)
+	assert.Contains(t, result.ConvertSkipped[0], "cribl:default tag")
+}
+
+func TestToResourceItemsPackLookupsFetchesContentFromGet(t *testing.T) {
+	getCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/m/default/packs":
+			_, _ = w.Write([]byte(`{"items":[{"id":"knowledge"}]}`))
+		case "/api/v1/m/default/p/knowledge/system/lookups":
+			_, _ = w.Write([]byte(`{"items":[{"id":"pack_lookup.csv","description":"metadata only","version":"list-version"}]}`))
+		case "/api/v1/m/default/p/knowledge/system/lookups/pack_lookup.csv":
+			getCalled = true
+			_, _ = w.Write([]byte(`{"items":[{"id":"pack_lookup.csv","content":"key,value\nalpha,beta","description":"from get","mode":"memory","version":"get-version","pendingTask":{"id":"task-1","type":"upload"}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	result, err := ToResourceItems(
+		context.Background(),
+		client,
+		reg,
+		[]discovery.Result{{TypeName: "criblio_pack_lookups", Count: 1}},
+		[]string{"default"},
+		nil,
+		1,
+		false,
+		IncludeOverride{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, getCalled, "pack lookup export should fetch the item by ID after list discovery")
+	require.Empty(t, result.ListSkipped)
+	require.Empty(t, result.ConvertSkipped)
+	require.Len(t, result.Items, 1)
+
+	item := result.Items[0]
+	assert.Equal(t, "criblio_pack_lookups", item.TypeName)
+	assert.Equal(t, "default", item.GroupID)
+	assert.Equal(t, `{"group_id":"default","id":"pack_lookup.csv","pack":"knowledge"}`, item.ImportID)
+	assert.Equal(t, "default", item.Attrs["group_id"].String)
+	assert.Equal(t, "knowledge", item.Attrs["pack"].String)
+	require.Len(t, item.Files, 1)
+	assert.Equal(t, "files/pack_lookups_default_pack_lookup_csv_knowledge/pack_lookup.csv", item.Files[0].Path)
+	assert.Equal(t, []byte("key,value\nalpha,beta"), item.Files[0].Content)
+	require.Equal(t, hcl.KindExpression, item.Attrs["content"].Kind)
+	assert.Equal(t, `file("${path.module}/files/pack_lookups_default_pack_lookup_csv_knowledge/pack_lookup.csv")`, item.Attrs["content"].Expr)
+	assert.Equal(t, "from get", item.Attrs["description"].String)
+	assert.Equal(t, "memory", item.Attrs["mode"].String)
+	assert.NotContains(t, item.Attrs, "pending_task")
+	assert.NotContains(t, item.Attrs, "version")
+}
+
+func TestToResourceItemsPackLookupsDownloadsRawContentWhenGetOmitsContent(t *testing.T) {
+	rawCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/v1/m/default/packs":
+			_, _ = w.Write([]byte(`{"items":[{"id":"knowledge"}]}`))
+		case "/api/v1/m/default/p/knowledge/system/lookups":
+			_, _ = w.Write([]byte(`{"items":[{"id":"pack_lookup.csv","description":"metadata only","version":"list-version"}]}`))
+		case "/api/v1/m/default/p/knowledge/system/lookups/pack_lookup.csv":
+			_, _ = w.Write([]byte(`{"items":[{"id":"pack_lookup.csv","description":"from get","mode":"memory","version":"get-version"}]}`))
+		case "/api/v1/m/default/p/knowledge/system/lookups/pack_lookup.csv/content":
+			if r.URL.Query().Get("raw") == "true" {
+				rawCalled = true
+				w.Header().Set("Content-Type", "text/csv")
+				_, _ = w.Write([]byte("key,value\nraw,pack"))
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	reg := buildTestRegistry(t)
+	client := &importclient.Client{
+		REST: restclient.New(restclient.Config{
+			BaseURL:     server.URL,
+			BearerToken: "mock",
+			HTTPClient:  server.Client(),
+		}),
+	}
+	result, err := ToResourceItems(
+		context.Background(),
+		client,
+		reg,
+		[]discovery.Result{{TypeName: "criblio_pack_lookups", Count: 1}},
+		[]string{"default"},
+		nil,
+		1,
+		false,
+		IncludeOverride{},
+		nil,
+	)
+	require.NoError(t, err)
+	require.True(t, rawCalled, "pack lookup export should fall back to raw content download")
+	require.Empty(t, result.ConvertSkipped)
+	require.Len(t, result.Items, 1)
+
+	item := result.Items[0]
+	require.Len(t, item.Files, 1)
+	assert.Equal(t, []byte("key,value\nraw,pack"), item.Files[0].Content)
+	require.Equal(t, hcl.KindExpression, item.Attrs["content"].Kind)
+	assert.Equal(t, `file("${path.module}/files/pack_lookups_default_pack_lookup_csv_knowledge/pack_lookup.csv")`, item.Attrs["content"].Expr)
 }
 
 func buildTestRegistry(t *testing.T) *registry.Registry {
@@ -313,8 +688,9 @@ func TestSkipResourceByID(t *testing.T) {
 		idMap := map[string]string{"group_id": "default", "id": "default", "product": "stream"}
 		assert.False(t, skipResourceByID("criblio_group", idMap))
 	})
-	t.Run("skip criblio_pack_lookups when id starts with cribl.", func(t *testing.T) {
-		assert.True(t, skipResourceByID("criblio_pack_lookups", map[string]string{"id": "cribl.something"}))
+	t.Run("not skip user-created lookup files", func(t *testing.T) {
+		assert.False(t, skipResourceByID("criblio_lookup_file", map[string]string{"id": "my_id.csv"}))
+		assert.False(t, skipResourceByID("criblio_pack_lookups", map[string]string{"id": "test.csv"}))
 	})
 	t.Run("skip criblio_pack_vars when id contains dots", func(t *testing.T) {
 		assert.True(t, skipResourceByID("criblio_pack_vars", map[string]string{"id": "foo.bar.baz"}))
@@ -403,11 +779,17 @@ func TestDefaultResource(t *testing.T) {
 		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblLogs"}, attrs, noOverride))
 		assert.True(t, DefaultResource("criblio_source", map[string]string{"id": "CriblMetrics"}, attrs, noOverride))
 	})
+	t.Run("skip default lookup file IDs", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		assert.True(t, DefaultResource("criblio_lookup_file", map[string]string{"id": "service_names_port_numbers.csv"}, attrs, noOverride))
+		assert.True(t, DefaultResource("criblio_pack_lookups", map[string]string{"id": "xsiam_name_vendor_products.csv"}, attrs, noOverride))
+	})
 	t.Run("not skip user-created resources", func(t *testing.T) {
 		attrs := map[string]hcl.Value{}
 		assert.False(t, DefaultResource("criblio_pipeline", map[string]string{"id": "my_custom_pipeline"}, attrs, noOverride))
 		assert.False(t, DefaultResource("criblio_grok", map[string]string{"id": "my_grok"}, attrs, noOverride))
 		assert.False(t, DefaultResource("criblio_source", map[string]string{"id": "my_source"}, attrs, noOverride))
+		assert.False(t, DefaultResource("criblio_lookup_file", map[string]string{"id": "my_id.csv"}, attrs, noOverride))
 	})
 	t.Run("not skip when tags is empty list", func(t *testing.T) {
 		attrs := map[string]hcl.Value{"tags": {Kind: hcl.KindList, List: []hcl.Value{}}}
@@ -429,6 +811,12 @@ func TestDefaultResource(t *testing.T) {
 		override := ParseIncludeDefaultIDs([]string{"devnull"})
 		assert.False(t, DefaultResource("criblio_pipeline", map[string]string{"id": "devnull"}, attrs, override))
 		assert.False(t, DefaultResource("criblio_destination", map[string]string{"id": "devnull"}, attrs, override))
+	})
+	t.Run("include override bypasses default lookup IDs", func(t *testing.T) {
+		attrs := map[string]hcl.Value{}
+		override := ParseIncludeDefaultIDs([]string{"criblio_lookup_file:service_names_port_numbers.csv"})
+		assert.False(t, DefaultResource("criblio_lookup_file", map[string]string{"id": "service_names_port_numbers.csv"}, attrs, override))
+		assert.True(t, DefaultResource("criblio_pack_lookups", map[string]string{"id": "service_names_port_numbers.csv"}, attrs, override))
 	})
 	t.Run("include override matches criblio_routes group id", func(t *testing.T) {
 		attrs := map[string]hcl.Value{}

--- a/tools/import-cli/internal/export/filters.go
+++ b/tools/import-cli/internal/export/filters.go
@@ -100,12 +100,6 @@ func skipResourceByID(typeName string, idMap map[string]string) bool {
 	if pack := idMap["pack"]; pack != "" && custom.SkipPacks[pack] {
 		return true
 	}
-	// criblio_pack_lookups: skip built-in lookups (id starts with "cribl."); provider id pattern rejects them.
-	if typeName == "criblio_pack_lookups" {
-		if id := idMap["id"]; id != "" && strings.HasPrefix(id, "cribl.") {
-			return true
-		}
-	}
 	// criblio_pack_vars: skip vars whose id contains dots (e.g. cribl.my_globalvar); provider id pattern is ^[a-zA-Z0-9_-]+$
 	if typeName == "criblio_pack_vars" {
 		if id := idMap["id"]; id != "" && strings.Contains(id, ".") {
@@ -138,6 +132,21 @@ func skipResourceByID(typeName string, idMap map[string]string) bool {
 	return false
 }
 
+func isLookupFileType(typeName string) bool {
+	return typeName == "criblio_lookup_file" || typeName == "criblio_pack_lookups"
+}
+
+func defaultLookupFileByID(typeName string, idMap map[string]string, includeOverride IncludeOverride) bool {
+	if !isLookupFileType(typeName) {
+		return false
+	}
+	id := idMap["id"]
+	if id == "" || includeOverride.Includes(typeName, id) {
+		return false
+	}
+	return custom.DefaultLookupFileIDs[id]
+}
+
 func skipResourceWhenLibCribl(attrs map[string]hcl.Value) bool {
 	v, ok := attrs["lib"]
 	if !ok || v.Kind != hcl.KindString {
@@ -160,6 +169,8 @@ func DefaultResource(typeName string, idMap map[string]string, attrs map[string]
 	}
 	pack := idMap["pack"]
 	switch typeName {
+	case "criblio_lookup_file", "criblio_pack_lookups":
+		return custom.DefaultLookupFileIDs[id]
 	case "criblio_destination":
 		return custom.DefaultDestinationIDs[id]
 	case "criblio_pack_destination":

--- a/tools/import-cli/internal/export/items.go
+++ b/tools/import-cli/internal/export/items.go
@@ -24,6 +24,9 @@ func convertOneResource(ctx context.Context, client *importclient.Client, r disc
 	if skipResourceByID(r.TypeName, idMap) {
 		return nil, fmt.Sprintf("%s %v: skipped by config", r.TypeName, idMap)
 	}
+	if defaultLookupFileByID(r.TypeName, idMap, includeOverride) {
+		return nil, fmt.Sprintf("%s %v: built-in default lookup (skip export)", r.TypeName, idMap)
+	}
 	requestParams := toRequestParams(idMap)
 	model, convErr := converter.Convert(ctx, client, e, requestParams)
 	if convErr != nil {
@@ -82,6 +85,12 @@ func convertOneResource(ctx context.Context, client *importclient.Client, r disc
 	if skipResourceWhenLibCribl(attrs) {
 		return nil, fmt.Sprintf("%s %v: lib is cribl (built-in, skip export)", r.TypeName, idMap)
 	}
+	if isLookupFileType(r.TypeName) && criblDefaultTag(attrs) {
+		return nil, fmt.Sprintf("%s %v: cribl:default tag (built-in, skip export)", r.TypeName, idMap)
+	}
+	if isLookupFileType(r.TypeName) && DefaultResource(r.TypeName, idMap, attrs, includeOverride) {
+		return nil, fmt.Sprintf("%s %v: built-in default lookup (skip export)", r.TypeName, idMap)
+	}
 	if excludeDefaults && DefaultResource(r.TypeName, idMap, attrs, includeOverride) {
 		out.DefaultsSkipped++
 		return nil, fmt.Sprintf("%s %v: built-in default (--exclude-defaults)", r.TypeName, idMap)
@@ -110,12 +119,20 @@ func convertOneResource(ctx context.Context, client *importclient.Client, r disc
 		attrs["cert"] = hcl.Value{Kind: hcl.KindVariableRef, VarName: hcl.CertificateCertVariableName(name)}
 		attrs["priv_key"] = hcl.Value{Kind: hcl.KindVariableRef, VarName: hcl.CertificatePrivKeyVariableName(name)}
 	}
+	files, hasLookupContent, contentErr := lookupContentAsset(ctx, client, r.TypeName, attrs, name, idMap)
+	if contentErr != nil {
+		return nil, fmt.Sprintf("%s %v: lookup content: %s", r.TypeName, idMap, sanitizeConvertError(contentErr))
+	}
+	if !hasLookupContent {
+		return nil, fmt.Sprintf("%s %v: lookup content missing from API response", r.TypeName, idMap)
+	}
 	it := generator.ResourceItem{
 		TypeName: e.TypeName,
 		Name:     name,
 		Attrs:    attrs,
 		ImportID: importID,
 		GroupID:  groupIDForOutput(e.TypeName, groupIDFromIDMap(idMap)),
+		Files:    files,
 	}
 	it.LifecycleIgnoreChanges = lifecycleIgnoreChangesForConvertedResource(r.TypeName, attrs)
 	return &it, ""

--- a/tools/import-cli/internal/export/lookup_content.go
+++ b/tools/import-cli/internal/export/lookup_content.go
@@ -1,0 +1,157 @@
+package export
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+
+	"github.com/criblio/terraform-provider-criblio/internal/restclient"
+	importclient "github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/client"
+	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/generator"
+	"github.com/criblio/terraform-provider-criblio/tools/import-cli/internal/hcl"
+)
+
+func lookupContentAsset(ctx context.Context, client *importclient.Client, typeName string, attrs map[string]hcl.Value, resourceName string, idMap map[string]string) ([]generator.ResourceFile, bool, error) {
+	if !isLookupFileType(typeName) {
+		return nil, true, nil
+	}
+
+	content, ok := attrs["content"]
+	if !ok || content.Kind == hcl.KindNull {
+		downloaded, found, err := fetchLookupContent(ctx, client, typeName, idMap)
+		if err != nil || !found {
+			return nil, false, err
+		}
+		content = hcl.Value{Kind: hcl.KindString, String: downloaded}
+	}
+	if content.Kind != hcl.KindString {
+		return nil, false, nil
+	}
+
+	assetPath := path.Join("files", resourceName, lookupContentFilename(attrs))
+	attrs["content"] = hcl.Value{
+		Kind: hcl.KindExpression,
+		Expr: "file(" + strconv.Quote("${path.module}/"+assetPath) + ")",
+	}
+	return []generator.ResourceFile{{
+		Path:    assetPath,
+		Content: []byte(content.String),
+	}}, true, nil
+}
+
+func lookupContentFilename(attrs map[string]hcl.Value) string {
+	id, ok := attrs["id"]
+	if !ok || id.Kind != hcl.KindString || id.String == "" {
+		return "lookup.csv"
+	}
+	name := safeLookupContentFilename(id.String)
+	if name == "" || name == "." {
+		return "lookup.csv"
+	}
+	return name
+}
+
+func safeLookupContentFilename(name string) string {
+	name = strings.TrimSpace(name)
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range name {
+		allowed := (r >= 'a' && r <= 'z') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= '0' && r <= '9') ||
+			r == '.' ||
+			r == '-' ||
+			r == '_'
+		if allowed {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "._")
+}
+
+func fetchLookupContent(ctx context.Context, client *importclient.Client, typeName string, idMap map[string]string) (string, bool, error) {
+	if client == nil || client.REST == nil {
+		return "", false, nil
+	}
+	id := idMap["id"]
+	groupID := idMap["group_id"]
+	if id == "" || groupID == "" {
+		return "", false, nil
+	}
+
+	filename := lookupDownloadFilename(id)
+	var requestPath string
+	switch typeName {
+	case "criblio_lookup_file":
+		requestPath = fmt.Sprintf("/m/%s/system/lookups/%s/content?raw=true", url.PathEscape(groupID), url.PathEscape(filename))
+	case "criblio_pack_lookups":
+		pack := idMap["pack"]
+		if pack == "" {
+			return "", false, nil
+		}
+		requestPath = fmt.Sprintf("/m/%s/p/%s/system/lookups/%s/content?raw=true", url.PathEscape(groupID), url.PathEscape(pack), url.PathEscape(filename))
+	default:
+		return "", false, nil
+	}
+
+	body, err := restclient.GetRaw(ctx, client.REST, requestPath)
+	if err != nil {
+		if restclient.IsNotFound(err) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	if content, ok, isEnvelope := lookupContentFromJSONResponse(body); isEnvelope {
+		if !ok {
+			return "", false, nil
+		}
+		return content, true, nil
+	}
+	if len(body) == 0 {
+		return "", false, nil
+	}
+	return string(body), true, nil
+}
+
+func lookupContentFromJSONResponse(body []byte) (string, bool, bool) {
+	var envelope struct {
+		Items []struct {
+			Content *string `json:"content"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return "", false, false
+	}
+	if envelope.Items == nil {
+		return "", false, false
+	}
+	if len(envelope.Items) == 0 || envelope.Items[0].Content == nil {
+		return "", false, true
+	}
+	return *envelope.Items[0].Content, true, true
+}
+
+func lookupDownloadFilename(id string) string {
+	if lookupIDHasKnownExtension(id) {
+		return id
+	}
+	return id + ".csv"
+}
+
+func lookupIDHasKnownExtension(id string) bool {
+	lower := strings.ToLower(id)
+	return strings.HasSuffix(lower, ".csv") ||
+		strings.HasSuffix(lower, ".gz") ||
+		strings.HasSuffix(lower, ".csv.gz") ||
+		strings.HasSuffix(lower, ".mmdb")
+}

--- a/tools/import-cli/internal/generator/fs.go
+++ b/tools/import-cli/internal/generator/fs.go
@@ -14,6 +14,8 @@ type FileSystem interface {
 	// WriteFileAtomic writes data to name in dir by writing to a temp file then renaming.
 	// Callers get either the full content on disk or no file (atomic).
 	WriteFileAtomic(dir, name string, data []byte, perm os.FileMode) error
+	// RemoveAll removes path and any children. Used for generated asset directories.
+	RemoveAll(path string) error
 }
 
 // DefaultFS is the filesystem used by WriteModuleDirectory when no FS is provided.
@@ -25,6 +27,10 @@ type osFS struct{}
 
 func (*osFS) MkdirAll(path string, perm os.FileMode) error {
 	return os.MkdirAll(path, perm)
+}
+
+func (*osFS) RemoveAll(path string) error {
+	return os.RemoveAll(path)
 }
 
 func (*osFS) WriteFileAtomic(dir, name string, data []byte, perm os.FileMode) error {

--- a/tools/import-cli/internal/generator/fs_test.go
+++ b/tools/import-cli/internal/generator/fs_test.go
@@ -14,14 +14,22 @@ import (
 // mockFS implements FileSystem with in-memory storage for unit tests.
 // No real disk I/O; use to mock filesystem interactions.
 type mockFS struct {
-	mu            sync.Mutex
-	MkdirAllCalls []string          // paths passed to MkdirAll
-	Files         map[string][]byte // full path -> content
+	mu             sync.Mutex
+	MkdirAllCalls  []string          // paths passed to MkdirAll
+	RemoveAllCalls []string          // paths passed to RemoveAll
+	Files          map[string][]byte // full path -> content
 }
 
 func (m *mockFS) MkdirAll(path string, perm os.FileMode) error {
 	m.mu.Lock()
 	m.MkdirAllCalls = append(m.MkdirAllCalls, path)
+	m.mu.Unlock()
+	return nil
+}
+
+func (m *mockFS) RemoveAll(path string) error {
+	m.mu.Lock()
+	m.RemoveAllCalls = append(m.RemoveAllCalls, path)
 	m.mu.Unlock()
 	return nil
 }

--- a/tools/import-cli/internal/generator/importid.go
+++ b/tools/import-cli/internal/generator/importid.go
@@ -26,9 +26,11 @@ func BuildImportID(format string, identifiers map[string]string) (string, error)
 			if k == "" {
 				continue
 			}
-			if v, ok := identifiers[k]; ok {
-				obj[k] = v
+			v, ok := identifiers[k]
+			if !ok || v == "" {
+				return "", fmt.Errorf("identifier %q not found", k)
 			}
+			obj[k] = v
 		}
 		// Sort keys for deterministic JSON
 		names := make([]string, 0, len(obj))

--- a/tools/import-cli/internal/generator/importid_test.go
+++ b/tools/import-cli/internal/generator/importid_test.go
@@ -33,4 +33,9 @@ func TestBuildImportID(t *testing.T) {
 		_, err := BuildImportID("", map[string]string{"id": "x"})
 		require.Error(t, err)
 	})
+	t.Run("json_missing_identifier_error", func(t *testing.T) {
+		_, err := BuildImportID("json:group_id,id", map[string]string{"id": "lookup.csv"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), `identifier "group_id" not found`)
+	})
 }

--- a/tools/import-cli/internal/generator/module.go
+++ b/tools/import-cli/internal/generator/module.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -17,12 +18,20 @@ type ResourceItem struct {
 	Name     string
 	Attrs    map[string]hcl.Value
 	ImportID string
+	// Files are auxiliary files to write under this resource module directory.
+	Files []ResourceFile
 	// GroupID is the worker group/fleet/default_search id; used to organize output under <output_dir>/<id>/resources/.
 	// Empty or "global" for resources without group scope.
 	GroupID string
 	// LifecycleIgnoreChanges, when non-nil, adds lifecycle { ignore_changes = [...] } to the resource.
 	// Used for criblio_group_system_settings group_id=default (cloud disables API host/port updates).
 	LifecycleIgnoreChanges []string
+}
+
+// ResourceFile is an auxiliary file emitted next to generated Terraform.
+type ResourceFile struct {
+	Path    string
+	Content []byte
 }
 
 // SortResourceItems sorts items by TypeName then Name for deterministic output.
@@ -179,6 +188,7 @@ func WriteModuleDirectoryWithFSAndGroup(fs FileSystem, baseDir string, items []R
 		return nil
 	}
 	EnsureUniqueNames(items)
+	syncResourceFilePaths(items)
 	ApplyPipelineFunctionProcessorReferences(items)
 	SortResourceItems(items)
 	var dir string
@@ -189,6 +199,9 @@ func WriteModuleDirectoryWithFSAndGroup(fs FileSystem, baseDir string, items []R
 	}
 	if err := fs.MkdirAll(dir, 0755); err != nil {
 		return fmt.Errorf("create module dir: %w", err)
+	}
+	if err := writeResourceFiles(fs, dir, items); err != nil {
+		return err
 	}
 
 	// main.tf: resource blocks (order by name)
@@ -253,6 +266,101 @@ func WriteModuleDirectoryWithFSAndGroup(fs FileSystem, baseDir string, items []R
 		return err
 	}
 	return nil
+}
+
+func writeResourceFiles(fs FileSystem, moduleDir string, items []ResourceItem) error {
+	if !resourceItemsHaveFiles(items) {
+		return nil
+	}
+	if err := fs.RemoveAll(filepath.Join(moduleDir, "files")); err != nil {
+		return fmt.Errorf("remove stale resource files: %w", err)
+	}
+	written := make(map[string]bool)
+	for _, it := range items {
+		for _, file := range it.Files {
+			clean, err := cleanResourceFilePath(file.Path)
+			if err != nil {
+				return fmt.Errorf("%s.%s file %q: %w", it.TypeName, it.Name, file.Path, err)
+			}
+			if written[clean] {
+				return fmt.Errorf("%s.%s file %q: duplicate generated file path", it.TypeName, it.Name, file.Path)
+			}
+			written[clean] = true
+			fileDir := filepath.Join(moduleDir, filepath.Dir(clean))
+			if err := fs.MkdirAll(fileDir, 0755); err != nil {
+				return fmt.Errorf("create resource file dir: %w", err)
+			}
+			if err := fs.WriteFileAtomic(fileDir, filepath.Base(clean), file.Content, 0644); err != nil {
+				return fmt.Errorf("write resource file %s: %w", clean, err)
+			}
+		}
+	}
+	return nil
+}
+
+func syncResourceFilePaths(items []ResourceItem) {
+	for i := range items {
+		for j := range items[i].Files {
+			clean, err := cleanResourceFilePath(items[i].Files[j].Path)
+			if err != nil {
+				continue
+			}
+			slashPath := filepath.ToSlash(clean)
+			parts := strings.Split(slashPath, "/")
+			if len(parts) < 3 || parts[0] != "files" {
+				continue
+			}
+			nextPath := path.Join("files", items[i].Name, path.Join(parts[2:]...))
+			if nextPath == slashPath {
+				continue
+			}
+			items[i].Files[j].Path = nextPath
+			replaceResourceFilePathInAttrs(items[i].Attrs, slashPath, nextPath)
+		}
+	}
+}
+
+func replaceResourceFilePathInAttrs(attrs map[string]hcl.Value, oldPath, newPath string) {
+	for key, value := range attrs {
+		attrs[key] = replaceResourceFilePathInValue(value, oldPath, newPath)
+	}
+}
+
+func replaceResourceFilePathInValue(value hcl.Value, oldPath, newPath string) hcl.Value {
+	switch value.Kind {
+	case hcl.KindExpression:
+		value.Expr = strings.ReplaceAll(value.Expr, "${path.module}/"+oldPath, "${path.module}/"+newPath)
+		value.Expr = strings.ReplaceAll(value.Expr, oldPath, newPath)
+	case hcl.KindList:
+		for i := range value.List {
+			value.List[i] = replaceResourceFilePathInValue(value.List[i], oldPath, newPath)
+		}
+	case hcl.KindMap:
+		for key, nested := range value.Map {
+			value.Map[key] = replaceResourceFilePathInValue(nested, oldPath, newPath)
+		}
+	}
+	return value
+}
+
+func resourceItemsHaveFiles(items []ResourceItem) bool {
+	for _, it := range items {
+		if len(it.Files) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanResourceFilePath(path string) (string, error) {
+	if path == "" {
+		return "", fmt.Errorf("path is required")
+	}
+	clean := filepath.Clean(filepath.FromSlash(path))
+	if clean == "." || filepath.IsAbs(clean) || clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path must be relative and stay within the module")
+	}
+	return clean, nil
 }
 
 // ProgressFunc reports progress to the user; nil means no progress output.

--- a/tools/import-cli/internal/generator/module_test.go
+++ b/tools/import-cli/internal/generator/module_test.go
@@ -113,6 +113,85 @@ func TestWriteModuleDirectory_parseable_hcl(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWriteModuleDirectory_writesResourceFiles(t *testing.T) {
+	tmp := t.TempDir()
+	items := []ResourceItem{
+		{
+			TypeName: "criblio_lookup_file",
+			Name:     "lookup_file_default_lookup_csv",
+			Attrs: map[string]hcl.Value{
+				"id":       {Kind: hcl.KindString, String: "lookup.csv"},
+				"group_id": {Kind: hcl.KindString, String: "default"},
+				"content":  {Kind: hcl.KindExpression, Expr: `file("${path.module}/files/lookup_file_default_lookup_csv/lookup.csv")`},
+			},
+			Files: []ResourceFile{{
+				Path:    "files/lookup_file_default_lookup_csv/lookup.csv",
+				Content: []byte("key,value\none,two"),
+			}},
+			ImportID: `{"group_id":"default","id":"lookup.csv"}`,
+		},
+	}
+
+	err := WriteModuleDirectory(tmp, items, hcl.DefaultResourceBlockOptions())
+	require.NoError(t, err)
+
+	moduleDir := filepath.Join(tmp, "lookup_file")
+	content, err := os.ReadFile(filepath.Join(moduleDir, "files", "lookup_file_default_lookup_csv", "lookup.csv"))
+	require.NoError(t, err)
+	assert.Equal(t, "key,value\none,two", string(content))
+
+	mainBytes, err := os.ReadFile(filepath.Join(moduleDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(mainBytes), `content  = file("${path.module}/files/lookup_file_default_lookup_csv/lookup.csv")`)
+	assert.NoError(t, hcl.ParseHCL(mainBytes, "main.tf"))
+}
+
+func TestWriteModuleDirectory_rebasesResourceFilesAfterNameDedup(t *testing.T) {
+	tmp := t.TempDir()
+	items := []ResourceItem{
+		{
+			TypeName: "criblio_lookup_file",
+			Name:     "lookup_file_default_lookup_csv",
+			Attrs: map[string]hcl.Value{
+				"id":       {Kind: hcl.KindString, String: "lookup.csv"},
+				"group_id": {Kind: hcl.KindString, String: "default"},
+				"content":  {Kind: hcl.KindExpression, Expr: `file("${path.module}/files/lookup_file_default_lookup_csv/lookup.csv")`},
+			},
+			Files: []ResourceFile{{
+				Path:    "files/lookup_file_default_lookup_csv/lookup.csv",
+				Content: []byte("key,value\none,two"),
+			}},
+		},
+		{
+			TypeName: "criblio_lookup_file",
+			Name:     "lookup_file_default_lookup_csv",
+			Attrs: map[string]hcl.Value{
+				"id":       {Kind: hcl.KindString, String: "lookup.csv"},
+				"group_id": {Kind: hcl.KindString, String: "default"},
+				"content":  {Kind: hcl.KindExpression, Expr: `file("${path.module}/files/lookup_file_default_lookup_csv/lookup.csv")`},
+			},
+			Files: []ResourceFile{{
+				Path:    "files/lookup_file_default_lookup_csv/lookup.csv",
+				Content: []byte("key,value\nthree,four"),
+			}},
+		},
+	}
+
+	err := WriteModuleDirectory(tmp, items, hcl.DefaultResourceBlockOptions())
+	require.NoError(t, err)
+
+	moduleDir := filepath.Join(tmp, "lookup_file")
+	content, err := os.ReadFile(filepath.Join(moduleDir, "files", "lookup_file_default_lookup_csv_2", "lookup.csv"))
+	require.NoError(t, err)
+	assert.Equal(t, "key,value\nthree,four", string(content))
+
+	mainBytes, err := os.ReadFile(filepath.Join(moduleDir, "main.tf"))
+	require.NoError(t, err)
+	assert.Contains(t, string(mainBytes), `resource "criblio_lookup_file" "lookup_file_default_lookup_csv_2"`)
+	assert.Contains(t, string(mainBytes), `content  = file("${path.module}/files/lookup_file_default_lookup_csv_2/lookup.csv")`)
+	assert.NoError(t, hcl.ParseHCL(mainBytes, "main.tf"))
+}
+
 func TestWriteModuleDirectory_rewrites_pipeline_processor_refs(t *testing.T) {
 	tmp := t.TempDir()
 	items := []ResourceItem{


### PR DESCRIPTION
- Added criblio_lookup_file and pack lookup export support, including lookup content files referenced from generated Terraform with file(...).
- Skipped built-in/default Cribl lookup files during export so only user-created lookup files are emitted.
- Fixed provider lookup Read behavior to fetch raw lookup content during import/refresh, preventing immediate + content drift after export/import.
- Added focused tests for lookup content export, provider read/download behavior, generated templates, and import ID handling.