### PR TITLE
fixing output router if no descriptions defined.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.44"
+      version = "1.25.45"
     }
   }
 }

--- a/examples/destination/main.tf
+++ b/examples/destination/main.tf
@@ -1,17 +1,3 @@
-terraform {
-  required_providers {
-    criblio = {
-      source = "criblio/criblio"
-    }
-  }
-}
-
-provider "criblio" {
-  organization_id = "beautiful-nguyen-y8y4azd"
-  workspace_id    = "main"
-  cloud_domain    = "cribl-playground.cloud"
-}
-
 locals {
   # Base Cribl HTTP configuration
   cribl_http_config = {

--- a/examples/destination/main.tf
+++ b/examples/destination/main.tf
@@ -1,3 +1,17 @@
+terraform {
+  required_providers {
+    criblio = {
+      source = "criblio/criblio"
+    }
+  }
+}
+
+provider "criblio" {
+  organization_id = "beautiful-nguyen-y8y4azd"
+  workspace_id    = "main"
+  cloud_domain    = "cribl-playground.cloud"
+}
+
 locals {
   # Base Cribl HTTP configuration
   cribl_http_config = {
@@ -102,6 +116,29 @@ locals {
       reject_unauthorized = true
       servername          = "collector.cribl.example.com"
     }
+  }
+}
+
+# Router destination with omitted rule descriptions.
+resource "criblio_destination" "router_without_rule_descriptions" {
+  group_id = "default"
+  id       = "router-without-rule-descriptions"
+
+  output_router = {
+    id   = "router-without-rule-descriptions"
+    type = "router"
+    rules = [
+      {
+        filter = "_logType == 'security'"
+        final  = false
+        output = "devnull"
+      },
+      {
+        filter = "true"
+        final  = true
+        output = "default"
+      },
+    ]
   }
 }
 

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -50384,6 +50384,11 @@ func applyDestinationAPIToState(api *DestinationModel, state *DestinationModel, 
 			state.OutputIbmCloudS3.MaxRetryNum = types.Float64Null()
 		}
 	}
+	if api.OutputRouter != nil && state.OutputRouter != nil &&
+		!api.OutputRouter.Rules.IsNull() && !api.OutputRouter.Rules.IsUnknown() &&
+		!state.OutputRouter.Rules.IsNull() && !state.OutputRouter.Rules.IsUnknown() {
+		state.OutputRouter.Rules = routesListWithKnownAPIValues(api.OutputRouter.Rules, state.OutputRouter.Rules)
+	}
 }
 
 func DestinationDebug(value any) string {

--- a/internal/provider/destination_types_test.go
+++ b/internal/provider/destination_types_test.go
@@ -85,3 +85,32 @@ func TestDestinationSplunkResponseResolvesPlannedUnknowns(t *testing.T) {
 		}
 	}
 }
+
+func TestDestinationRouterResponseResolvesUnknownRuleDescriptions(t *testing.T) {
+	ruleType := types.ObjectType{AttrTypes: OutputRouterRulesAttrTypes()}
+	plannedRule := types.ObjectValueMust(OutputRouterRulesAttrTypes(), map[string]attr.Value{
+		"filter":      types.StringValue("true"),
+		"output":      types.StringValue("default"),
+		"description": types.StringUnknown(),
+		"final":       types.BoolValue(false),
+	})
+	apiRule := types.ObjectValueMust(OutputRouterRulesAttrTypes(), map[string]attr.Value{
+		"filter":      types.StringValue("true"),
+		"output":      types.StringValue("default"),
+		"description": types.StringNull(),
+		"final":       types.BoolValue(false),
+	})
+	state := DestinationModel{OutputRouter: &OutputRouterModel{
+		Rules: types.ListValueMust(ruleType, []attr.Value{plannedRule}),
+	}}
+	api := DestinationModel{OutputRouter: &OutputRouterModel{
+		Rules: types.ListValueMust(ruleType, []attr.Value{apiRule}),
+	}}
+
+	applyDestinationAPIToState(&api, &state, true, false)
+
+	description := state.OutputRouter.Rules.Elements()[0].(types.Object).Attributes()["description"].(types.String)
+	if description.IsUnknown() || !description.IsNull() {
+		t.Fatalf("expected resolved null description, got %#v", description)
+	}
+}

--- a/internal/provider/pack_destination_resource.go
+++ b/internal/provider/pack_destination_resource.go
@@ -50405,6 +50405,11 @@ func applyPackDestinationAPIToState(api *PackDestinationModel, state *PackDestin
 			state.OutputIbmCloudS3.MaxRetryNum = types.Float64Null()
 		}
 	}
+	if api.OutputRouter != nil && state.OutputRouter != nil &&
+		!api.OutputRouter.Rules.IsNull() && !api.OutputRouter.Rules.IsUnknown() &&
+		!state.OutputRouter.Rules.IsNull() && !state.OutputRouter.Rules.IsUnknown() {
+		state.OutputRouter.Rules = routesListWithKnownAPIValues(api.OutputRouter.Rules, state.OutputRouter.Rules)
+	}
 }
 
 func PackDestinationDebug(value any) string {

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -2134,6 +2134,13 @@ func apply{{ .StructName }}APIToState(api *{{ .StructName }}Model, state *{{ .St
 {{- end }}
 	}
 {{- end }}
+{{- if or (eq .StructName "Destination") (eq .StructName "PackDestination") }}
+	if api.OutputRouter != nil && state.OutputRouter != nil &&
+		!api.OutputRouter.Rules.IsNull() && !api.OutputRouter.Rules.IsUnknown() &&
+		!state.OutputRouter.Rules.IsNull() && !state.OutputRouter.Rules.IsUnknown() {
+		state.OutputRouter.Rules = routesListWithKnownAPIValues(api.OutputRouter.Rules, state.OutputRouter.Rules)
+	}
+{{- end }}
 }
 
 func {{ .Name }}Debug(value any) string {


### PR DESCRIPTION
- Fixes nested router rule descriptions remaining unknown after apply for destination and pack destination resources.
- Adds regression coverage and an output_router example with omitted rule descriptions.