### PR TITLE
Infra 11714 figure out a way and implement patterns for all schema properties within the provider

### DIFF
--- a/.codegen-ignore
+++ b/.codegen-ignore
@@ -5,6 +5,7 @@ tests/acceptance/cribl_lake_house_test.go
 tests/acceptance/lakehouse_dataset_connection_test.go
 tests/acceptance/search_datatype_test.go
 internal/provider/collector_planmodifiers.go
+internal/provider/collector_state_upgrade.go
 internal/provider/pipeline_planmodifiers.go
 internal/provider/source_resource_mirror.go
 internal/provider/searchdashboard_config_planmodifier.go

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.53"
+      version = "1.25.54"
     }
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.51"
+      version = "1.25.53"
     }
   }
 }

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -1168,8 +1168,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -1271,8 +1271,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -1515,8 +1515,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -1620,8 +1620,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -1730,8 +1730,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -1817,8 +1817,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -1906,8 +1906,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -2008,8 +2008,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -2102,8 +2102,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.
@@ -2191,8 +2191,8 @@ Optional:
 - `job_timeout` (String) Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.
 - `mode` (String) Job run mode. Preview will either return up to N matching results, or will run until capture time T is reached. Discovery will gather the list of files to turn into streaming tasks, without running the data collection job. Full Run will run the collection job.
 - `time_range_type` (String)
-- `earliest` (Number) Earliest time to collect data for the selected timezone
-- `latest` (Number) Latest time to collect data for the selected timezone
+- `earliest` (String) Earliest absolute or relative time to collect data for the selected timezone.
+- `latest` (String) Latest absolute or relative time to collect data for the selected timezone.
 - `expression` (String) A filter for tokens in the provided collect path and/or the events being collected
 - `min_task_size` (String) Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.
 - `max_task_size` (String) Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.

--- a/examples/database-connection/main.tf
+++ b/examples/database-connection/main.tf
@@ -11,7 +11,7 @@ resource "criblio_database_connection" "my_databaseconnection" {
   connection_string  = "mysql://user:password@localhost:3306/mydb"
   connection_timeout = 1000
   password           = "test"
-  request_timeout    = 60
+  request_timeout    = 30000
   tags               = "test"
   user               = "test"
 }

--- a/examples/resources/criblio_database_connection/resource.tf
+++ b/examples/resources/criblio_database_connection/resource.tf
@@ -8,7 +8,7 @@ resource "criblio_database_connection" "my_databaseconnection" {
   group_id           = "Cribl"
   id                 = "db-prod-01"
   password           = "$$${{secret:db_password}"
-  request_timeout    = 60
+  request_timeout    = 30000
   tags               = "prod,db"
   user               = "appuser"
 }

--- a/internal/provider/collector_data_source.go
+++ b/internal/provider/collector_data_source.go
@@ -136,13 +136,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -402,13 +402,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -965,13 +965,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -1224,13 +1224,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -1505,13 +1505,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -1719,13 +1719,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -1940,13 +1940,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -2189,13 +2189,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -2424,13 +2424,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,
@@ -2643,13 +2643,13 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 									"time_range_type": schema.StringAttribute{
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Computed:    true,

--- a/internal/provider/collector_resource.go
+++ b/internal/provider/collector_resource.go
@@ -6,14 +6,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -156,6 +161,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -185,6 +193,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -197,6 +208,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -232,12 +246,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -309,6 +329,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -346,6 +369,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -442,6 +468,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Required: false,
 										Optional: true,
 										Computed: true,
+										Validators: []validator.Int64{
+											int64validator.Between(0, 1800),
+										},
 									},
 									"use_round_robin_dns": schema.BoolAttribute{
 										Required: false,
@@ -559,6 +588,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -588,6 +620,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -600,6 +635,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -635,12 +673,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -712,6 +756,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -749,6 +796,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -988,6 +1038,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Required: false,
 										Optional: true,
 										Computed: true,
+										Validators: []validator.Int64{
+											int64validator.Between(0, 1800),
+										},
 									},
 									"use_round_robin_dns": schema.BoolAttribute{
 										Required: false,
@@ -1421,6 +1474,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -1450,6 +1506,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -1462,6 +1521,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -1497,12 +1559,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -1574,6 +1642,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -1611,6 +1682,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -1737,6 +1811,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Required: false,
 										Optional: true,
 										Computed: true,
+										Validators: []validator.Int64{
+											int64validator.AtLeast(1),
+										},
 									},
 								},
 							},
@@ -1809,6 +1886,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -1838,6 +1918,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -1850,6 +1933,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -1885,12 +1971,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -1962,6 +2054,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -1999,6 +2094,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -2115,6 +2213,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Required: false,
 										Optional: true,
 										Computed: true,
+										Validators: []validator.Int64{
+											int64validator.AtLeast(1),
+										},
 									},
 									"include_metadata": schema.BoolAttribute{
 										Required:    false,
@@ -2229,6 +2330,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -2258,6 +2362,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -2270,6 +2377,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -2305,12 +2415,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -2382,6 +2498,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -2419,6 +2538,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -2548,6 +2670,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -2577,6 +2702,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -2589,6 +2717,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -2624,12 +2755,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -2701,6 +2838,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -2738,6 +2878,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -2878,6 +3021,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -2907,6 +3053,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -2919,6 +3068,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -2954,12 +3106,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -3031,6 +3189,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -3068,6 +3229,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -3178,6 +3342,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Required: false,
 										Optional: true,
 										Computed: true,
+										Validators: []validator.Int64{
+											int64validator.AtLeast(1),
+										},
 									},
 								},
 							},
@@ -3250,6 +3417,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -3279,6 +3449,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -3291,6 +3464,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -3326,12 +3502,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -3403,6 +3585,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -3440,6 +3625,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -3512,6 +3700,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Required: false,
 										Optional: true,
 										Computed: true,
+										Validators: []validator.Int64{
+											int64validator.Between(0, 1800),
+										},
 									},
 									"reject_unauthorized": schema.BoolAttribute{
 										Required: false,
@@ -3604,6 +3795,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -3633,6 +3827,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -3645,6 +3842,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -3680,12 +3880,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -3757,6 +3963,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -3794,6 +4003,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -3932,6 +4144,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum number of instances of this scheduled job that may be running at any time`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"skippable": schema.BoolAttribute{
 								Required:    false,
@@ -3961,6 +4176,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of times a task can be rescheduled`,
+										Validators: []validator.Float64{
+											float64validator.AtLeast(1),
+										},
 									},
 									"log_level": schema.StringAttribute{
 										Required:    false,
@@ -3973,6 +4191,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+										},
 									},
 									"mode": schema.StringAttribute{
 										Required:    false,
@@ -4008,12 +4229,18 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for small tasks. For example, if your lower bundle size is 1MB, you can bundle up to five 200KB files into one task.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"max_task_size": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
 										Description: `Limits the bundle size for files above the lower task bundle size. For example, if your upper bundle size is 10MB, you can bundle up to five 2MB files into one task. Files greater than this size will be assigned to individual tasks.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^((\d*\.?\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$`), "must match pattern ^((\\d*\\.?\\d+)((KB|MB|GB|TB|PB|EB|ZB|YB|kb|mb|gb|tb|pb|eb|zb|yb){1}))$"),
+										},
 									},
 									"time_warning": schema.MapAttribute{
 										Required:    false,
@@ -4085,6 +4312,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+								Validators: []validator.Float64{
+									float64validator.Between(10, 43200000),
+								},
 							},
 							"send_to_routes": schema.BoolAttribute{
 								Required:    false,
@@ -4122,6 +4352,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 								Optional:    true,
 								Computed:    true,
 								Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+								},
 							},
 							"metadata": schema.ListNestedAttribute{
 								Required:    false,
@@ -4223,6 +4456,9 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional:    true,
 										Computed:    true,
 										Description: `Maximum number of metadata files to batch before recording as results.`,
+										Validators: []validator.Int64{
+											int64validator.AtLeast(1),
+										},
 									},
 								},
 							},

--- a/internal/provider/collector_resource.go
+++ b/internal/provider/collector_resource.go
@@ -29,6 +29,7 @@ var _ = types.String{}
 var _ resource.Resource = &CollectorResource{}
 var _ resource.ResourceWithConfigure = &CollectorResource{}
 var _ resource.ResourceWithImportState = &CollectorResource{}
+var _ resource.ResourceWithUpgradeState = &CollectorResource{}
 
 type CollectorResource struct {
 	client *restclient.Client
@@ -45,6 +46,7 @@ func (r *CollectorResource) Metadata(_ context.Context, req resource.MetadataReq
 
 func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		Version:             1,
 		MarkdownDescription: "Collector Resource",
 		Attributes: map[string]schema.Attribute{
 			"environment": schema.StringAttribute{
@@ -223,17 +225,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -650,17 +652,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -1536,17 +1538,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -1948,17 +1950,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -2392,17 +2394,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -2732,17 +2734,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -3083,17 +3085,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -3479,17 +3481,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -3857,17 +3859,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,
@@ -4206,17 +4208,17 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 										Optional: true,
 										Computed: true,
 									},
-									"earliest": schema.Float64Attribute{
+									"earliest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Earliest time to collect data for the selected timezone`,
+										Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 									},
-									"latest": schema.Float64Attribute{
+									"latest": schema.StringAttribute{
 										Required:    false,
 										Optional:    true,
 										Computed:    true,
-										Description: `Latest time to collect data for the selected timezone`,
+										Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 									},
 									"expression": schema.StringAttribute{
 										Required:    false,

--- a/internal/provider/collector_state_upgrade.go
+++ b/internal/provider/collector_state_upgrade.go
@@ -1,0 +1,75 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// UpgradeState migrates collector state written before schedule time ranges supported strings.
+func (r *CollectorResource) UpgradeState(ctx context.Context) map[int64]resource.StateUpgrader {
+	return map[int64]resource.StateUpgrader{
+		0: {
+			StateUpgrader: func(ctx context.Context, req resource.UpgradeStateRequest, resp *resource.UpgradeStateResponse) {
+				if req.RawState == nil || len(req.RawState.JSON) == 0 {
+					resp.Diagnostics.AddError("Unable to upgrade collector state", "Prior collector state is not available as JSON.")
+					return
+				}
+				upgradedJSON, err := upgradeCollectorStateJSON(req.RawState.JSON)
+				if err != nil {
+					resp.Diagnostics.AddError("Unable to upgrade collector state", err.Error())
+					return
+				}
+				var schemaResp resource.SchemaResponse
+				r.Schema(ctx, resource.SchemaRequest{}, &schemaResp)
+				terraformType := schemaResp.Schema.Type().TerraformType(ctx)
+				value, err := tftypes.ValueFromJSON(upgradedJSON, terraformType)
+				if err != nil {
+					resp.Diagnostics.AddError("Unable to decode upgraded collector state", err.Error())
+					return
+				}
+				dynamicValue, err := tfprotov6.NewDynamicValue(terraformType, value)
+				if err != nil {
+					resp.Diagnostics.AddError("Unable to encode upgraded collector state", err.Error())
+					return
+				}
+				resp.DynamicValue = &dynamicValue
+			},
+		},
+	}
+}
+
+func upgradeCollectorStateJSON(raw []byte) ([]byte, error) {
+	var state map[string]any
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("decode prior state: %w", err)
+	}
+	for key, value := range state {
+		if !strings.HasPrefix(key, "input_collector_") {
+			continue
+		}
+		block, ok := value.(map[string]any)
+		if !ok {
+			continue
+		}
+		schedule, ok := block["schedule"].(map[string]any)
+		if !ok {
+			continue
+		}
+		run, ok := schedule["run"].(map[string]any)
+		if !ok {
+			continue
+		}
+		for _, field := range []string{"earliest", "latest"} {
+			if number, ok := run[field].(float64); ok {
+				run[field] = fmt.Sprintf("%v", number)
+			}
+		}
+	}
+	return json.Marshal(state)
+}

--- a/internal/provider/collector_state_upgrade_test.go
+++ b/internal/provider/collector_state_upgrade_test.go
@@ -1,0 +1,29 @@
+package provider
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestUpgradeCollectorStateJSON(t *testing.T) {
+	upgraded, err := upgradeCollectorStateJSON([]byte(`{
+		"id":"collector",
+		"input_collector_rest":{"schedule":{"run":{"earliest":-300,"latest":0}}},
+		"input_collector_s3":null
+	}`))
+	if err != nil {
+		t.Fatalf("upgradeCollectorStateJSON returned error: %v", err)
+	}
+	var state map[string]any
+	if err := json.Unmarshal(upgraded, &state); err != nil {
+		t.Fatalf("decode upgraded state: %v", err)
+	}
+	rest := state["input_collector_rest"].(map[string]any)
+	run := rest["schedule"].(map[string]any)["run"].(map[string]any)
+	if got := run["earliest"]; got != "-300" {
+		t.Fatalf("earliest = %#v, want -300", got)
+	}
+	if got := run["latest"]; got != "0" {
+		t.Fatalf("latest = %#v, want 0", got)
+	}
+}

--- a/internal/provider/collector_types.go
+++ b/internal/provider/collector_types.go
@@ -122,8 +122,8 @@ type InputCollectorSplunkScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -138,8 +138,8 @@ type InputCollectorSplunkScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -155,8 +155,8 @@ func InputCollectorSplunkScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -375,8 +375,8 @@ type InputCollectorRestScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -391,8 +391,8 @@ type InputCollectorRestScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -408,8 +408,8 @@ func InputCollectorRestScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -981,8 +981,8 @@ type InputCollectorS3ScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -997,8 +997,8 @@ type InputCollectorS3ScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -1014,8 +1014,8 @@ func InputCollectorS3ScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -1233,8 +1233,8 @@ type InputCollectorAzureBlobScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -1249,8 +1249,8 @@ type InputCollectorAzureBlobScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -1266,8 +1266,8 @@ func InputCollectorAzureBlobScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -1500,8 +1500,8 @@ type InputCollectorCriblLakeScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -1516,8 +1516,8 @@ type InputCollectorCriblLakeScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -1533,8 +1533,8 @@ func InputCollectorCriblLakeScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -1705,8 +1705,8 @@ type InputCollectorDatabaseScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -1721,8 +1721,8 @@ type InputCollectorDatabaseScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -1738,8 +1738,8 @@ func InputCollectorDatabaseScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -1916,8 +1916,8 @@ type InputCollectorGCSScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -1932,8 +1932,8 @@ type InputCollectorGCSScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -1949,8 +1949,8 @@ func InputCollectorGCSScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -2159,8 +2159,8 @@ type InputCollectorHealthCheckScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -2175,8 +2175,8 @@ type InputCollectorHealthCheckScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -2192,8 +2192,8 @@ func InputCollectorHealthCheckScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -2385,8 +2385,8 @@ type InputCollectorScriptScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -2401,8 +2401,8 @@ type InputCollectorScriptScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -2418,8 +2418,8 @@ func InputCollectorScriptScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -2596,8 +2596,8 @@ type InputCollectorFilesystemScheduleRunModel struct {
 	JobTimeout             types.String  `tfsdk:"job_timeout" json:"jobTimeout,omitempty"`
 	Mode                   types.String  `tfsdk:"mode" json:"mode,omitempty"`
 	TimeRangeType          types.String  `tfsdk:"time_range_type" json:"timeRangeType,omitempty"`
-	Earliest               types.Float64 `tfsdk:"earliest" json:"earliest,omitempty"`
-	Latest                 types.Float64 `tfsdk:"latest" json:"latest,omitempty"`
+	Earliest               types.String  `tfsdk:"earliest" json:"earliest,omitempty"`
+	Latest                 types.String  `tfsdk:"latest" json:"latest,omitempty"`
 	Expression             types.String  `tfsdk:"expression" json:"expression,omitempty"`
 	MinTaskSize            types.String  `tfsdk:"min_task_size" json:"minTaskSize,omitempty"`
 	MaxTaskSize            types.String  `tfsdk:"max_task_size" json:"maxTaskSize,omitempty"`
@@ -2612,8 +2612,8 @@ type InputCollectorFilesystemScheduleRunAPIModel struct {
 	JobTimeout             *string           `json:"jobTimeout,omitempty"`
 	Mode                   *string           `json:"mode,omitempty"`
 	TimeRangeType          *string           `json:"timeRangeType,omitempty"`
-	Earliest               *float64          `json:"earliest,omitempty"`
-	Latest                 *float64          `json:"latest,omitempty"`
+	Earliest               *string           `json:"earliest,omitempty"`
+	Latest                 *string           `json:"latest,omitempty"`
 	Expression             *string           `json:"expression,omitempty"`
 	MinTaskSize            *string           `json:"minTaskSize,omitempty"`
 	MaxTaskSize            *string           `json:"maxTaskSize,omitempty"`
@@ -2629,8 +2629,8 @@ func InputCollectorFilesystemScheduleRunAttrTypes() map[string]attr.Type {
 		"job_timeout":              types.StringType,
 		"mode":                     types.StringType,
 		"time_range_type":          types.StringType,
-		"earliest":                 types.Float64Type,
-		"latest":                   types.Float64Type,
+		"earliest":                 types.StringType,
+		"latest":                   types.StringType,
 		"expression":               types.StringType,
 		"min_task_size":            types.StringType,
 		"max_task_size":            types.StringType,
@@ -3148,6 +3148,11 @@ func (m *CollectorModel) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
+	normalizeCollectorUnionValues(raw)
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
 	var input CollectorAPIModel
 	if err := json.Unmarshal(data, &input); err != nil {
 		return err
@@ -3240,6 +3245,25 @@ func (m *CollectorModel) UnmarshalJSON(data []byte) error {
 		}
 	}
 	return nil
+}
+func normalizeCollectorUnionValues(raw map[string]any) {
+	if input, ok := raw["input"].(map[string]any); ok {
+		if value, ok := input["throttleRatePerSec"].(float64); ok {
+			input["throttleRatePerSec"] = fmt.Sprintf("%v", value)
+		}
+	}
+	if schedule, ok := raw["schedule"].(map[string]any); ok {
+		if run, ok := schedule["run"].(map[string]any); ok {
+			for _, field := range []string{"earliest", "latest"} {
+				if value, ok := run[field].(float64); ok {
+					run[field] = fmt.Sprintf("%v", value)
+				}
+			}
+		}
+	}
+	if savedState, ok := raw["savedState"].([]any); ok && len(savedState) == 0 {
+		raw["savedState"] = map[string]any{}
+	}
 }
 
 type InputCollectorSplunkModel struct {

--- a/internal/provider/collector_types_test.go
+++ b/internal/provider/collector_types_test.go
@@ -134,3 +134,46 @@ func TestCollectorModelUnmarshalHealthCheckAlias(t *testing.T) {
 		t.Fatalf("InputCollectorHealthCheck was not selected")
 	}
 }
+
+func TestCollectorModelUnmarshalRelativeScheduleRange(t *testing.T) {
+	var model CollectorModel
+	err := json.Unmarshal([]byte(`{
+		"id":"rest-collector",
+		"type":"collection",
+		"collector":{"type":"rest","conf":{"collectUrl":"https://example.com"}},
+		"schedule":{"run":{"earliest":"-10m@m","latest":"-9m@m"}}
+	}`), &model)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON returned error: %v", err)
+	}
+	if model.InputCollectorRest == nil {
+		t.Fatal("InputCollectorRest was not selected")
+	}
+	run := model.InputCollectorRest.Schedule.Attributes()["run"].(types.Object).Attributes()
+	if got := run["earliest"].(types.String).ValueString(); got != "-10m@m" {
+		t.Fatalf("earliest = %q", got)
+	}
+	if got := run["latest"].(types.String).ValueString(); got != "-9m@m" {
+		t.Fatalf("latest = %q", got)
+	}
+}
+
+func TestCollectorModelUnmarshalNumericScheduleRangeAsStrings(t *testing.T) {
+	var model CollectorModel
+	err := json.Unmarshal([]byte(`{
+		"id":"rest-collector",
+		"type":"collection",
+		"collector":{"type":"rest","conf":{"collectUrl":"https://example.com"}},
+		"schedule":{"run":{"earliest":-10,"latest":0}}
+	}`), &model)
+	if err != nil {
+		t.Fatalf("UnmarshalJSON returned error: %v", err)
+	}
+	run := model.InputCollectorRest.Schedule.Attributes()["run"].(types.Object).Attributes()
+	if got := run["earliest"].(types.String).ValueString(); got != "-10" {
+		t.Fatalf("earliest = %q", got)
+	}
+	if got := run["latest"].(types.String).ValueString(); got != "0" {
+		t.Fatalf("latest = %q", got)
+	}
+}

--- a/internal/provider/collectors_data_source.go
+++ b/internal/provider/collectors_data_source.go
@@ -142,13 +142,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -408,13 +408,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -971,13 +971,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -1230,13 +1230,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -1511,13 +1511,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -1725,13 +1725,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -1946,13 +1946,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -2195,13 +2195,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -2430,13 +2430,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,
@@ -2649,13 +2649,13 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 												"time_range_type": schema.StringAttribute{
 													Computed: true,
 												},
-												"earliest": schema.Float64Attribute{
+												"earliest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Earliest time to collect data for the selected timezone`,
+													Description: `Earliest absolute or relative time to collect data for the selected timezone.`,
 												},
-												"latest": schema.Float64Attribute{
+												"latest": schema.StringAttribute{
 													Computed:    true,
-													Description: `Latest time to collect data for the selected timezone`,
+													Description: `Latest absolute or relative time to collect data for the selected timezone.`,
 												},
 												"expression": schema.StringAttribute{
 													Computed:    true,

--- a/internal/provider/database_connection_resource.go
+++ b/internal/provider/database_connection_resource.go
@@ -6,15 +6,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -68,6 +72,9 @@ func (r *DatabaseConnectionResource) Schema(_ context.Context, _ resource.Schema
 				Optional:    true,
 				Computed:    false,
 				Description: `Maximum time (in milliseconds) to wait when establishing the database connection.`,
+				Validators: []validator.Int64{
+					int64validator.Between(1000, 60000),
+				},
 			},
 			"creds_secrets": schema.StringAttribute{
 				Required:    false,
@@ -106,6 +113,9 @@ func (r *DatabaseConnectionResource) Schema(_ context.Context, _ resource.Schema
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
 				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_\\-]+$`), "must match pattern ^[a-zA-Z0-9_\\\\-]+$"),
+				},
 			},
 			"items": schema.ListNestedAttribute{
 				Required:    false,
@@ -139,6 +149,9 @@ func (r *DatabaseConnectionResource) Schema(_ context.Context, _ resource.Schema
 							Optional:    true,
 							Computed:    false,
 							Description: `Maximum time (in milliseconds) to wait when establishing the database connection.`,
+							Validators: []validator.Int64{
+								int64validator.Between(1000, 60000),
+							},
 						},
 						"creds_secrets": schema.StringAttribute{
 							Required:    false,
@@ -167,6 +180,9 @@ func (r *DatabaseConnectionResource) Schema(_ context.Context, _ resource.Schema
 							PlanModifiers: []planmodifier.String{
 								custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
 							},
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_\\-]+$`), "must match pattern ^[a-zA-Z0-9_\\\\-]+$"),
+							},
 						},
 						"password": schema.StringAttribute{
 							Required:    false,
@@ -180,6 +196,9 @@ func (r *DatabaseConnectionResource) Schema(_ context.Context, _ resource.Schema
 							Optional:    true,
 							Computed:    false,
 							Description: `Maximum time (in milliseconds) to wait for a database query to complete. Applies to SQL Server connections only.`,
+							Validators: []validator.Int64{
+								int64validator.AtLeast(1000),
+							},
 						},
 						"tags": schema.StringAttribute{
 							Required:    false,
@@ -282,6 +301,9 @@ func (r *DatabaseConnectionResource) Schema(_ context.Context, _ resource.Schema
 				Optional:    true,
 				Computed:    false,
 				Description: `Maximum time (in milliseconds) to wait for a database query to complete. Applies to SQL Server connections only.`,
+				Validators: []validator.Int64{
+					int64validator.AtLeast(1000),
+				},
 			},
 			"tags": schema.StringAttribute{
 				Required:    false,

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -6,14 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -191,18 +197,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 512000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -223,6 +238,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -275,6 +293,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -282,24 +303,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -320,18 +353,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -417,6 +459,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"load_balanced": schema.BoolAttribute{
 						Required:    false,
@@ -489,6 +534,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -500,24 +548,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -540,6 +600,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -585,6 +648,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL for OAuth`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"secret_param_name": schema.StringAttribute{
 						Required:    false,
@@ -616,6 +682,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the OAuth token should be refreshed.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 300000),
+						},
 					},
 					"oauth_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -678,6 +747,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Override the refresh endpoint URL if it differs from the Login URL. Defaults to Login URL.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"refresh_request_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -706,6 +778,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of a webhook endpoint to send events to, such as http://localhost:10200`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -718,6 +793,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Webhook URLs`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -725,12 +803,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `URL of a webhook endpoint to send events to, such as http://localhost:10200`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -740,12 +824,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 				},
 			},
@@ -801,18 +891,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of the request body (defaults to the API's maximum limit of 1000 KB)`,
+						Validators: []validator.Float64{
+							float64validator.Between(100, 1000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -833,6 +932,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -885,6 +987,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -892,24 +997,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -930,18 +1047,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -967,6 +1093,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL for OAuth`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"secret": schema.StringAttribute{
 						Required:    false,
@@ -992,6 +1121,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Override the refresh endpoint URL if it differs from the Login URL. Defaults to Login URL.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"refresh_request_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -1038,6 +1170,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -1109,6 +1244,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -1120,24 +1258,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -1160,6 +1310,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -1173,6 +1326,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to send events to. Can be overwritten by an event's __url field.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"dcr_id": schema.StringAttribute{
 						Required:    false,
@@ -1185,6 +1341,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: "Data collection endpoint (DCE) URL. In the format: `https://<Endpoint-Name>-<Identifier>.<Region>.ingest.monitor.azure.com`",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https:\/\/([a-zA-Z0-9-_\.]+)\.ingest\.monitor\.azure\.com(\/?)$`), "must match pattern ^https:\\/\\/([a-zA-Z0-9-_\\.]+)\\.ingest\\.monitor\\.azure\\.com(\\/?)$"),
+						},
 					},
 					"stream_name": schema.StringAttribute{
 						Required:    false,
@@ -1318,6 +1477,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"octet_count_framing": schema.BoolAttribute{
 						Required:    false,
@@ -1354,6 +1516,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -1366,6 +1531,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of hosts to load-balance data to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -1379,6 +1547,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -1396,6 +1567,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -1405,18 +1579,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -1507,12 +1690,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of syslog messages. Make sure this value is less than or equal to the MTU to avoid UDP packet fragmentation.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"udp_dns_resolve_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every message sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"enable_ip_spoofing": schema.BoolAttribute{
 						Required:    false,
@@ -1531,6 +1720,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -1542,24 +1734,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -1582,6 +1786,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -1643,6 +1850,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"nested_fields": schema.StringAttribute{
 						Required: false,
@@ -1654,6 +1864,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -1778,6 +1991,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of times healthcheck can fail before we close connection. If set to 0 (disabled), and the connection to Splunk is forcibly closed, some data loss might occur.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -1795,6 +2011,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -1806,24 +2025,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -1846,6 +2077,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -1915,18 +2149,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"nested_fields": schema.StringAttribute{
 						Required: false,
@@ -1938,6 +2181,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -2057,6 +2303,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in milliseconds) each LB endpoint can report blocked before the Destination reports unhealthy, blocking the sender. (Grace period for fluctuations.) Use 0 to disable; max 1 minute.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 60000),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -2074,6 +2323,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of times healthcheck can fail before we close connection. If set to 0 (disabled), and the connection to Splunk is forcibly closed, some data loss might occur.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -2091,18 +2343,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Clustering site of the indexers from where indexers need to be discovered. In case of single site cluster, it defaults to 'default' site.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`[0-9A-Za-z-._]+`), "must match pattern [0-9A-Za-z-._]+"),
+								},
 							},
 							"master_uri": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Full URI of Splunk cluster manager (scheme://host:port). Example: https://managerAddress:8089`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^https?://[a-zA-Z0-9-._]+:[0-9]+$`), "must match pattern ^https?://[a-zA-Z0-9-._]+:[0-9]+$"),
+								},
 							},
 							"refresh_interval_sec": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Time interval, in seconds, between two consecutive indexer list fetches from cluster manager`,
+								Validators: []validator.Float64{
+									float64validator.Between(60, 86400),
+								},
 							},
 							"reject_unauthorized": schema.BoolAttribute{
 								Required:    false,
@@ -2169,6 +2430,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of Splunk indexers to load-balance data to.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -2182,6 +2446,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -2199,6 +2466,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -2214,6 +2484,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -2225,24 +2498,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -2265,6 +2550,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -2400,18 +2688,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 2097152),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -2432,6 +2729,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -2489,6 +2789,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -2496,24 +2799,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -2534,18 +2849,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -2583,6 +2907,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to a Splunk HEC endpoint to send events to, e.g., http://localhost:8088/services/collector/event`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -2601,6 +2928,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Splunk HEC Endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -2608,12 +2938,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `URL to a Splunk HEC endpoint to send events to, e.g., http://localhost:8088/services/collector/event`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -2623,12 +2959,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"token": schema.StringAttribute{
 						Required:    false,
@@ -2654,6 +2996,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -2665,24 +3010,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -2705,6 +3062,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -2821,18 +3181,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 9000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -2853,6 +3222,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -2904,6 +3276,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -2911,24 +3286,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -2949,18 +3336,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -3029,6 +3425,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3040,24 +3439,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -3080,6 +3491,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -3152,6 +3566,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -3237,6 +3654,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires, valid values between 1 and 60`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"send_header": schema.BoolAttribute{
 						Required:    false,
@@ -3271,6 +3691,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -3283,6 +3706,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of hosts to load-balance data to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -3296,6 +3722,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -3313,6 +3742,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -3322,18 +3754,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -3346,6 +3787,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3357,24 +3801,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -3397,6 +3853,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -3477,18 +3936,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -3509,6 +3977,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -3561,6 +4032,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -3568,24 +4042,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -3606,18 +4092,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -3662,6 +4157,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3673,24 +4171,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -3713,6 +4223,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -3780,18 +4293,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -3812,6 +4334,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -3864,6 +4389,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -3871,24 +4399,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -3909,18 +4449,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -3965,6 +4514,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3976,24 +4528,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -4016,6 +4580,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -4119,24 +4686,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -4149,6 +4728,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -4225,6 +4807,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -4255,6 +4840,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -4271,12 +4859,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -4289,6 +4883,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -4329,6 +4926,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -4347,6 +4947,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -4407,6 +5010,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -4419,6 +5026,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -4460,6 +5070,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -4472,6 +5085,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -4519,24 +5135,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -4549,6 +5177,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -4625,6 +5256,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -4695,6 +5329,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -4711,12 +5348,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -4729,6 +5372,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -4769,6 +5415,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -4787,6 +5436,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -4865,6 +5517,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"remove_empty_dirs": schema.BoolAttribute{
 						Required:    false,
@@ -4900,24 +5555,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -4930,6 +5597,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -5006,6 +5676,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -5047,6 +5720,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -5063,12 +5739,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -5081,6 +5763,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -5121,6 +5806,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -5139,6 +5827,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"connection_string": schema.StringAttribute{
 						Required:    false,
@@ -5249,18 +5940,29 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: "The base URI for your cluster. Typically, `https://<cluster>.<region>.kusto.windows.net`.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https://`), "must match pattern ^https://"),
+						},
 					},
 					"database": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the database containing the table where data will be ingested`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\s\-\.]+$`), "must match pattern ^[\\w\\s\\-\\.]+$"),
+							stringvalidator.UTF8LengthAtMost(260),
+						},
 					},
 					"table": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the table to ingest data into`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\-\.]+$`), "must match pattern ^[\\w\\-\\.]+$"),
+							stringvalidator.UTF8LengthAtMost(1024),
+						},
 					},
 					"validate_database_settings": schema.BoolAttribute{
 						Required:    false,
@@ -5361,6 +6063,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -5377,12 +6082,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -5395,6 +6106,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -5441,6 +6155,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -5465,6 +6182,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"is_mapping_obj": schema.BoolAttribute{
 						Required:    false,
@@ -5483,12 +6203,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Enter the name of a data mapping associated with your target table. Or, if incoming event and target table fields match exactly, you can leave the field empty.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\-\.]+$`), "must match pattern ^[\\w\\-\\.]+$"),
+						},
 					},
 					"ingest_url": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: "The ingestion service URI for your cluster. Typically, `https://ingest-<cluster>.<region>.kusto.windows.net`.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https://`), "must match pattern ^https://"),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -5512,30 +6238,45 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"max_concurrent_file_parts": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"on_disk_full_backpressure": schema.StringAttribute{
 						Required: false,
@@ -5601,6 +6342,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -5609,6 +6353,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_immediately": schema.BoolAttribute{
 						Required:    false,
@@ -5684,6 +6431,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Key`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\-\.]+$`), "must match pattern ^[\\w\\-\\.]+$"),
+									},
 								},
 								"value": schema.StringAttribute{
 									Required:    false,
@@ -5699,6 +6449,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -5706,24 +6459,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -5744,18 +6509,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -5770,18 +6544,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 4096),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -5820,6 +6603,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -5831,24 +6617,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -5871,6 +6669,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -5927,6 +6728,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: "The Log Type of events sent to this LogAnalytics workspace. Defaults to `Cribl`. Use only letters, numbers, and `_` characters, and can't exceed 100 characters. Can be overwritten by event field __logType.",
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtMost(100),
+						},
 					},
 					"resource_id": schema.StringAttribute{
 						Required:    false,
@@ -5939,18 +6743,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required: false,
@@ -5970,6 +6783,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6022,12 +6838,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The DNS name of the Log API endpoint that sends log data to a Log Analytics workspace in Azure Monitor. Defaults to .ods.opinsights.azure.com. @{product} will add a prefix and suffix to construct a URI in this format: <https://<Workspace_ID><your_DNS_name>/api/logs?api-version=<API version>.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\.[^\/]+$`), "must match pattern ^\\.[^\\/]+$"),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -6035,24 +6857,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -6073,18 +6907,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -6122,6 +6965,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -6133,24 +6979,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -6173,6 +7031,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -6294,6 +7155,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -6306,18 +7171,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing put requests before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of each individual record before compression. For uncompressed or non-compressible data 1MB is the max recommended size`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6371,6 +7245,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of records to send in a single request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 500),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -6383,6 +7260,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -6394,24 +7274,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -6434,6 +7326,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -6496,18 +7391,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -6528,6 +7432,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6580,6 +7487,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -6587,24 +7497,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -6625,18 +7547,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -6673,6 +7604,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -6684,24 +7618,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -6724,6 +7670,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -6792,6 +7741,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `List of Event Hubs Kafka brokers to connect to, eg. yourdomain.servicebus.windows.net:9093. The hostname can be found in the host portion of the primary or secondary connection string in Shared Access Policies.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topic": schema.StringAttribute{
@@ -6815,12 +7768,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. Setting should be < message.max.bytes settings in Event Hubs brokers.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6833,48 +7792,72 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -7022,6 +8005,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -7033,24 +8019,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -7073,6 +8071,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -7166,30 +8167,45 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait before sending a batch (when batch size limit is not reached)`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of a single append request. BigQuery limit is 10 MB`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"max_in_progress": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of in-progress API requests before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"max_send_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum retries per batch for retryable failures (transient, rate-limit, unknown) before dropping. 0 (default) retries indefinitely.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -7213,6 +8229,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -7224,24 +8243,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -7264,6 +8295,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -7332,6 +8366,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -7339,24 +8376,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -7377,18 +8426,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -7415,18 +8473,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -7447,6 +8514,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -7504,6 +8574,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -7523,6 +8596,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Log Type`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z0-9_]+$`), "must match pattern ^[A-Z0-9_]+$"),
+									},
 								},
 								"description": schema.StringAttribute{
 									Required:    false,
@@ -7621,6 +8697,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -7632,24 +8711,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -7672,6 +8763,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -7827,24 +8921,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -7857,6 +8963,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -7933,6 +9042,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -7963,6 +9075,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -7979,12 +9094,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -7997,6 +9118,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -8037,6 +9161,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -8055,6 +9182,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"aws_api_key": schema.StringAttribute{
 						Required:    false,
@@ -8227,12 +9357,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Max number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -8245,6 +9381,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -8257,12 +9396,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"throttle_rate_req_per_sec": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of requests to limit to per second.`,
+						Validators: []validator.Int64{
+							int64validator.AtMost(2000),
+						},
 					},
 					"request_method_expression": schema.StringAttribute{
 						Required:    false,
@@ -8442,6 +9587,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -8472,6 +9620,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -8483,24 +9634,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -8523,6 +9686,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -8603,6 +9769,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -8637,18 +9806,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body sent to Google Cloud Observability`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -8672,6 +9850,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -8739,6 +9920,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Max number of events to include in the request body. Default is 0 (unlimited). Use to keep outgoing data points within GCO request limits. For metrics, combine with the OTLP Metrics function batchSize.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -8769,6 +9953,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -8780,24 +9967,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -8820,6 +10019,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -8917,24 +10119,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of items the Google API should batch before it sends them to the topic.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"batch_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum amount of time, in milliseconds, that the Google API should wait to send a batch (if the Batch size is not reached).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100000),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of batches to send.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 256),
+						},
 					},
 					"flush_period": schema.Float64Attribute{
 						Required:    false,
@@ -8947,6 +10161,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of in-progress API requests before backpressure is applied.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -8970,6 +10187,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -8981,24 +10201,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -9021,6 +10253,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -9135,18 +10370,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -9217,6 +10461,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -9225,6 +10472,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"encoded_configuration": schema.StringAttribute{
 						Required:    false,
@@ -9281,6 +10531,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -9299,6 +10552,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -9347,6 +10603,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify hostname and port, e.g., mykafkabroker:9092, or just hostname, in which case @{product} will assign port 9092.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topic": schema.StringAttribute{
@@ -9375,12 +10635,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. The value must not exceed the Kafka brokers' message.max.bytes setting.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of events you want the Destination to allow in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -9410,18 +10676,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -9591,48 +10866,72 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -9868,6 +11167,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -9879,24 +11181,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -9919,6 +11233,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -9974,6 +11291,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `List of Confluent Cloud bootstrap servers to use, such as yourAccount.confluent.cloud:9092.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"tls": schema.SingleNestedAttribute{
@@ -10069,12 +11390,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. The value must not exceed the Kafka brokers' message.max.bytes setting.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of events you want the Destination to allow in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -10104,18 +11431,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -10285,48 +11621,72 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -10495,6 +11855,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -10506,24 +11869,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -10546,6 +11921,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -10601,6 +11979,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify hostname and port, e.g., mykafkabroker:9092, or just hostname, in which case @{product} will assign port 9092.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topic": schema.StringAttribute{
@@ -10629,12 +12011,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. The value must not exceed the Kafka brokers' message.max.bytes setting.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of events you want the Destination to allow in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -10664,18 +12052,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -10845,48 +12242,72 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -10935,6 +12356,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -10947,6 +12372,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -11061,6 +12489,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -11072,24 +12503,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -11112,6 +12555,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -11186,18 +12632,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 102400),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -11218,6 +12673,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -11264,6 +12722,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -11271,24 +12732,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -11309,18 +12782,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -11465,6 +12947,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Bulk API URLs`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -11478,6 +12963,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -11487,12 +12975,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -11505,6 +12999,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -11516,24 +13013,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -11556,6 +13065,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -11624,18 +13136,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 102400),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -11656,6 +13177,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -11785,6 +13309,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -11792,24 +13319,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -11830,18 +13369,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -11873,6 +13421,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -11884,24 +13435,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -11924,6 +13487,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -11997,6 +13563,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to add to events from this input`,
+						Validators: []validator.List{
+							listvalidator.SizeAtMost(4),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"name": schema.StringAttribute{
@@ -12019,18 +13588,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -12051,6 +13629,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -12103,6 +13684,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -12110,24 +13694,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -12148,18 +13744,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -12184,6 +13789,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -12195,6 +13803,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -12207,6 +13818,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -12218,24 +13832,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -12258,6 +13884,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -12344,18 +13973,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -12376,6 +14014,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -12428,6 +14069,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -12435,24 +14079,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -12473,18 +14129,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -12514,6 +14179,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -12526,6 +14194,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -12537,24 +14208,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -12577,6 +14260,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -12646,6 +14332,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of an InfluxDB cluster to send events to, e.g., http://localhost:8086/write`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_v2_api": schema.BoolAttribute{
 						Required:    false,
@@ -12676,18 +14365,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 51200),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -12708,6 +14406,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -12760,6 +14461,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -12767,24 +14471,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -12805,18 +14521,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -12872,6 +14597,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -12883,24 +14611,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -12923,6 +14663,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -13065,6 +14808,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -13077,18 +14824,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of each individual record before compression. For non compressible data 1MB is the max recommended size`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -13130,6 +14886,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -13141,24 +14900,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -13181,6 +14952,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -13272,6 +15046,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -13284,6 +15061,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -13331,24 +15111,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -13361,6 +15153,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -13437,6 +15232,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -13452,6 +15250,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `MinIO service url (e.g. http://minioHost:9000)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"object_acl": schema.StringAttribute{
 						Required: false,
@@ -13507,6 +15308,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -13523,12 +15327,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -13541,6 +15351,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -13581,6 +15394,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -13599,6 +15415,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -13659,12 +15478,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Destination port.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"mtu": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `When protocol is UDP, specifies the maximum size of packets sent to the destination. Also known as the MTU for the network path to the destination system.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -13677,6 +15502,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every batch sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -13689,6 +15517,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -13718,6 +15549,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -13729,24 +15563,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -13769,6 +15615,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -13836,12 +15685,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Destination port.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"mtu": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `When protocol is UDP, specifies the maximum size of packets sent to the destination. Also known as the MTU for the network path to the destination system.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -13854,6 +15709,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every batch sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -13866,6 +15724,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -13895,6 +15756,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -13906,24 +15770,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -13946,6 +15822,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14013,12 +15892,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Destination port.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"mtu": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `When protocol is UDP, specifies the maximum size of packets sent to the destination. Also known as the MTU for the network path to the destination system.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -14031,6 +15916,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every batch sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -14043,6 +15931,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -14072,6 +15963,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -14083,24 +15977,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -14123,6 +16029,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14179,6 +16088,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Event routing rules`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"filter": schema.StringAttribute{
@@ -14322,6 +16234,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -14334,6 +16250,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -14369,6 +16288,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -14380,24 +16302,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -14420,6 +16354,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14547,6 +16484,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -14559,18 +16500,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of batches to send. Per the SQS spec, the max allowed value is 256 KB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 256),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -14583,6 +16533,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of in-progress API requests before backpressure is applied.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -14618,6 +16571,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -14629,24 +16585,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -14669,6 +16637,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14724,6 +16695,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `One or more SNMP destinations to forward traps to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -14737,6 +16711,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Destination port, default is 162`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 							},
 						},
@@ -14746,6 +16723,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if all destinations are IP addresses. A value of 0 means every trap sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"enable_ip_spoofing": schema.BoolAttribute{
 						Required:    false,
@@ -14764,6 +16744,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `MTU in bytes. The actual maximum SNMP Trap payload size will be MTU minus IP and UDP headers (28 bytes for IPv4, 48 bytes for IPv6). Payloads exceeding this limit will be dropped.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -14813,6 +16796,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Sumo Logic HTTP collector URL to which events should be sent`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"custom_source": schema.StringAttribute{
 						Required:    false,
@@ -14837,18 +16823,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -14869,6 +16864,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -14921,6 +16919,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -14928,24 +16929,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -14966,18 +16979,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -14997,6 +17019,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -15015,6 +17040,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -15026,24 +17054,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -15066,6 +17106,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -15189,18 +17232,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -15221,6 +17273,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -15273,6 +17328,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -15280,24 +17338,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -15318,18 +17388,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -15354,6 +17433,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -15377,6 +17459,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -15388,24 +17473,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -15428,6 +17525,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -15497,12 +17597,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The endpoint to send logs to, such as https://logs-prod-us-central1.grafana.net`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"prometheus_url": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The remote_write endpoint to send Prometheus metrics to, such as https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"message": schema.StringAttribute{
 						Required:    false,
@@ -15520,6 +17626,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `List of labels to send with logs. Labels define Loki streams, so use static labels to avoid proliferating label value combinations and streams. Can be merged and/or overridden by the event's __labels field. Example: '__labels: {host: "cribl.io", level: "error"}'`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"name": schema.StringAttribute{
@@ -15636,18 +17745,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking. Warning: Setting this value > 1 can cause Loki and Prometheus to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body. Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki and Prometheus to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited). Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki and Prometheus to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -15662,6 +17780,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -15714,6 +17835,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -15721,24 +17845,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -15759,18 +17895,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -15808,6 +17953,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -15819,24 +17967,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -15859,6 +18019,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -15915,6 +18078,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The endpoint to send logs to`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"message": schema.StringAttribute{
 						Required:    false,
@@ -15932,6 +18098,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `List of labels to send with logs. Labels define Loki streams, so use static labels to avoid proliferating label value combinations and streams. Can be merged and/or overridden by the event's __labels field. Example: '__labels: {host: "cribl.io", level: "error"}'`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"name": schema.StringAttribute{
@@ -15959,18 +18128,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking. Warning: Setting this value > 1 can cause Loki to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body. Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Defaults to 0 (unlimited). Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -15985,6 +18163,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -16037,6 +18218,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -16044,24 +18228,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -16082,18 +18278,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -16119,6 +18324,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -16175,6 +18383,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -16186,24 +18397,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -16226,6 +18449,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -16282,6 +18508,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The Amazon Managed Service for Prometheus remote_write endpoint`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https://aps-workspaces(?:-fips)?\.([a-z0-9]+(?:-[a-z0-9]+)*)\.(?:amazonaws\.com|api\.aws)/workspaces/ws-[A-Za-z0-9-]+/api/v1/remote_write$`), "must match pattern ^https://aps-workspaces(?:-fips)?\\.([a-z0-9]+(?:-[a-z0-9]+)*)\\.(?:amazonaws\\.com|api\\.aws)/workspaces/ws-[A-Za-z0-9-]+/api/v1/remote_write$"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -16320,6 +18549,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -16332,6 +18565,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"metric_rename_expr": schema.StringAttribute{
 						Required:    false,
@@ -16356,24 +18592,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed size, in KB, of the request body. The 1 MB cap is intentional and protects against data that compresses poorly, since oversized requests fail with a non-retryable 413.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -16426,6 +18674,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -16433,24 +18684,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -16471,18 +18734,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -16526,6 +18798,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -16537,24 +18812,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -16577,6 +18864,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -16632,6 +18922,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The endpoint to send metrics to`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"metric_rename_expr": schema.StringAttribute{
 						Required:    false,
@@ -16656,18 +18949,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -16682,6 +18984,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -16734,6 +19039,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -16741,24 +19049,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -16779,18 +19099,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -16834,6 +19163,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -16845,24 +19177,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -16885,6 +19229,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -16947,6 +19294,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: "ID used to sign Remote Write requests (for example, `aps` for Amazon Managed Service for Prometheus)",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`), "must match pattern ^[a-z][a-z0-9]*(-[a-z0-9]+)*$"),
+						},
 					},
 					"enable_assume_role": schema.BoolAttribute{
 						Required:    false,
@@ -16959,6 +19309,10 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -16971,6 +19325,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 				},
 			},
@@ -17032,12 +19389,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"max_data_time": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -17160,6 +19523,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -17194,18 +19560,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -17229,6 +19604,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"keep_alive": schema.BoolAttribute{
 						Required:    false,
@@ -17284,6 +19662,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL for OAuth`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"secret_param_name": schema.StringAttribute{
 						Required:    false,
@@ -17314,6 +19695,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the OAuth token should be refreshed.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 300000),
+						},
 					},
 					"oauth_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -17407,6 +19791,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -17414,24 +19801,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -17452,18 +19851,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -17545,6 +19953,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -17556,24 +19967,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -17596,6 +20019,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -17675,6 +20101,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"protocol": schema.StringAttribute{
 						Required: false,
@@ -17714,6 +20143,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -17748,12 +20180,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -17777,6 +20215,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"keep_alive": schema.BoolAttribute{
 						Required:    false,
@@ -17843,6 +20284,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -17850,24 +20294,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -17888,18 +20344,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -17981,6 +20446,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -17992,24 +20460,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -18032,6 +20512,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -18119,6 +20602,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -18126,24 +20612,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -18164,18 +20662,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -18196,18 +20703,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 6144),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -18228,6 +20744,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -18290,6 +20809,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -18301,6 +20823,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -18313,6 +20838,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -18324,24 +20852,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -18364,6 +20904,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -18449,6 +20992,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -18534,6 +21080,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires, valid values between 1 and 60`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -18592,6 +21141,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -18604,6 +21156,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of hosts to load-balance data to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -18617,6 +21172,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -18634,6 +21192,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -18643,18 +21204,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -18667,6 +21237,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -18678,24 +21251,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -18718,6 +21303,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -18847,6 +21435,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires. Valid values are between 1 and 60.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"exclude_fields": schema.ListAttribute{
 						Required:    false,
@@ -18865,18 +21456,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -18891,6 +21491,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -18937,12 +21540,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -18950,24 +21559,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -18988,18 +21609,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -19053,6 +21683,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -19071,6 +21704,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Cribl Worker endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -19078,12 +21714,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -19093,12 +21735,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -19111,6 +21759,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -19122,24 +21773,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -19162,6 +21825,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -19291,6 +21957,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires. Valid values are between 1 and 60.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"exclude_fields": schema.ListAttribute{
 						Required:    false,
@@ -19309,18 +21978,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -19335,6 +22013,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -19381,12 +22062,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -19394,24 +22081,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -19432,18 +22131,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -19503,6 +22211,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -19515,6 +22226,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Cribl Worker endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -19522,12 +22236,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -19537,12 +22257,18 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -19555,6 +22281,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -19566,24 +22295,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -19606,6 +22347,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -19662,24 +22406,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to a CrowdStrike Falcon LogScale endpoint to send events to. Examples: https://cloud.us.humio.com/api/v1/ingest/hec for JSON and https://cloud.us.humio.com/api/v1/ingest/hec/raw for raw`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 32768),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -19700,6 +22456,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -19762,6 +22521,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -19769,24 +22531,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -19807,18 +22581,27 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -19863,6 +22646,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -19874,24 +22660,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -19914,6 +22712,9 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -19971,24 +22772,36 @@ func (r *DestinationResource) Schema(_ context.Context, _ resource.SchemaRequest
 						Computed: true,
 						Description: `URL provided from a CrowdStrike data connector. 
 Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/v1/services/collector`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 32768),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -20009,6 +22822,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -20071,6 +22887,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -20078,24 +22897,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -20116,18 +22947,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -20172,6 +23012,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -20183,24 +23026,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -20223,6 +23078,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -20291,6 +23149,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -20303,6 +23165,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -20344,6 +23209,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -20356,6 +23224,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -20397,24 +23268,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -20427,6 +23310,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -20503,6 +23389,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -20580,6 +23469,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -20596,12 +23488,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -20614,6 +23512,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -20654,6 +23555,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -20672,6 +23576,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -20732,6 +23639,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -20744,6 +23655,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -20779,6 +23693,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -20791,6 +23708,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -20821,24 +23741,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -20851,6 +23783,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -20927,6 +23862,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -20991,12 +23929,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -21009,6 +23953,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -21067,6 +24014,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -21079,6 +24029,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"deadletter_path": schema.StringAttribute{
 						Required:    false,
@@ -21091,6 +24044,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -21170,24 +24126,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -21200,6 +24168,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -21276,6 +24247,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -21305,11 +24279,17 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1000),
+						},
 					},
 					"max_concurrent_file_parts": schema.Float64Attribute{
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -21338,6 +24318,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -21354,12 +24337,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -21372,6 +24361,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -21412,6 +24404,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -21430,6 +24425,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -21485,12 +24483,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum disk space that can be consumed before older buckets are deleted. Examples: 420MB, 4GB. Default is 1GB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+(\.\d+)?\s*(?:[kmgKMG](b|B))?$`), "must match pattern ^\\d+(\\.\\d+)?\\s*(?:[kmgKMG](b|B))?$"),
+						},
 					},
 					"max_data_time": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to retain data before older buckets are deleted. Examples: 2h, 4d. Default is 24h.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -21574,6 +24578,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the ClickHouse table where data will be inserted. Name can contain letters (A-Z, a-z), numbers (0-9), and the character "_", and must start with either a letter or the character "_".`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z_][0-9a-zA-Z_]*$`), "must match pattern ^[a-zA-Z_][0-9a-zA-Z_]*$"),
+						},
 					},
 					"format": schema.StringAttribute{
 						Required: false,
@@ -21656,18 +24663,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 25600),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -21688,6 +24704,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -21740,6 +24759,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -21747,24 +24769,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -21785,18 +24819,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -21865,6 +24908,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to exclude from sending to ClickHouse`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(0)),
+						},
 						ElementType: types.StringType,
 					},
 					"describe_table": schema.StringAttribute{
@@ -21912,6 +24959,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -21923,24 +24973,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -21963,6 +25025,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -22036,6 +25101,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the ClickHouse table where data will be inserted. Name can contain letters (A-Z, a-z), numbers (0-9), and the character "_", and must start with either a letter or the character "_".`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z_][0-9a-zA-Z_]*$`), "must match pattern ^[a-zA-Z_][0-9a-zA-Z_]*$"),
+						},
 					},
 					"format": schema.StringAttribute{
 						Required: false,
@@ -22118,18 +25186,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 25600),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -22150,6 +25227,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -22202,6 +25282,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -22209,24 +25292,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -22247,18 +25342,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -22327,6 +25431,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to exclude from sending to ClickHouse`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(0)),
+						},
 						ElementType: types.StringType,
 					},
 					"describe_table": schema.StringAttribute{
@@ -22374,6 +25482,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -22385,24 +25496,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -22425,6 +25548,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -22498,6 +25624,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the table where data will be inserted. Name can contain letters (A-Z, a-z), numbers (0-9), and the character "_", and must start with either a letter or the character "_".`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z_][0-9a-zA-Z_]*$`), "must match pattern ^[a-zA-Z_][0-9a-zA-Z_]*$"),
+						},
 					},
 					"format": schema.StringAttribute{
 						Required:    false,
@@ -22582,18 +25711,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 25600),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -22614,6 +25752,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -22666,6 +25807,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -22673,24 +25817,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -22711,18 +25867,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -22844,6 +26009,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to exclude from sending`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(0)),
+						},
 						ElementType: types.StringType,
 					},
 					"describe_table": schema.StringAttribute{
@@ -22891,6 +26060,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -22902,24 +26074,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -22942,6 +26126,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -23004,18 +26191,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(100, 10000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -23036,6 +26232,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -23088,6 +26287,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -23095,24 +26297,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -23133,18 +26347,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -23159,6 +26382,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of requests to limit to per second`,
+						Validators: []validator.Int64{
+							int64validator.AtMost(2000),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -23170,6 +26396,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -23182,6 +26411,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `XSIAM endpoint URL to send events to, such as https://api-{tenant external URL}/logs/v1/event`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -23200,6 +26432,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `XSIAM Endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"weight": schema.Float64Attribute{
@@ -23207,6 +26442,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -23216,12 +26454,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"token": schema.StringAttribute{
 						Required:    false,
@@ -23247,6 +26491,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -23258,24 +26505,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -23298,6 +26557,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -23353,6 +26615,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `One or more NetFlow Destinations to forward events to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -23366,6 +26631,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `Destination port, default is 2055`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 							},
 						},
@@ -23375,6 +26643,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if all destinations are IP addresses. A value of 0 means every datagram sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"enable_ip_spoofing": schema.BoolAttribute{
 						Required:    false,
@@ -23393,6 +26664,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `MTU in bytes. The actual maximum NetFlow payload size will be MTU minus IP and UDP headers (28 bytes for IPv4, 48 bytes for IPv6). For example, with the default MTU of 1500, the max payload is 1472 bytes for IPv4. Payloads exceeding this limit will be dropped.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -23453,18 +26727,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 5000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 50000),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -23485,6 +26768,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -23537,6 +26823,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -23544,24 +26833,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -23582,18 +26883,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -23637,6 +26947,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -23655,6 +26968,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -23666,24 +26982,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -23706,6 +27034,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -23744,6 +27075,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to send events to. Can be overwritten by an event's __url field.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 				},
 			},
@@ -23838,6 +27172,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -23872,18 +27209,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (in KB) of the request body. The maximum payload size is 4 MB. If this limit is exceeded, the entire OTLP message is dropped`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 4096),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -23907,6 +27253,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"keep_alive": schema.BoolAttribute{
 						Required:    false,
@@ -23991,6 +27340,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -23998,24 +27350,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -24036,18 +27400,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -24068,6 +27441,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -24079,24 +27455,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -24119,6 +27507,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -24175,18 +27566,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 2097152),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -24207,6 +27607,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -24258,6 +27661,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -24265,24 +27671,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -24303,18 +27721,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -24365,6 +27792,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Base URL of the endpoint used to send events to, such as https://<Your-S1-Tenant>.sentinelone.net. Must begin with http:// or https://, can include a port number, and no trailing slashes. Matches pattern: ^https?://[a-zA-Z0-9.-]+(:[0-9]+)?$.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://[a-zA-Z0-9.-]+(:[0-9]+)?$`), "must match pattern ^https?://[a-zA-Z0-9.-]+(:[0-9]+)?$"),
+						},
 					},
 					"host_expression": schema.StringAttribute{
 						Required:    false,
@@ -24461,6 +27891,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -24472,24 +27905,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -24512,6 +27957,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -24580,6 +28028,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -24587,24 +28038,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -24625,18 +28088,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -24657,18 +28129,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 4096),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -24689,6 +28170,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -24746,6 +28230,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ingestion_method": schema.StringAttribute{
 						Required:    false,
@@ -24816,6 +28303,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Chronicle API service endpoint. If empty, defaults to the Region-specific endpoint. Otherwise, it must point to a Chronicle API-compatible endpoint. (Example: https://custom-endpoint.googleapis.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -24846,6 +28336,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -24857,24 +28350,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -24897,6 +28402,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -25000,24 +28508,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -25030,6 +28550,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -25106,6 +28629,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -25162,6 +28688,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(30),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -25190,6 +28719,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -25206,12 +28738,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -25224,6 +28762,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -25264,6 +28805,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -25282,6 +28826,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -25393,18 +28940,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed size of each batch. With compression enabled (default), batches are zstd-compressed before sending. Snowflake has observed a ~4 MB limit on the compressed wire size.`,
+						Validators: []validator.Float64{
+							float64validator.Between(64, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events per request. Default is 0 (unlimited, size-gated only).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -25425,6 +28981,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -25471,12 +29030,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Timeout in seconds for token exchange, channel open/close, and hostname discovery. Defaults to 30 seconds.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 300),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -25484,24 +29049,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -25522,18 +29099,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -25565,6 +29151,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -25576,24 +29165,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -25616,6 +29217,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -25688,12 +29292,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. Setting should be < message.max.bytes settings in Event Hubs brokers.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -25706,48 +29316,72 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required:    false,
@@ -25883,6 +29517,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -25894,24 +29531,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -25934,6 +29583,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -26019,6 +29671,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -26031,6 +29686,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -26078,24 +29736,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -26108,6 +29778,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -26184,6 +29857,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -26199,6 +29875,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Cloudflare R2 service URL (example: https://<ACCOUNT_ID>.r2.cloudflarestorage.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"storage_class": schema.StringAttribute{
 						Required: false,
@@ -26243,6 +29922,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -26259,12 +29941,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -26277,6 +29965,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -26317,6 +30008,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -26335,6 +30029,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -26419,6 +30116,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -26431,6 +30131,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -26478,24 +30181,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -26508,6 +30223,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -26584,6 +30302,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -26592,6 +30313,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Nutanix Objects S3-compatible endpoint URL (example: https://objects.nutanix.local)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -26626,6 +30350,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -26642,12 +30369,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -26660,6 +30393,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -26700,6 +30436,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -26718,6 +30457,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -26796,6 +30538,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -26808,6 +30553,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -26855,24 +30603,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -26885,6 +30645,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -26961,6 +30724,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -26969,6 +30735,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Storj S3-compatible gateway endpoint URL (example: https://gateway.storjshare.io)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27003,6 +30772,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -27019,12 +30791,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -27037,6 +30815,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -27077,6 +30858,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -27095,6 +30879,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -27173,6 +30960,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -27185,6 +30975,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -27232,24 +31025,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -27262,6 +31067,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -27338,6 +31146,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -27346,6 +31157,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `AlphaSOC S3-compatible endpoint URL (example: https://s3.alphasoc.net)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27380,6 +31194,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -27396,12 +31213,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -27414,6 +31237,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -27454,6 +31280,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -27472,6 +31301,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -27556,6 +31388,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -27568,6 +31403,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -27615,24 +31453,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -27645,6 +31495,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -27721,6 +31574,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -27734,6 +31590,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Dell PowerScale OneFS S3-compatible endpoint URL (example: https://powerscale.example.com:9021)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27768,6 +31627,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -27784,12 +31646,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -27802,6 +31670,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -27842,6 +31713,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -27860,6 +31734,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -27909,6 +31786,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Cloudian HyperStore S3-compatible endpoint URL (example: https://s3.hyperstore.example.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -27950,6 +31830,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -27962,6 +31845,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -28009,24 +31895,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -28039,6 +31937,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -28115,6 +32016,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -28172,6 +32076,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -28188,12 +32095,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -28206,6 +32119,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -28246,6 +32162,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -28264,6 +32183,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -28348,6 +32270,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -28360,6 +32285,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -28407,24 +32335,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -28437,6 +32377,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -28513,6 +32456,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -28521,6 +32467,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Scality RING S3-compatible endpoint URL (example: https://s3.scality.example.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -28555,6 +32504,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -28571,12 +32523,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -28589,6 +32547,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -28629,6 +32590,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -28647,6 +32611,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -28726,6 +32693,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -28738,6 +32708,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -28785,24 +32758,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -28815,6 +32800,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -28891,6 +32879,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -28904,6 +32895,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: "Alibaba OSS S3-compatible endpoint URL. Examples: public `https://s3.oss-{region}.aliyuncs.com`, internal `https://s3.oss-{region}-internal.aliyuncs.com`",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"enable_assume_role": schema.BoolAttribute{
 						Required:    false,
@@ -28916,12 +32910,19 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"assume_role_arn": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `ARN of the RAM role to assume. Format: acs:ram::<account-id>:role/<role-name>. Example: acs:ram::123456789:role/OSSAccessRole`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^acs:`), "must match pattern ^acs:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -28962,6 +32963,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -28978,12 +32982,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -28996,6 +33006,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -29036,6 +33049,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -29054,6 +33070,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -29103,6 +33122,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `IBM Cloud Object Storage S3-compatible endpoint URL (example: https://s3.us-south.cloud-object-storage.appdomain.cloud)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -29138,6 +33160,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -29150,6 +33175,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -29197,24 +33225,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -29227,6 +33267,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -29303,6 +33346,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -29339,6 +33385,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -29355,12 +33404,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -29373,6 +33428,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -29413,6 +33471,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -29431,6 +33492,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},

--- a/internal/provider/event_breaker_ruleset_resource.go
+++ b/internal/provider/event_breaker_ruleset_resource.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_int64planmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/int64planmodifier"
@@ -13,11 +14,14 @@ import (
 	custom_objectplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/objectplanmodifier"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -70,6 +74,9 @@ func (r *EventBreakerRulesetResource) Schema(_ context.Context, _ resource.Schem
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
 				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9\-_ ]+$`), "must match pattern ^[a-zA-Z0-9\\-_ ]+$"),
+				},
 			},
 			"lib": schema.StringAttribute{
 				Required:    false,
@@ -87,6 +94,9 @@ func (r *EventBreakerRulesetResource) Schema(_ context.Context, _ resource.Schem
 				Description: `The  minimum number of characters in _raw to determine which rule to use`,
 				PlanModifiers: []planmodifier.Int64{
 					custom_int64planmodifier.SuppressDiff(custom_int64planmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.Int64{
+					int64validator.Between(50, 100000),
 				},
 			},
 			"rules": schema.ListNestedAttribute{
@@ -143,6 +153,9 @@ func (r *EventBreakerRulesetResource) Schema(_ context.Context, _ resource.Schem
 									Optional:    true,
 									Computed:    false,
 									Description: `Number of characters from the start of the event to search for a timestamp.`,
+									Validators: []validator.Int64{
+										int64validator.AtLeast(2),
+									},
 								},
 								"format": schema.StringAttribute{
 									Required:    false,
@@ -175,6 +188,9 @@ func (r *EventBreakerRulesetResource) Schema(_ context.Context, _ resource.Schem
 							Optional:    true,
 							Computed:    false,
 							Description: `The maximum number of bytes in an event before it is flushed to the pipelines`,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 134217728),
+							},
 						},
 						"fields": schema.ListNestedAttribute{
 							Required:    false,

--- a/internal/provider/global_var_resource.go
+++ b/internal/provider/global_var_resource.go
@@ -6,17 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_listplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/listplanmodifier"
 	custom_objectplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/objectplanmodifier"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -102,6 +105,9 @@ func (r *GlobalVarResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
 				},
 			},
 			"lib": schema.StringAttribute{

--- a/internal/provider/grok_resource.go
+++ b/internal/provider/grok_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -66,6 +69,9 @@ func (r *GrokResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`\S`), "must match pattern \\S"),
 				},
 			},
 			"size": schema.Int64Attribute{

--- a/internal/provider/key_resource.go
+++ b/internal/provider/key_resource.go
@@ -10,11 +10,13 @@ import (
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -109,6 +111,9 @@ func (r *KeyResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *
 				Optional:    true,
 				Computed:    true,
 				Description: `Key class`,
+				Validators: []validator.Float64{
+					float64validator.AtLeast(0),
+				},
 			},
 			"kms": schema.StringAttribute{
 				Required:    false,

--- a/internal/provider/lookup_file_resource.go
+++ b/internal/provider/lookup_file_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -72,6 +75,9 @@ func (r *LookupFileResource) Schema(_ context.Context, _ resource.SchemaRequest,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^\w[\w -]+(?:\.csv|\.gz|\.csv\.gz|\.mmdb)?$`), "must match pattern ^\\w[\\w -]+(?:\\.csv|\\.gz|\\.csv\\.gz|\\.mmdb)?$"),
 				},
 			},
 			"mode": schema.StringAttribute{

--- a/internal/provider/mapping_ruleset_resource.go
+++ b/internal/provider/mapping_ruleset_resource.go
@@ -6,15 +6,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -103,6 +107,9 @@ func (r *MappingRulesetResource) Schema(_ context.Context, _ resource.SchemaRequ
 											Optional:    false,
 											Computed:    false,
 											Description: `The group assignment action for the Mapping Rule.`,
+											Validators: []validator.List{
+												listvalidator.SizeBetween(1, 1),
+											},
 											NestedObject: schema.NestedAttributeObject{
 												Attributes: map[string]schema.Attribute{
 													"name": schema.StringAttribute{
@@ -116,6 +123,9 @@ func (r *MappingRulesetResource) Schema(_ context.Context, _ resource.SchemaRequ
 														Optional:    false,
 														Computed:    false,
 														Description: `The <code>id</code> of the group to assign the Worker or Edge Node to if the Mapping Rule applies.`,
+														Validators: []validator.String{
+															stringvalidator.UTF8LengthAtLeast(1),
+														},
 													},
 												},
 											},
@@ -141,6 +151,9 @@ func (r *MappingRulesetResource) Schema(_ context.Context, _ resource.SchemaRequ
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
 				},
 			},
 			"product": schema.StringAttribute{

--- a/internal/provider/notification_resource.go
+++ b/internal/provider/notification_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -138,6 +141,9 @@ func (r *NotificationResource) Schema(_ context.Context, _ resource.SchemaReques
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
 				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+				},
 			},
 			"metadata": schema.ListNestedAttribute{
 				Required:    false,
@@ -185,6 +191,9 @@ func (r *NotificationResource) Schema(_ context.Context, _ resource.SchemaReques
 							Optional:    false,
 							Computed:    false,
 							Description: `The <code>id</code> of the Notification target.`,
+							Validators: []validator.String{
+								stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							},
 						},
 					},
 				},

--- a/internal/provider/notification_target_resource.go
+++ b/internal/provider/notification_target_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_listplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/listplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -52,6 +53,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+				},
 			},
 			"type": schema.StringAttribute{
 				Required:    false,
@@ -68,6 +72,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique ID for this notification target`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -89,6 +96,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to send the webhook to`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.+`), "must match pattern ^https?://.+"),
+						},
 					},
 					"format": schema.StringAttribute{
 						Required:    false,
@@ -136,6 +146,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique ID for this notification target`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -192,6 +205,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique ID for this notification target`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -227,6 +243,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique ID for this notification target`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -332,6 +351,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique ID for this notification target`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -359,6 +381,9 @@ func (r *NotificationTargetResource) Schema(_ context.Context, _ resource.Schema
 						Optional:    true,
 						Computed:    true,
 						Description: `SMTP server port`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 65535),
+						},
 					},
 					"from": schema.StringAttribute{
 						Required:    false,

--- a/internal/provider/pack_breakers_resource.go
+++ b/internal/provider/pack_breakers_resource.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_int64planmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/int64planmodifier"
@@ -13,11 +14,14 @@ import (
 	custom_objectplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/objectplanmodifier"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -69,6 +73,9 @@ func (r *PackBreakersResource) Schema(_ context.Context, _ resource.SchemaReques
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
 				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9\-_ ]+$`), "must match pattern ^[a-zA-Z0-9\\-_ ]+$"),
+				},
 			},
 			"lib": schema.StringAttribute{
 				Required:    false,
@@ -86,6 +93,9 @@ func (r *PackBreakersResource) Schema(_ context.Context, _ resource.SchemaReques
 				Description: `The  minimum number of characters in _raw to determine which rule to use`,
 				PlanModifiers: []planmodifier.Int64{
 					custom_int64planmodifier.SuppressDiff(custom_int64planmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.Int64{
+					int64validator.Between(50, 100000),
 				},
 			},
 			"pack": schema.StringAttribute{
@@ -150,6 +160,9 @@ func (r *PackBreakersResource) Schema(_ context.Context, _ resource.SchemaReques
 									Optional:    true,
 									Computed:    false,
 									Description: `Number of characters from the start of the event to search for a timestamp.`,
+									Validators: []validator.Int64{
+										int64validator.AtLeast(2),
+									},
 								},
 								"format": schema.StringAttribute{
 									Required:    false,
@@ -182,6 +195,9 @@ func (r *PackBreakersResource) Schema(_ context.Context, _ resource.SchemaReques
 							Optional:    true,
 							Computed:    false,
 							Description: `The maximum number of bytes in an event before it is flushed to the pipelines`,
+							Validators: []validator.Int64{
+								int64validator.Between(1, 134217728),
+							},
 						},
 						"fields": schema.ListNestedAttribute{
 							Required:    false,

--- a/internal/provider/pack_destination_resource.go
+++ b/internal/provider/pack_destination_resource.go
@@ -6,14 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -200,18 +206,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 512000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -232,6 +247,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -284,6 +302,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -291,24 +312,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -329,18 +362,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -426,6 +468,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"load_balanced": schema.BoolAttribute{
 						Required:    false,
@@ -498,6 +543,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -509,24 +557,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -549,6 +609,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -594,6 +657,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL for OAuth`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"secret_param_name": schema.StringAttribute{
 						Required:    false,
@@ -625,6 +691,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the OAuth token should be refreshed.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 300000),
+						},
 					},
 					"oauth_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -687,6 +756,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Override the refresh endpoint URL if it differs from the Login URL. Defaults to Login URL.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"refresh_request_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -715,6 +787,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of a webhook endpoint to send events to, such as http://localhost:10200`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -727,6 +802,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Webhook URLs`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -734,12 +812,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `URL of a webhook endpoint to send events to, such as http://localhost:10200`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -749,12 +833,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 				},
 			},
@@ -810,18 +900,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of the request body (defaults to the API's maximum limit of 1000 KB)`,
+						Validators: []validator.Float64{
+							float64validator.Between(100, 1000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -842,6 +941,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -894,6 +996,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -901,24 +1006,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -939,18 +1056,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -976,6 +1102,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL for OAuth`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"secret": schema.StringAttribute{
 						Required:    false,
@@ -1001,6 +1130,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Override the refresh endpoint URL if it differs from the Login URL. Defaults to Login URL.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"refresh_request_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -1047,6 +1179,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -1118,6 +1253,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -1129,24 +1267,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -1169,6 +1319,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -1182,6 +1335,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to send events to. Can be overwritten by an event's __url field.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"dcr_id": schema.StringAttribute{
 						Required:    false,
@@ -1194,6 +1350,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: "Data collection endpoint (DCE) URL. In the format: `https://<Endpoint-Name>-<Identifier>.<Region>.ingest.monitor.azure.com`",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https:\/\/([a-zA-Z0-9-_\.]+)\.ingest\.monitor\.azure\.com(\/?)$`), "must match pattern ^https:\\/\\/([a-zA-Z0-9-_\\.]+)\\.ingest\\.monitor\\.azure\\.com(\\/?)$"),
+						},
 					},
 					"stream_name": schema.StringAttribute{
 						Required:    false,
@@ -1327,6 +1486,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"octet_count_framing": schema.BoolAttribute{
 						Required:    false,
@@ -1363,6 +1525,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -1375,6 +1540,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of hosts to load-balance data to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -1388,6 +1556,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -1405,6 +1576,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -1414,18 +1588,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -1516,12 +1699,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of syslog messages. Make sure this value is less than or equal to the MTU to avoid UDP packet fragmentation.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"udp_dns_resolve_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every message sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"enable_ip_spoofing": schema.BoolAttribute{
 						Required:    false,
@@ -1540,6 +1729,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -1551,24 +1743,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -1591,6 +1795,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -1652,6 +1859,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"nested_fields": schema.StringAttribute{
 						Required: false,
@@ -1663,6 +1873,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -1787,6 +2000,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of times healthcheck can fail before we close connection. If set to 0 (disabled), and the connection to Splunk is forcibly closed, some data loss might occur.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -1804,6 +2020,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -1815,24 +2034,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -1855,6 +2086,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -1924,18 +2158,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"nested_fields": schema.StringAttribute{
 						Required: false,
@@ -1947,6 +2190,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -2066,6 +2312,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in milliseconds) each LB endpoint can report blocked before the Destination reports unhealthy, blocking the sender. (Grace period for fluctuations.) Use 0 to disable; max 1 minute.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 60000),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -2083,6 +2332,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of times healthcheck can fail before we close connection. If set to 0 (disabled), and the connection to Splunk is forcibly closed, some data loss might occur.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -2100,18 +2352,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Clustering site of the indexers from where indexers need to be discovered. In case of single site cluster, it defaults to 'default' site.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`[0-9A-Za-z-._]+`), "must match pattern [0-9A-Za-z-._]+"),
+								},
 							},
 							"master_uri": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Full URI of Splunk cluster manager (scheme://host:port). Example: https://managerAddress:8089`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^https?://[a-zA-Z0-9-._]+:[0-9]+$`), "must match pattern ^https?://[a-zA-Z0-9-._]+:[0-9]+$"),
+								},
 							},
 							"refresh_interval_sec": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Time interval, in seconds, between two consecutive indexer list fetches from cluster manager`,
+								Validators: []validator.Float64{
+									float64validator.Between(60, 86400),
+								},
 							},
 							"reject_unauthorized": schema.BoolAttribute{
 								Required:    false,
@@ -2178,6 +2439,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of Splunk indexers to load-balance data to.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -2191,6 +2455,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -2208,6 +2475,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -2223,6 +2493,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -2234,24 +2507,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -2274,6 +2559,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -2409,18 +2697,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 2097152),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -2441,6 +2738,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -2498,6 +2798,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -2505,24 +2808,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -2543,18 +2858,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -2592,6 +2916,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to a Splunk HEC endpoint to send events to, e.g., http://localhost:8088/services/collector/event`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -2610,6 +2937,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Splunk HEC Endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -2617,12 +2947,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `URL to a Splunk HEC endpoint to send events to, e.g., http://localhost:8088/services/collector/event`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -2632,12 +2968,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"token": schema.StringAttribute{
 						Required:    false,
@@ -2663,6 +3005,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -2674,24 +3019,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -2714,6 +3071,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -2830,18 +3190,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 9000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -2862,6 +3231,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -2913,6 +3285,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -2920,24 +3295,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -2958,18 +3345,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -3038,6 +3434,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3049,24 +3448,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -3089,6 +3500,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -3161,6 +3575,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -3246,6 +3663,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires, valid values between 1 and 60`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"send_header": schema.BoolAttribute{
 						Required:    false,
@@ -3280,6 +3700,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -3292,6 +3715,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of hosts to load-balance data to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -3305,6 +3731,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -3322,6 +3751,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -3331,18 +3763,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -3355,6 +3796,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3366,24 +3810,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -3406,6 +3862,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -3486,18 +3945,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -3518,6 +3986,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -3570,6 +4041,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -3577,24 +4051,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -3615,18 +4101,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -3671,6 +4166,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3682,24 +4180,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -3722,6 +4232,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -3789,18 +4302,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -3821,6 +4343,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -3873,6 +4398,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -3880,24 +4408,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -3918,18 +4458,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -3974,6 +4523,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -3985,24 +4537,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -4025,6 +4589,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -4128,24 +4695,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -4158,6 +4737,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -4234,6 +4816,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -4264,6 +4849,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -4280,12 +4868,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -4298,6 +4892,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -4338,6 +4935,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -4356,6 +4956,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -4416,6 +5019,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -4428,6 +5035,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -4469,6 +5079,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -4481,6 +5094,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -4528,24 +5144,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -4558,6 +5186,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -4634,6 +5265,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -4704,6 +5338,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -4720,12 +5357,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -4738,6 +5381,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -4778,6 +5424,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -4796,6 +5445,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -4874,6 +5526,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"remove_empty_dirs": schema.BoolAttribute{
 						Required:    false,
@@ -4909,24 +5564,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -4939,6 +5606,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -5015,6 +5685,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -5056,6 +5729,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -5072,12 +5748,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -5090,6 +5772,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -5130,6 +5815,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -5148,6 +5836,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"connection_string": schema.StringAttribute{
 						Required:    false,
@@ -5258,18 +5949,29 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: "The base URI for your cluster. Typically, `https://<cluster>.<region>.kusto.windows.net`.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https://`), "must match pattern ^https://"),
+						},
 					},
 					"database": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the database containing the table where data will be ingested`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\s\-\.]+$`), "must match pattern ^[\\w\\s\\-\\.]+$"),
+							stringvalidator.UTF8LengthAtMost(260),
+						},
 					},
 					"table": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the table to ingest data into`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\-\.]+$`), "must match pattern ^[\\w\\-\\.]+$"),
+							stringvalidator.UTF8LengthAtMost(1024),
+						},
 					},
 					"validate_database_settings": schema.BoolAttribute{
 						Required:    false,
@@ -5370,6 +6072,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -5386,12 +6091,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -5404,6 +6115,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -5450,6 +6164,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -5474,6 +6191,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"is_mapping_obj": schema.BoolAttribute{
 						Required:    false,
@@ -5492,12 +6212,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Enter the name of a data mapping associated with your target table. Or, if incoming event and target table fields match exactly, you can leave the field empty.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\-\.]+$`), "must match pattern ^[\\w\\-\\.]+$"),
+						},
 					},
 					"ingest_url": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: "The ingestion service URI for your cluster. Typically, `https://ingest-<cluster>.<region>.kusto.windows.net`.",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https://`), "must match pattern ^https://"),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -5521,30 +6247,45 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"max_concurrent_file_parts": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"on_disk_full_backpressure": schema.StringAttribute{
 						Required: false,
@@ -5610,6 +6351,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -5618,6 +6362,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_immediately": schema.BoolAttribute{
 						Required:    false,
@@ -5693,6 +6440,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Key`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^[\w\-\.]+$`), "must match pattern ^[\\w\\-\\.]+$"),
+									},
 								},
 								"value": schema.StringAttribute{
 									Required:    false,
@@ -5708,6 +6458,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -5715,24 +6468,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -5753,18 +6518,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -5779,18 +6553,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 4096),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -5829,6 +6612,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -5840,24 +6626,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -5880,6 +6678,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -5936,6 +6737,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: "The Log Type of events sent to this LogAnalytics workspace. Defaults to `Cribl`. Use only letters, numbers, and `_` characters, and can't exceed 100 characters. Can be overwritten by event field __logType.",
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtMost(100),
+						},
 					},
 					"resource_id": schema.StringAttribute{
 						Required:    false,
@@ -5948,18 +6752,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required: false,
@@ -5979,6 +6792,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6031,12 +6847,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The DNS name of the Log API endpoint that sends log data to a Log Analytics workspace in Azure Monitor. Defaults to .ods.opinsights.azure.com. @{product} will add a prefix and suffix to construct a URI in this format: <https://<Workspace_ID><your_DNS_name>/api/logs?api-version=<API version>.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\.[^\/]+$`), "must match pattern ^\\.[^\\/]+$"),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -6044,24 +6866,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -6082,18 +6916,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -6131,6 +6974,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -6142,24 +6988,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -6182,6 +7040,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -6303,6 +7164,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -6315,18 +7180,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing put requests before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of each individual record before compression. For uncompressed or non-compressible data 1MB is the max recommended size`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6380,6 +7254,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of records to send in a single request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 500),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -6392,6 +7269,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -6403,24 +7283,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -6443,6 +7335,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -6505,18 +7400,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -6537,6 +7441,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6589,6 +7496,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -6596,24 +7506,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -6634,18 +7556,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -6682,6 +7613,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -6693,24 +7627,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -6733,6 +7679,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -6801,6 +7750,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `List of Event Hubs Kafka brokers to connect to, eg. yourdomain.servicebus.windows.net:9093. The hostname can be found in the host portion of the primary or secondary connection string in Shared Access Policies.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topic": schema.StringAttribute{
@@ -6824,12 +7777,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. Setting should be < message.max.bytes settings in Event Hubs brokers.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -6842,48 +7801,72 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -7031,6 +8014,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -7042,24 +8028,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -7082,6 +8080,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -7175,30 +8176,45 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait before sending a batch (when batch size limit is not reached)`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of a single append request. BigQuery limit is 10 MB`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"max_in_progress": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of in-progress API requests before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"max_send_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum retries per batch for retryable failures (transient, rate-limit, unknown) before dropping. 0 (default) retries indefinitely.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -7222,6 +8238,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -7233,24 +8252,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -7273,6 +8304,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -7341,6 +8375,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -7348,24 +8385,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -7386,18 +8435,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -7424,18 +8482,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -7456,6 +8523,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -7513,6 +8583,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -7532,6 +8605,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Log Type`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^[A-Z0-9_]+$`), "must match pattern ^[A-Z0-9_]+$"),
+									},
 								},
 								"description": schema.StringAttribute{
 									Required:    false,
@@ -7630,6 +8706,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -7641,24 +8720,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -7681,6 +8772,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -7836,24 +8930,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -7866,6 +8972,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -7942,6 +9051,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -7972,6 +9084,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -7988,12 +9103,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -8006,6 +9127,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -8046,6 +9170,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -8064,6 +9191,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"aws_api_key": schema.StringAttribute{
 						Required:    false,
@@ -8236,12 +9366,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Max number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -8254,6 +9390,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -8266,12 +9405,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"throttle_rate_req_per_sec": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of requests to limit to per second.`,
+						Validators: []validator.Int64{
+							int64validator.AtMost(2000),
+						},
 					},
 					"request_method_expression": schema.StringAttribute{
 						Required:    false,
@@ -8451,6 +9596,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -8481,6 +9629,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -8492,24 +9643,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -8532,6 +9695,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -8612,6 +9778,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -8646,18 +9815,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body sent to Google Cloud Observability`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -8681,6 +9859,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -8748,6 +9929,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Max number of events to include in the request body. Default is 0 (unlimited). Use to keep outgoing data points within GCO request limits. For metrics, combine with the OTLP Metrics function batchSize.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -8778,6 +9962,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -8789,24 +9976,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -8829,6 +10028,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -8926,24 +10128,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of items the Google API should batch before it sends them to the topic.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"batch_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum amount of time, in milliseconds, that the Google API should wait to send a batch (if the Batch size is not reached).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100000),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of batches to send.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 256),
+						},
 					},
 					"flush_period": schema.Float64Attribute{
 						Required:    false,
@@ -8956,6 +10170,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of in-progress API requests before backpressure is applied.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -8979,6 +10196,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -8990,24 +10210,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -9030,6 +10262,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -9144,18 +10379,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -9226,6 +10470,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -9234,6 +10481,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"encoded_configuration": schema.StringAttribute{
 						Required:    false,
@@ -9290,6 +10540,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -9308,6 +10561,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -9356,6 +10612,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify hostname and port, e.g., mykafkabroker:9092, or just hostname, in which case @{product} will assign port 9092.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topic": schema.StringAttribute{
@@ -9384,12 +10644,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. The value must not exceed the Kafka brokers' message.max.bytes setting.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of events you want the Destination to allow in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -9419,18 +10685,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -9600,48 +10875,72 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -9877,6 +11176,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -9888,24 +11190,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -9928,6 +11242,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -9983,6 +11300,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `List of Confluent Cloud bootstrap servers to use, such as yourAccount.confluent.cloud:9092.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"tls": schema.SingleNestedAttribute{
@@ -10078,12 +11399,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. The value must not exceed the Kafka brokers' message.max.bytes setting.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of events you want the Destination to allow in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -10113,18 +11440,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -10294,48 +11630,72 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -10504,6 +11864,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -10515,24 +11878,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -10555,6 +11930,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -10610,6 +11988,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify hostname and port, e.g., mykafkabroker:9092, or just hostname, in which case @{product} will assign port 9092.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topic": schema.StringAttribute{
@@ -10638,12 +12020,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. The value must not exceed the Kafka brokers' message.max.bytes setting.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of events you want the Destination to allow in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -10673,18 +12061,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -10854,48 +12251,72 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -10944,6 +12365,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -10956,6 +12381,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -11070,6 +12498,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -11081,24 +12512,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -11121,6 +12564,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -11195,18 +12641,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 102400),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -11227,6 +12682,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -11273,6 +12731,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -11280,24 +12741,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -11318,18 +12791,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -11474,6 +12956,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Bulk API URLs`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -11487,6 +12972,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -11496,12 +12984,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -11514,6 +13008,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -11525,24 +13022,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -11565,6 +13074,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -11633,18 +13145,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 102400),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -11665,6 +13186,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -11794,6 +13318,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -11801,24 +13328,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -11839,18 +13378,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -11882,6 +13430,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -11893,24 +13444,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -11933,6 +13496,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -12006,6 +13572,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to add to events from this input`,
+						Validators: []validator.List{
+							listvalidator.SizeAtMost(4),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"name": schema.StringAttribute{
@@ -12028,18 +13597,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -12060,6 +13638,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -12112,6 +13693,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -12119,24 +13703,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -12157,18 +13753,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -12193,6 +13798,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -12204,6 +13812,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -12216,6 +13827,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -12227,24 +13841,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -12267,6 +13893,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -12353,18 +13982,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -12385,6 +14023,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -12437,6 +14078,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -12444,24 +14088,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -12482,18 +14138,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -12523,6 +14188,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -12535,6 +14203,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -12546,24 +14217,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -12586,6 +14269,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -12655,6 +14341,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of an InfluxDB cluster to send events to, e.g., http://localhost:8086/write`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_v2_api": schema.BoolAttribute{
 						Required:    false,
@@ -12685,18 +14374,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 51200),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -12717,6 +14415,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -12769,6 +14470,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -12776,24 +14480,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -12814,18 +14530,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -12881,6 +14606,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -12892,24 +14620,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -12932,6 +14672,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -13074,6 +14817,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -13086,18 +14833,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of each individual record before compression. For non compressible data 1MB is the max recommended size`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10240),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -13139,6 +14895,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -13150,24 +14909,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -13190,6 +14961,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -13281,6 +15055,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -13293,6 +15070,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -13340,24 +15120,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -13370,6 +15162,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -13446,6 +15241,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -13461,6 +15259,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `MinIO service url (e.g. http://minioHost:9000)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"object_acl": schema.StringAttribute{
 						Required: false,
@@ -13516,6 +15317,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -13532,12 +15336,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -13550,6 +15360,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -13590,6 +15403,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -13608,6 +15424,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -13668,12 +15487,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Destination port.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"mtu": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `When protocol is UDP, specifies the maximum size of packets sent to the destination. Also known as the MTU for the network path to the destination system.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -13686,6 +15511,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every batch sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -13698,6 +15526,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -13727,6 +15558,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -13738,24 +15572,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -13778,6 +15624,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -13845,12 +15694,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Destination port.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"mtu": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `When protocol is UDP, specifies the maximum size of packets sent to the destination. Also known as the MTU for the network path to the destination system.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -13863,6 +15718,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every batch sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -13875,6 +15733,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -13904,6 +15765,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -13915,24 +15779,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -13955,6 +15831,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14022,12 +15901,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Destination port.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"mtu": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `When protocol is UDP, specifies the maximum size of packets sent to the destination. Also known as the MTU for the network path to the destination system.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -14040,6 +15925,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if the destination is an IP address. A value of 0 means every batch sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -14052,6 +15940,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"connection_timeout": schema.Float64Attribute{
 						Required:    false,
@@ -14081,6 +15972,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -14092,24 +15986,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -14132,6 +16038,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14188,6 +16097,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Event routing rules`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"filter": schema.StringAttribute{
@@ -14331,6 +16243,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -14343,6 +16259,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -14378,6 +16297,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -14389,24 +16311,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -14429,6 +16363,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14556,6 +16493,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -14568,18 +16509,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"max_queue_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of queued batches before blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"max_record_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (KB) of batches to send. Per the SQS spec, the max allowed value is 256 KB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 256),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -14592,6 +16542,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of in-progress API requests before backpressure is applied.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -14627,6 +16580,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -14638,24 +16594,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -14678,6 +16646,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -14733,6 +16704,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `One or more SNMP destinations to forward traps to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -14746,6 +16720,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Destination port, default is 162`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 							},
 						},
@@ -14755,6 +16732,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if all destinations are IP addresses. A value of 0 means every trap sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"enable_ip_spoofing": schema.BoolAttribute{
 						Required:    false,
@@ -14773,6 +16753,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `MTU in bytes. The actual maximum SNMP Trap payload size will be MTU minus IP and UDP headers (28 bytes for IPv4, 48 bytes for IPv6). Payloads exceeding this limit will be dropped.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -14822,6 +16805,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Sumo Logic HTTP collector URL to which events should be sent`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"custom_source": schema.StringAttribute{
 						Required:    false,
@@ -14846,18 +16832,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -14878,6 +16873,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -14930,6 +16928,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -14937,24 +16938,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -14975,18 +16988,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -15006,6 +17028,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -15024,6 +17049,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -15035,24 +17063,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -15075,6 +17115,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -15198,18 +17241,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -15230,6 +17282,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -15282,6 +17337,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -15289,24 +17347,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -15327,18 +17397,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -15363,6 +17442,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -15386,6 +17468,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -15397,24 +17482,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -15437,6 +17534,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -15506,12 +17606,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The endpoint to send logs to, such as https://logs-prod-us-central1.grafana.net`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"prometheus_url": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The remote_write endpoint to send Prometheus metrics to, such as https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"message": schema.StringAttribute{
 						Required:    false,
@@ -15529,6 +17635,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `List of labels to send with logs. Labels define Loki streams, so use static labels to avoid proliferating label value combinations and streams. Can be merged and/or overridden by the event's __labels field. Example: '__labels: {host: "cribl.io", level: "error"}'`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"name": schema.StringAttribute{
@@ -15645,18 +17754,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking. Warning: Setting this value > 1 can cause Loki and Prometheus to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body. Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki and Prometheus to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited). Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki and Prometheus to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -15671,6 +17789,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -15723,6 +17844,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -15730,24 +17854,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -15768,18 +17904,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -15817,6 +17962,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -15828,24 +17976,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -15868,6 +18028,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -15924,6 +18087,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The endpoint to send logs to`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"message": schema.StringAttribute{
 						Required:    false,
@@ -15941,6 +18107,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `List of labels to send with logs. Labels define Loki streams, so use static labels to avoid proliferating label value combinations and streams. Can be merged and/or overridden by the event's __labels field. Example: '__labels: {host: "cribl.io", level: "error"}'`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"name": schema.StringAttribute{
@@ -15968,18 +18137,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking. Warning: Setting this value > 1 can cause Loki to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body. Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Defaults to 0 (unlimited). Warning: Setting this too low can increase the number of ongoing requests (depending on the value of 'Request concurrency'); this can cause Loki to complain about entries being delivered out of order.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -15994,6 +18172,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -16046,6 +18227,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -16053,24 +18237,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -16091,18 +18287,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -16128,6 +18333,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -16184,6 +18392,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -16195,24 +18406,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -16235,6 +18458,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -16291,6 +18517,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The Amazon Managed Service for Prometheus remote_write endpoint`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https://aps-workspaces(?:-fips)?\.([a-z0-9]+(?:-[a-z0-9]+)*)\.(?:amazonaws\.com|api\.aws)/workspaces/ws-[A-Za-z0-9-]+/api/v1/remote_write$`), "must match pattern ^https://aps-workspaces(?:-fips)?\\.([a-z0-9]+(?:-[a-z0-9]+)*)\\.(?:amazonaws\\.com|api\\.aws)/workspaces/ws-[A-Za-z0-9-]+/api/v1/remote_write$"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -16329,6 +18558,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -16341,6 +18574,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"metric_rename_expr": schema.StringAttribute{
 						Required:    false,
@@ -16365,24 +18601,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed size, in KB, of the request body. The 1 MB cap is intentional and protects against data that compresses poorly, since oversized requests fail with a non-retryable 413.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1024),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -16435,6 +18683,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -16442,24 +18693,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -16480,18 +18743,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -16535,6 +18807,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -16546,24 +18821,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -16586,6 +18873,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -16641,6 +18931,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The endpoint to send metrics to`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"metric_rename_expr": schema.StringAttribute{
 						Required:    false,
@@ -16665,18 +18958,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -16691,6 +18993,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -16743,6 +19048,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -16750,24 +19058,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -16788,18 +19108,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -16843,6 +19172,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -16854,24 +19186,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -16894,6 +19238,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -16956,6 +19303,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: "ID used to sign Remote Write requests (for example, `aps` for Amazon Managed Service for Prometheus)",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`), "must match pattern ^[a-z][a-z0-9]*(-[a-z0-9]+)*$"),
+						},
 					},
 					"enable_assume_role": schema.BoolAttribute{
 						Required:    false,
@@ -16968,6 +19318,10 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -16980,6 +19334,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 				},
 			},
@@ -17041,12 +19398,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"max_data_time": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -17169,6 +19532,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -17203,18 +19569,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -17238,6 +19613,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"keep_alive": schema.BoolAttribute{
 						Required:    false,
@@ -17293,6 +19671,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL for OAuth`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"secret_param_name": schema.StringAttribute{
 						Required:    false,
@@ -17323,6 +19704,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the OAuth token should be refreshed.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 300000),
+						},
 					},
 					"oauth_params": schema.ListNestedAttribute{
 						Required:    false,
@@ -17416,6 +19800,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -17423,24 +19810,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -17461,18 +19860,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -17554,6 +19962,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -17565,24 +19976,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -17605,6 +20028,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -17684,6 +20110,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"protocol": schema.StringAttribute{
 						Required: false,
@@ -17723,6 +20152,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -17757,12 +20189,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -17786,6 +20224,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"keep_alive": schema.BoolAttribute{
 						Required:    false,
@@ -17852,6 +20293,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -17859,24 +20303,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -17897,18 +20353,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -17990,6 +20455,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -18001,24 +20469,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -18041,6 +20521,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -18128,6 +20611,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -18135,24 +20621,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -18173,18 +20671,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -18205,18 +20712,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 6144),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -18237,6 +20753,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -18299,6 +20818,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -18310,6 +20832,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -18322,6 +20847,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -18333,24 +20861,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -18373,6 +20913,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -18458,6 +21001,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -18543,6 +21089,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires, valid values between 1 and 60`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -18601,6 +21150,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The port to connect to on the provided host`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -18613,6 +21165,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Set of hosts to load-balance data to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -18626,6 +21181,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The port to connect to on the provided host`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 								"tls": schema.StringAttribute{
 									Required: false,
@@ -18643,6 +21201,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -18652,18 +21213,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_concurrent_senders": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of concurrent connections (per Worker Process). A random set of IPs will be picked on every DNS resolution period. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -18676,6 +21246,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -18687,24 +21260,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -18727,6 +21312,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -18856,6 +21444,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires. Valid values are between 1 and 60.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"exclude_fields": schema.ListAttribute{
 						Required:    false,
@@ -18874,18 +21465,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -18900,6 +21500,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -18946,12 +21549,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -18959,24 +21568,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -18997,18 +21618,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -19062,6 +21692,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -19080,6 +21713,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Cribl Worker endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -19087,12 +21723,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -19102,12 +21744,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -19120,6 +21768,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -19131,24 +21782,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -19171,6 +21834,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -19300,6 +21966,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of minutes before the internally generated authentication token expires. Valid values are between 1 and 60.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"exclude_fields": schema.ListAttribute{
 						Required:    false,
@@ -19318,18 +21987,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required: false,
@@ -19344,6 +22022,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -19390,12 +22071,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -19403,24 +22090,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -19441,18 +22140,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -19512,6 +22220,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"exclude_self": schema.BoolAttribute{
 						Required:    false,
@@ -19524,6 +22235,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Cribl Worker endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"url": schema.StringAttribute{
@@ -19531,12 +22245,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `URL of a Cribl Worker to send events to, such as http://localhost:10200`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+									},
 								},
 								"weight": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -19546,12 +22266,18 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"pq_strict_ordering": schema.BoolAttribute{
 						Required:    false,
@@ -19564,6 +22290,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -19575,24 +22304,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -19615,6 +22356,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -19671,24 +22415,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to a CrowdStrike Falcon LogScale endpoint to send events to. Examples: https://cloud.us.humio.com/api/v1/ingest/hec for JSON and https://cloud.us.humio.com/api/v1/ingest/hec/raw for raw`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 32768),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -19709,6 +22465,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -19771,6 +22530,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -19778,24 +22540,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -19816,18 +22590,27 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -19872,6 +22655,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -19883,24 +22669,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -19923,6 +22721,9 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -19980,24 +22781,36 @@ func (r *PackDestinationResource) Schema(_ context.Context, _ resource.SchemaReq
 						Computed: true,
 						Description: `URL provided from a CrowdStrike data connector. 
 Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/v1/services/collector`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 32768),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -20018,6 +22831,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -20080,6 +22896,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -20087,24 +22906,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -20125,18 +22956,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -20181,6 +23021,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -20192,24 +23035,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -20232,6 +23087,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -20300,6 +23158,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -20312,6 +23174,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -20353,6 +23218,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -20365,6 +23233,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -20406,24 +23277,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -20436,6 +23319,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -20512,6 +23398,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -20589,6 +23478,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -20605,12 +23497,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -20623,6 +23521,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -20663,6 +23564,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -20681,6 +23585,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -20741,6 +23648,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -20753,6 +23664,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -20788,6 +23702,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -20800,6 +23717,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -20830,24 +23750,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -20860,6 +23792,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -20936,6 +23871,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -21000,12 +23938,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -21018,6 +23962,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -21076,6 +24023,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -21088,6 +24038,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"deadletter_path": schema.StringAttribute{
 						Required:    false,
@@ -21100,6 +24053,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -21179,24 +24135,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -21209,6 +24177,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -21285,6 +24256,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -21314,11 +24288,17 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1000),
+						},
 					},
 					"max_concurrent_file_parts": schema.Float64Attribute{
 						Required: false,
 						Optional: true,
 						Computed: true,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -21347,6 +24327,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -21363,12 +24346,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -21381,6 +24370,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -21421,6 +24413,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -21439,6 +24434,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -21494,12 +24492,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum disk space that can be consumed before older buckets are deleted. Examples: 420MB, 4GB. Default is 1GB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+(\.\d+)?\s*(?:[kmgKMG](b|B))?$`), "must match pattern ^\\d+(\\.\\d+)?\\s*(?:[kmgKMG](b|B))?$"),
+						},
 					},
 					"max_data_time": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to retain data before older buckets are deleted. Examples: 2h, 4d. Default is 24h.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+						},
 					},
 					"compress": schema.StringAttribute{
 						Required: false,
@@ -21583,6 +24587,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the ClickHouse table where data will be inserted. Name can contain letters (A-Z, a-z), numbers (0-9), and the character "_", and must start with either a letter or the character "_".`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z_][0-9a-zA-Z_]*$`), "must match pattern ^[a-zA-Z_][0-9a-zA-Z_]*$"),
+						},
 					},
 					"format": schema.StringAttribute{
 						Required: false,
@@ -21665,18 +24672,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 25600),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -21697,6 +24713,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -21749,6 +24768,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -21756,24 +24778,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -21794,18 +24828,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -21874,6 +24917,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to exclude from sending to ClickHouse`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(0)),
+						},
 						ElementType: types.StringType,
 					},
 					"describe_table": schema.StringAttribute{
@@ -21921,6 +24968,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -21932,24 +24982,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -21972,6 +25034,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -22045,6 +25110,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the ClickHouse table where data will be inserted. Name can contain letters (A-Z, a-z), numbers (0-9), and the character "_", and must start with either a letter or the character "_".`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z_][0-9a-zA-Z_]*$`), "must match pattern ^[a-zA-Z_][0-9a-zA-Z_]*$"),
+						},
 					},
 					"format": schema.StringAttribute{
 						Required: false,
@@ -22127,18 +25195,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 25600),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -22159,6 +25236,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -22211,6 +25291,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -22218,24 +25301,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -22256,18 +25351,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -22336,6 +25440,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to exclude from sending to ClickHouse`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(0)),
+						},
 						ElementType: types.StringType,
 					},
 					"describe_table": schema.StringAttribute{
@@ -22383,6 +25491,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -22394,24 +25505,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -22434,6 +25557,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -22507,6 +25633,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Name of the table where data will be inserted. Name can contain letters (A-Z, a-z), numbers (0-9), and the character "_", and must start with either a letter or the character "_".`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z_][0-9a-zA-Z_]*$`), "must match pattern ^[a-zA-Z_][0-9a-zA-Z_]*$"),
+						},
 					},
 					"format": schema.StringAttribute{
 						Required:    false,
@@ -22591,18 +25720,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 25600),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -22623,6 +25761,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -22675,6 +25816,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -22682,24 +25826,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -22720,18 +25876,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -22853,6 +26018,10 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Fields to exclude from sending`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(0)),
+						},
 						ElementType: types.StringType,
 					},
 					"describe_table": schema.StringAttribute{
@@ -22900,6 +26069,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -22911,24 +26083,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -22951,6 +26135,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -23013,18 +26200,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(100, 10000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -23045,6 +26241,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -23097,6 +26296,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -23104,24 +26306,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -23142,18 +26356,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -23168,6 +26391,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of requests to limit to per second`,
+						Validators: []validator.Int64{
+							int64validator.AtMost(2000),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -23179,6 +26405,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -23191,6 +26420,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `XSIAM endpoint URL to send events to, such as https://api-{tenant external URL}/logs/v1/event`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -23209,6 +26441,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `XSIAM Endpoints`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"weight": schema.Float64Attribute{
@@ -23216,6 +26451,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `Assign a weight (>0) to each endpoint to indicate its traffic-handling capability`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -23225,12 +26463,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The interval in which to re-resolve any hostnames and pick up destinations from A records`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"load_balance_stats_period_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How far back in time to keep traffic stats for load balancing purposes`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"token": schema.StringAttribute{
 						Required:    false,
@@ -23256,6 +26500,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -23267,24 +26514,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -23307,6 +26566,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -23362,6 +26624,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `One or more NetFlow Destinations to forward events to`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"host": schema.StringAttribute{
@@ -23375,6 +26640,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `Destination port, default is 2055`,
+									Validators: []validator.Float64{
+										float64validator.AtMost(65535),
+									},
 								},
 							},
 						},
@@ -23384,6 +26652,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How often to resolve the destination hostname to an IP address. Ignored if all destinations are IP addresses. A value of 0 means every datagram sent will incur a DNS lookup.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 86400),
+						},
 					},
 					"enable_ip_spoofing": schema.BoolAttribute{
 						Required:    false,
@@ -23402,6 +26673,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `MTU in bytes. The actual maximum NetFlow payload size will be MTU minus IP and UDP headers (28 bytes for IPv4, 48 bytes for IPv6). For example, with the default MTU of 1500, the max payload is 1472 bytes for IPv4. Payloads exceeding this limit will be dropped.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -23462,18 +26736,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 5000),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 50000),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -23494,6 +26777,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -23546,6 +26832,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -23553,24 +26842,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -23591,18 +26892,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -23646,6 +26956,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -23664,6 +26977,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -23675,24 +26991,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -23715,6 +27043,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -23753,6 +27084,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to send events to. Can be overwritten by an event's __url field.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 				},
 			},
@@ -23847,6 +27181,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `List of key-value pairs to send with each gRPC request. Value supports JavaScript expressions that are evaluated just once, when the destination gets started. To pass credentials as metadata, use 'C.Secret'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -23881,18 +27218,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size (in KB) of the request body. The maximum payload size is 4 MB. If this limit is exceeded, the entire OTLP message is dropped`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 4096),
+						},
 					},
 					"timeout_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -23916,6 +27262,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How often the sender should ping the peer to keep the connection open`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"keep_alive": schema.BoolAttribute{
 						Required:    false,
@@ -24000,6 +27349,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -24007,24 +27359,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -24045,18 +27409,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -24077,6 +27450,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -24088,24 +27464,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -24128,6 +27516,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -24184,18 +27575,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1024, 2097152),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -24216,6 +27616,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -24267,6 +27670,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -24274,24 +27680,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -24312,18 +27730,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -24374,6 +27801,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Base URL of the endpoint used to send events to, such as https://<Your-S1-Tenant>.sentinelone.net. Must begin with http:// or https://, can include a port number, and no trailing slashes. Matches pattern: ^https?://[a-zA-Z0-9.-]+(:[0-9]+)?$.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://[a-zA-Z0-9.-]+(:[0-9]+)?$`), "must match pattern ^https?://[a-zA-Z0-9.-]+(:[0-9]+)?$"),
+						},
 					},
 					"host_expression": schema.StringAttribute{
 						Required:    false,
@@ -24470,6 +27900,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -24481,24 +27914,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -24521,6 +27966,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -24589,6 +28037,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -24596,24 +28047,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -24634,18 +28097,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -24666,18 +28138,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size, in KB, of the request body`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 4096),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to include in the request body. Default is 0 (unlimited).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -24698,6 +28179,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -24755,6 +28239,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum total size of the batches waiting to be sent. If left blank, defaults to 5 times the max body size (if set). If 0, no limit is enforced.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ingestion_method": schema.StringAttribute{
 						Required:    false,
@@ -24825,6 +28312,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Chronicle API service endpoint. If empty, defaults to the Region-specific endpoint. Otherwise, it must point to a Chronicle API-compatible endpoint. (Example: https://custom-endpoint.googleapis.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -24855,6 +28345,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -24866,24 +28359,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -24906,6 +28411,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -25009,24 +28517,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 1800),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1800),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -25039,6 +28559,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -25115,6 +28638,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -25171,6 +28697,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(30),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -25199,6 +28728,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -25215,12 +28747,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -25233,6 +28771,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -25273,6 +28814,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -25291,6 +28835,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -25402,18 +28949,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of ongoing requests before blocking`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"max_payload_size_kb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed size of each batch. With compression enabled (default), batches are zstd-compressed before sending. Snowflake has observed a ~4 MB limit on the compressed wire size.`,
+						Validators: []validator.Float64{
+							float64validator.Between(64, 10240),
+						},
 					},
 					"max_payload_events": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events per request. Default is 0 (unlimited, size-gated only).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"compress": schema.BoolAttribute{
 						Required:    false,
@@ -25434,6 +28990,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Amount of time, in seconds, to wait for a request to complete before canceling it`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 9007199254740991),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -25480,12 +29039,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Timeout in seconds for token exchange, channel open/close, and hostname discovery. Defaults to 30 seconds.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 300),
+						},
 					},
 					"response_retry_settings": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Automatically retry after unsuccessful response status codes, such as 429 (Too Many Requests) or 503 (Service Unavailable)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"http_status": schema.Float64Attribute{
@@ -25493,24 +29058,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 									Optional:    true,
 									Computed:    true,
 									Description: `The HTTP response status code that will trigger retries`,
+									Validators: []validator.Float64{
+										float64validator.Between(100, 599),
+									},
 								},
 								"initial_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 600000),
+									},
 								},
 								"backoff_rate": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 20),
+									},
 								},
 								"max_backoff": schema.Float64Attribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+									Validators: []validator.Float64{
+										float64validator.Between(10000, 180000),
+									},
 								},
 							},
 						},
@@ -25531,18 +29108,27 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `How long, in milliseconds, Cribl Stream should wait before initiating backoff. Maximum interval is 600,000 ms (10 minutes).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 600000),
+								},
 							},
 							"backoff_rate": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `Base for exponential backoff. A value of 2 (default) means Cribl Stream will retry after 2 seconds, then 4 seconds, then 8 seconds, etc.`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"max_backoff": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    true,
 								Description: `The maximum backoff interval, in milliseconds, Cribl Stream should apply. Default (and minimum) is 10,000 ms (10 seconds); maximum is 180,000 ms (180 seconds).`,
+								Validators: []validator.Float64{
+									float64validator.Between(10000, 180000),
+								},
 							},
 						},
 					},
@@ -25574,6 +29160,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -25585,24 +29174,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -25625,6 +29226,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -25697,12 +29301,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum size of each record batch before compression. Setting should be < message.max.bytes settings in Event Hubs brokers.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"flush_event_count": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events in a batch before forcing a flush`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"flush_period_sec": schema.Float64Attribute{
 						Required:    false,
@@ -25715,48 +29325,72 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required:    false,
@@ -25892,6 +29526,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Throttling rate (in events per second) to impose while writing to Destinations from PQ. Defaults to 0, which disables throttling.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_mode": schema.StringAttribute{
 						Required: false,
@@ -25903,24 +29540,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use pqMaxBufferSizeBytes instead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(42, 1000),
+						},
 					},
 					"pq_max_backpressure_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `How long (in seconds) to wait for backpressure to resolve before engaging the queue`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"pq_max_file_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to store in each queue file before closing and optionally compressing (KB, MB, etc.)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_max_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_path": schema.StringAttribute{
 						Required:    false,
@@ -25943,6 +29592,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+						},
 					},
 					"pq_controls": schema.MapAttribute{
 						Required:    false,
@@ -26028,6 +29680,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -26040,6 +29695,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -26087,24 +29745,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -26117,6 +29787,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -26193,6 +29866,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -26208,6 +29884,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Cloudflare R2 service URL (example: https://<ACCOUNT_ID>.r2.cloudflarestorage.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"storage_class": schema.StringAttribute{
 						Required: false,
@@ -26252,6 +29931,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -26268,12 +29950,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -26286,6 +29974,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -26326,6 +30017,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -26344,6 +30038,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -26428,6 +30125,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -26440,6 +30140,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -26487,24 +30190,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -26517,6 +30232,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -26593,6 +30311,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -26601,6 +30322,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Nutanix Objects S3-compatible endpoint URL (example: https://objects.nutanix.local)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -26635,6 +30359,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -26651,12 +30378,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -26669,6 +30402,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -26709,6 +30445,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -26727,6 +30466,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -26805,6 +30547,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -26817,6 +30562,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -26864,24 +30612,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -26894,6 +30654,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -26970,6 +30733,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -26978,6 +30744,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Storj S3-compatible gateway endpoint URL (example: https://gateway.storjshare.io)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27012,6 +30781,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -27028,12 +30800,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -27046,6 +30824,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -27086,6 +30867,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -27104,6 +30888,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -27182,6 +30969,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -27194,6 +30984,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -27241,24 +31034,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -27271,6 +31076,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -27347,6 +31155,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -27355,6 +31166,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `AlphaSOC S3-compatible endpoint URL (example: https://s3.alphasoc.net)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27389,6 +31203,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -27405,12 +31222,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -27423,6 +31246,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -27463,6 +31289,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -27481,6 +31310,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -27565,6 +31397,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -27577,6 +31412,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -27624,24 +31462,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -27654,6 +31504,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -27730,6 +31583,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -27743,6 +31599,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Dell PowerScale OneFS S3-compatible endpoint URL (example: https://powerscale.example.com:9021)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27777,6 +31636,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -27793,12 +31655,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -27811,6 +31679,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -27851,6 +31722,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -27869,6 +31743,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -27918,6 +31795,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Cloudian HyperStore S3-compatible endpoint URL (example: https://s3.hyperstore.example.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -27959,6 +31839,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -27971,6 +31854,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -28018,24 +31904,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -28048,6 +31946,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -28124,6 +32025,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -28181,6 +32085,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -28197,12 +32104,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -28215,6 +32128,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -28255,6 +32171,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -28273,6 +32192,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -28357,6 +32279,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -28369,6 +32294,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -28416,24 +32344,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -28446,6 +32386,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -28522,6 +32465,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -28530,6 +32476,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Scality RING S3-compatible endpoint URL (example: https://s3.scality.example.com)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -28564,6 +32513,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -28580,12 +32532,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -28598,6 +32556,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -28638,6 +32599,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -28656,6 +32620,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -28735,6 +32702,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -28747,6 +32717,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -28794,24 +32767,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -28824,6 +32809,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -28900,6 +32888,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -28913,6 +32904,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: "Alibaba OSS S3-compatible endpoint URL. Examples: public `https://s3.oss-{region}.aliyuncs.com`, internal `https://s3.oss-{region}-internal.aliyuncs.com`",
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"enable_assume_role": schema.BoolAttribute{
 						Required:    false,
@@ -28925,12 +32919,19 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"assume_role_arn": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `ARN of the RAM role to assume. Format: acs:ram::<account-id>:role/<role-name>. Example: acs:ram::123456789:role/OSSAccessRole`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^acs:`), "must match pattern ^acs:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -28971,6 +32972,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -28987,12 +32991,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -29005,6 +33015,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -29045,6 +33058,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -29063,6 +33079,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},
@@ -29112,6 +33131,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `IBM Cloud Object Storage S3-compatible endpoint URL (example: https://s3.us-south.cloud-object-storage.appdomain.cloud)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.*`), "must match pattern ^https?://.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -29147,6 +33169,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of parts to upload in parallel per file. Minimum part size is 5MB.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"verify_permissions": schema.BoolAttribute{
 						Required:    false,
@@ -29159,6 +33184,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files that can be waiting for upload before backpressure is applied`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 4200),
+						},
 					},
 					"stage_path": schema.StringAttribute{
 						Required:    false,
@@ -29206,24 +33234,36 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum uncompressed output file size. Files of this size will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 1024),
+						},
 					},
 					"max_file_open_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to write to a file. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"max_file_idle_time_sec": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum amount of time to keep inactive files open. Files open for longer than this will be closed and moved to final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(5, 86400),
+						},
 					},
 					"max_open_files": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Maximum number of files to keep open concurrently. When exceeded, @{product} will close the oldest open files and move them to the final output location.`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 2000),
+						},
 					},
 					"header_line": schema.StringAttribute{
 						Required:    false,
@@ -29236,6 +33276,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `Buffer size used to write to a file`,
+						Validators: []validator.Float64{
+							float64validator.Between(16, 4096),
+						},
 					},
 					"on_backpressure": schema.StringAttribute{
 						Required: false,
@@ -29312,6 +33355,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 								Optional:    true,
 								Computed:    true,
 								Description: `Minimum interval between reconciliation runs`,
+								Validators: []validator.Float64{
+									float64validator.Between(5, 1440),
+								},
 							},
 						},
 					},
@@ -29348,6 +33394,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `To add a new schema, navigate to Processing > Knowledge > Parquet Schemas`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"parquet_version": schema.StringAttribute{
 						Required: false,
@@ -29364,12 +33413,18 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The number of rows that every group will contain. The final group can contain a smaller number of rows.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 67108864),
+						},
 					},
 					"parquet_page_size": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Target memory size for page segments, such as 1MB or 128MB. Generally, lower values improve reading speed, while higher values improve compression.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$`), "must match pattern ^\\d+\\s*(?:[kK][bB]|[mM][bB]|[gG][bB]|[tT][bB])?$"),
+						},
 					},
 					"should_log_invalid_rows": schema.BoolAttribute{
 						Required:    false,
@@ -29382,6 +33437,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The metadata of files the Destination writes will include the properties you add here as key-value pairs. Useful for tagging. Examples: "key":"OCSF Event Class", "value":"9001"`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"key": schema.StringAttribute{
@@ -29422,6 +33480,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `How frequently, in seconds, to clean up empty directories`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 86400),
+						},
 					},
 					"directory_batch_size": schema.Float64Attribute{
 						Required:    false,
@@ -29440,6 +33501,9 @@ Example: https://ingest.<region>.crowdstrike.com/api/ingest/hec/<connection-id>/
 						Optional:    true,
 						Computed:    true,
 						Description: `The maximum number of times a file will attempt to move to its final destination before being dead-lettered`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 				},
 			},

--- a/internal/provider/pack_lookups_resource.go
+++ b/internal/provider/pack_lookups_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -71,6 +74,9 @@ func (r *PackLookupsResource) Schema(_ context.Context, _ resource.SchemaRequest
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^\w[\w -]+(?:\.csv|\.gz|\.csv\.gz|\.mmdb)?$`), "must match pattern ^\\w[\\w -]+(?:\\.csv|\\.gz|\\.csv\\.gz|\\.mmdb)?$"),
 				},
 			},
 			"mode": schema.StringAttribute{

--- a/internal/provider/pack_pipeline_resource.go
+++ b/internal/provider/pack_pipeline_resource.go
@@ -17,6 +17,7 @@ import (
 	custom_validators "github.com/criblio/terraform-provider-criblio/internal/validators"
 	custom_stringvalidators "github.com/criblio/terraform-provider-criblio/internal/validators/stringvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -65,6 +66,9 @@ func (r *PackPipelineResource) Schema(_ context.Context, _ resource.SchemaReques
 						Description: `Timeout (in milliseconds) for asynchronous Pipeline functions.`,
 						PlanModifiers: []planmodifier.Int64{
 							custom_int64planmodifier.SuppressDiff(custom_int64planmodifier.ExplicitSuppress),
+						},
+						Validators: []validator.Int64{
+							int64validator.Between(0, 10000),
 						},
 					},
 					"output": schema.StringAttribute{

--- a/internal/provider/pack_source_resource.go
+++ b/internal/provider/pack_source_resource.go
@@ -6,14 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -19381,30 +19387,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -19443,6 +19464,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"preprocess": schema.SingleNestedAttribute{
 						Required: false,
@@ -19475,6 +19499,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -19619,30 +19646,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -19674,6 +19716,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify the hostname and port (such as mykafkabroker:9092) or just the hostname (in which case @{product} will assign port 9092).`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topics": schema.ListAttribute{
@@ -19681,6 +19727,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Topic to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Kafka Source to a single topic only.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -19717,18 +19767,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -19885,48 +19944,72 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -20136,6 +20219,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       the broker will remove the client from the group and initiate a rebalance.
       Value must be between the broker's configured group.min.session.timeout.ms and group.max.session.timeout.ms.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_session.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -20145,6 +20231,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Maximum allowed time for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#connectconfigs_rebalance.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -20154,36 +20243,54 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Expected time between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_heartbeat.interval.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_interval": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -20328,30 +20435,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -20383,6 +20505,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify the hostname and port (such as mykafkabroker:9092) or just the hostname (in which case @{product} will assign port 9092).`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topics": schema.ListAttribute{
@@ -20390,6 +20516,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Topic to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Kafka Source to a single topic only.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -20414,6 +20544,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       the broker will remove the client from the group and initiate a rebalance.
       Value must be between the broker's configured group.min.session.timeout.ms and group.max.session.timeout.ms.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_session.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -20423,6 +20556,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Maximum allowed time for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#connectconfigs_rebalance.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -20432,6 +20568,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Expected time between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_heartbeat.interval.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -20477,18 +20616,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -20645,48 +20793,72 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: true,
@@ -20734,6 +20906,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -20746,6 +20922,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -20818,30 +20997,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -20977,30 +21171,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -21038,6 +21247,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -21122,12 +21334,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -21146,24 +21364,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -21188,18 +21418,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Cribl HTTP API requests. Only _bulk (default /cribl/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"elastic_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Elasticsearch API requests. Only _bulk (default /elastic/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which listen for the Splunk HTTP Event Collector API requests. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_acks": schema.BoolAttribute{
 						Required:    false,
@@ -21394,30 +21633,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -21455,6 +21709,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -21538,24 +21795,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -21597,6 +21866,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -21772,30 +22044,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -21918,6 +22205,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 for no timeout.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -21942,24 +22232,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -22004,24 +22306,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -22056,6 +22370,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required:    true,
@@ -22215,30 +22532,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -22276,6 +22608,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -22318,6 +22653,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -22421,12 +22760,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -22445,24 +22790,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -22481,6 +22838,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Splunk HTTP Event Collector API requests. This input supports the /event, /raw and /s2s endpoints.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -22509,6 +22869,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"splunk_hec_acks": schema.BoolAttribute{
@@ -22529,6 +22893,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"use_fwd_timezone": schema.BoolAttribute{
 						Required:    false,
@@ -22553,6 +22920,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, list HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -22560,6 +22931,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, list HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -22689,30 +23064,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -22756,24 +23146,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 604800),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages to return in a poll request. Azure storage queues never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 32.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"service_period_secs": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The duration (in seconds) which pollers should be validated and restarted if exited`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -22815,18 +23217,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"parquet_chunk_size_mb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -23016,30 +23427,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -23077,6 +23503,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -23154,12 +23583,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -23178,24 +23613,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -23220,6 +23667,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Elasticsearch API requests. Defaults to /. _bulk will be appended automatically. For example, /myPath becomes /myPath/_bulk. Requests can then be made to either /myPath/_bulk or /myPath/<myIndexName>/_bulk. Other entries are faked as success.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required:    false,
@@ -23329,6 +23779,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of headers to remove from the request to proxy`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(0),
+									listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+								},
 								ElementType: types.StringType,
 							},
 							"timeout_sec": schema.Float64Attribute{
@@ -23336,6 +23790,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Amount of time, in seconds, to wait for a proxy request to complete before canceling it`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 9007199254740991),
+								},
 							},
 						},
 					},
@@ -23491,30 +23948,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -23546,6 +24018,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `List of Confluent Cloud bootstrap servers to use, such as yourAccount.confluent.cloud:9092`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"tls": schema.SingleNestedAttribute{
@@ -23619,6 +24095,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Topic to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Kafka Source to a single topic only.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -23655,18 +24135,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -23823,48 +24312,72 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -24008,6 +24521,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       the broker will remove the client from the group and initiate a rebalance.
       Value must be between the broker's configured group.min.session.timeout.ms and group.max.session.timeout.ms.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_session.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -24017,6 +24533,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Maximum allowed time for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#connectconfigs_rebalance.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -24026,36 +24545,54 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Expected time between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_heartbeat.interval.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_interval": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -24201,30 +24738,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -24262,6 +24814,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -24339,12 +24894,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -24363,24 +24924,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for additional data, after the last response was sent, before closing a socket connection. This can be very useful when Grafana Agent remote write's request frequency is high so, reusing connections, would help mitigating the cost of creating a new connection per request. Note that Grafana Agent's embedded Prometheus would attempt to keep connections open for up to 5 minutes.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -24405,12 +24978,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Grafana Agent's Remote Write requests. Defaults to /api/prom/push, which will expand as: 'http://<your‑upstream‑URL>:<your‑port>/api/prom/push'. Either this field or 'Logs API endpoint' must be configured.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"loki_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Loki logs requests. Defaults to /loki/api/v1/push, which will (in this example) expand as: 'http://<your‑upstream‑URL>:<your‑port>/loki/api/v1/push'. Either this field or 'Remote Write API endpoint' must be configured.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"prometheus_auth": schema.SingleNestedAttribute{
 						Required: false,
@@ -24640,30 +25219,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -24701,6 +25295,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -24778,12 +25375,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -24802,24 +25405,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -24844,6 +25459,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Loki logs requests. Defaults to /loki/api/v1/push, which will (in this example) expand as: 'http://<your‑upstream‑URL>:<your‑port>/loki/api/v1/push'.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -25024,30 +25642,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -25085,6 +25718,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -25162,12 +25798,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -25186,24 +25828,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -25228,6 +25882,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Prometheus requests. Defaults to /write, which will expand as: http://<your‑upstream‑URL>:<your‑port>/write.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -25407,30 +26064,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -25462,6 +26134,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Other dimensions to include in events`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						ElementType: types.StringType,
 					},
 					"field_per_metric": schema.BoolAttribute{
@@ -25481,6 +26156,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `How often, in minutes, to scrape targets for metrics. Maximum of 60 minutes. 60 must be evenly divisible by the value you enter.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: true,
@@ -25498,30 +26176,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, before aborting HTTP connection attempts; use 0 for no timeout`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -25567,6 +26260,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of Prometheus targets to pull metrics from. Values can be in URL or host[:port] format. For example: http://localhost:9090/metrics, localhost:9090, or localhost. In cases where just host[:port] is specified, the endpoint will resolve to 'http://host[:port]/metrics'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"record_type": schema.StringAttribute{
@@ -25579,12 +26275,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `The port number in the metrics URL for discovered targets`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"name_list": schema.ListAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of DNS names to resolve`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"scrape_protocol": schema.StringAttribute{
@@ -25598,6 +26300,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Path to use when collecting metrics from discovered targets`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/.*`), "must match pattern ^/.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -25640,6 +26345,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    false,
 									Computed:    false,
 									Description: `Values to match within this row's attribute. If empty, search will return only running EC2 instances.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 							},
@@ -25680,6 +26389,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -25692,12 +26405,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"http_discovery_url": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `URL to fetch target groups from (must be http or https)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"http_discovery_headers": schema.ListNestedAttribute{
 						Required:    false,
@@ -25867,30 +26586,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -25922,6 +26656,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Other dimensions to include in events`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						ElementType: types.StringType,
 					},
 					"field_per_metric": schema.BoolAttribute{
@@ -25941,12 +26678,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `How often in seconds to scrape targets for metrics.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Timeout, in milliseconds, before aborting HTTP connection attempts; 1-60000 or 0 to disable`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 60000),
+						},
 					},
 					"persistence": schema.SingleNestedAttribute{
 						Required: false,
@@ -25970,12 +26713,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space that can be consumed before older buckets are deleted. Examples: 420MB, 4GB. Default is 1GB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+(\.\d+)?\s*(?:[kmgKMG](b|B))?$`), "must match pattern ^\\d+(\\.\\d+)?\\s*(?:[kmgKMG](b|B))?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data before older buckets are deleted. Examples: 2h, 4d. Default is 24h.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -26023,6 +26772,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Targets`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"protocol": schema.StringAttribute{
@@ -26041,12 +26793,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `The port number in the metrics URL for discovered targets.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 65535),
+									},
 								},
 								"path": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Path to use when collecting metrics from discovered targets`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^/.*`), "must match pattern ^/.*"),
+									},
 								},
 							},
 						},
@@ -26061,12 +26819,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `The port number in the metrics URL for discovered targets.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"name_list": schema.ListAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of DNS names to resolve`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"scrape_protocol": schema.StringAttribute{
@@ -26079,6 +26843,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Path to use when collecting metrics from discovered targets`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/.*`), "must match pattern ^/.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -26121,6 +26888,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    false,
 									Computed:    false,
 									Description: `Values to match within this row's attribute. If empty, search will return only running EC2 instances.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 							},
@@ -26167,6 +26938,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -26179,6 +26954,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"service_monitor_namespace": schema.StringAttribute{
 						Required:    false,
@@ -26235,6 +27013,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `URL to fetch target groups from (must be http or https)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"http_discovery_headers": schema.ListNestedAttribute{
 						Required:    false,
@@ -26404,30 +27185,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -26476,30 +27272,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout, use 0 to disable`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -26559,6 +27370,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Interval`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 60),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required: false,
@@ -26579,6 +27393,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Use this setting to account for ingestion lag. This is necessary because there can be a lag of 60 - 90 minutes (or longer) before Microsoft 365 events are available for retrieval.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 7200),
+						},
 					},
 					"retry_rules": schema.SingleNestedAttribute{
 						Required: false,
@@ -26595,24 +27412,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -26774,30 +27603,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -26846,30 +27690,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout, use 0 to disable`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -26923,6 +27782,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Interval`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 60),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required: false,
@@ -26953,24 +27815,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -27132,30 +28006,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -27193,6 +28082,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `How often (in minutes) to run the report. Must divide evenly into 60 minutes to create a predictable schedule, or Save will fail.`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 60),
+						},
 					},
 					"start_date": schema.StringAttribute{
 						Required:    false,
@@ -27211,6 +28103,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Maximum is 2400 (40 minutes); enter 0 to wait indefinitely.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"disable_time_filter": schema.BoolAttribute{
 						Required:    false,
@@ -27229,24 +28124,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -27287,6 +28194,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of times a task can be rescheduled`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: false,
@@ -27308,24 +28218,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -27554,30 +28476,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -27615,6 +28552,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `How often (in minutes) to run the report. Must divide evenly into 60 minutes to create a predictable schedule, or Save will fail.`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 60),
+						},
 					},
 					"start_date": schema.StringAttribute{
 						Required:    false,
@@ -27633,6 +28573,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Maximum is 2400 (40 minutes); enter 0 to wait indefinitely.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"disable_time_filter": schema.BoolAttribute{
 						Required:    false,
@@ -27645,6 +28588,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of pages to retrieve per collection task. Set to 0 to retrieve all pages.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required:    false,
@@ -27657,24 +28603,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -27715,6 +28673,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of times a task can be rescheduled`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: false,
@@ -27736,24 +28697,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -27788,6 +28761,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27978,30 +28954,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -28033,6 +29024,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `List of Event Hubs Kafka brokers to connect to (example: yourdomain.servicebus.windows.net:9093). The hostname can be found in the host portion of the primary or secondary connection string in Shared Access Policies.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topics": schema.ListAttribute{
@@ -28040,6 +29035,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `The name of the Event Hub (Kafka topic) to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Event Hubs Source to only a single topic.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -28059,48 +29058,72 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -28232,6 +29255,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       If the client sends no heartbeats to the broker before the timeout expires, the broker will remove the client from the group and initiate a rebalance.
       Value must be lower than rebalanceTimeout.
       See details [here](https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/CONFIGURATION.md).`,
+						Validators: []validator.Float64{
+							float64validator.Between(6000, 300000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -28241,6 +29267,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Maximum allowed time (rebalance.timeout.ms in Kafka domain) for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Recommended configurations](https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/CONFIGURATION.md).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -28250,36 +29279,54 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
       Expected time (heartbeat.interval.ms in Kafka domain) between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Recommended configurations](https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/CONFIGURATION.md).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_interval": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"minimize_duplicates": schema.BoolAttribute{
 						Required:    false,
@@ -28431,30 +29478,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -28486,12 +29548,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `The name of the Event Hub to consume from`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"consumer_group": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `The consumer group this instance belongs to. Default is '$Default'.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"auth": schema.SingleNestedAttribute{
 						Required: false,
@@ -28593,6 +29661,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 										Optional:    false,
 										Computed:    false,
 										Description: `Azure Blob Storage container used to store checkpoints. Must be 3–63 lowercase alphanumeric characters or hyphens.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z0-9](-?[a-z0-9])*$`), "must match pattern ^[a-z0-9](-?[a-z0-9])*$"),
+											stringvalidator.UTF8LengthBetween(3, 63),
+										},
 									},
 									"auth_type": schema.StringAttribute{
 										Required:    false,
@@ -28670,60 +29742,90 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events in each batch delivered to the consumer`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"max_wait_time_in_seconds": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a batch of events before delivering a partial batch`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"prefetch_count": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Number of events to prefetch from the service for processing`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"max_retries": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of retries per operation`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"initial_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial delay before the first retry, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(300),
+						},
 					},
 					"max_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum delay between retries, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(30000),
+						},
 					},
 					"timeout_in_ms": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a request to complete`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1000),
+						},
 					},
 					"connection_initial_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial delay before the first reconnection attempt, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"connection_max_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum delay between reconnection attempts, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"connection_timeout_in_ms": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -28869,30 +29971,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -28936,6 +30053,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of retry attempts in the event that the command fails`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"schedule_type": schema.StringAttribute{
 						Required:    false,
@@ -28955,6 +30075,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -28989,6 +30112,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Interval between command executions in seconds.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"cron_schedule": schema.StringAttribute{
 						Required:    false,
@@ -29112,30 +30238,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29173,6 +30314,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -29257,12 +30401,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -29281,24 +30431,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -29461,30 +30623,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29569,18 +30746,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `If Destination exerts backpressure, this setting limits how many inbound events Stream will queue for processing before it stops retrieving events`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many streams to pull messages from at one time. Doubling the value doubles the number of messages this Source pulls from the topic (if available), while consuming more CPU and memory. Defaults to 5.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Pull request timeout, in milliseconds`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -29732,30 +30918,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29930,30 +31131,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29991,6 +31207,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -30068,24 +31287,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -30271,30 +31502,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -30332,6 +31578,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -30437,12 +31686,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -30461,24 +31716,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -30642,30 +31909,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -30703,6 +31985,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -30787,12 +32072,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -30811,24 +32102,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -30853,18 +32156,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Cribl HTTP API requests. Only _bulk (default /cribl/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"elastic_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Elasticsearch API requests. Only _bulk (default /elastic/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which listen for the Splunk HTTP Event Collector API requests. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_acks": schema.BoolAttribute{
 						Required:    false,
@@ -30951,9 +32263,13 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 											Computed: false,
 										},
 										"allowed_indexes_at_token": schema.ListAttribute{
-											Required:    false,
-											Optional:    true,
-											Computed:    false,
+											Required: false,
+											Optional: true,
+											Computed: false,
+											Validators: []validator.List{
+												listvalidator.SizeAtLeast(0),
+												listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+											},
 											ElementType: types.StringType,
 										},
 									},
@@ -31100,30 +32416,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -31161,6 +32492,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -31244,24 +32578,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -31436,30 +32782,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -31491,6 +32852,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive metric collections. Default is 10 seconds.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"host": schema.SingleNestedAttribute{
 						Required: false,
@@ -31728,6 +33092,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Timeout, in seconds, for the Docker API`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"filters": schema.ListNestedAttribute{
 								Required:    false,
@@ -31834,12 +33201,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -31976,30 +33349,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -32031,6 +33419,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive state collections. Default is 300 seconds (5 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -32237,12 +33628,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -32391,30 +33788,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -32446,6 +33858,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive metrics collections. Default is 15 secs.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"scrape_kubelet": schema.BoolAttribute{
 						Required:    false,
@@ -32526,12 +33941,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -32668,30 +34089,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -32723,6 +34159,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between checks for new containers. Default is 15 secs.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"rules": schema.ListNestedAttribute{
 						Required:    false,
@@ -32757,6 +34196,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum bytes to buffer while reassembling a single log line. A line that exceeds this size is flushed as-is, either whole or partially. The default is 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1024),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -32802,12 +34244,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space that can be consumed before older buckets are deleted. Examples: 420MB, 4GB. Default is 1GB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+(\.\d+)?\s*(?:[kmgKMG](b|B))?$`), "must match pattern ^\\d+(\\.\\d+)?\\s*(?:[kmgKMG](b|B))?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data before older buckets are deleted. Examples: 2h, 4d. Default is 24h.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -32828,6 +34276,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"enable_load_balancing": schema.BoolAttribute{
 						Required:    false,
@@ -32957,30 +34408,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -33173,30 +34639,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -33228,6 +34709,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive metric collections. Default is 10 seconds.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"host": schema.SingleNestedAttribute{
 						Required: false,
@@ -33491,12 +34975,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -33639,30 +35129,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -33754,30 +35259,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -33802,6 +35322,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -33814,6 +35338,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -33897,6 +35424,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -33905,6 +35435,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -33935,6 +35468,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -33947,6 +35484,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -34098,30 +35638,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -34159,6 +35714,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -34236,12 +35794,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -34260,24 +35824,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -34308,12 +35884,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `The rate_by_service hint sent to connected tracers as the catch-all sampling rate. Applies to any service/environment not explicitly listed in Per-Service Sampling Rules. 1.0 = keep all traces (default); 0.0 = suggest dropping all.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 1),
+						},
 					},
 					"sampling_rules": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Per-service sampling rate hints. Each row maps to a "service:<s>,env:<e>" key in the rate_by_service response sent to tracers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"service": schema.StringAttribute{
@@ -34321,18 +35903,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    false,
 									Computed:    false,
 									Description: `Datadog service name`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"environment": schema.StringAttribute{
 									Required:    true,
 									Optional:    false,
 									Computed:    false,
 									Description: `Datadog environment name (example: prod, staging)`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"rate": schema.Float64Attribute{
 									Required:    true,
 									Optional:    false,
 									Computed:    false,
 									Description: `Sampling rate for this service/environment combination (0.0–1.0)`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 1),
+									},
 								},
 							},
 						},
@@ -34500,30 +36091,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -34555,6 +36161,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Datagens`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"sample": schema.StringAttribute{
@@ -34568,6 +36177,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    false,
 									Computed:    false,
 									Description: `Maximum number of events to generate per second per Worker Node. Defaults to 10.`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(1),
+									},
 								},
 							},
 						},
@@ -34716,30 +36328,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -34777,6 +36404,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -34861,12 +36491,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -34885,24 +36521,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -34934,6 +36582,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -34962,6 +36613,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of URI paths accepted by this input, wildcards are supported, e.g /api/v*/hook. Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"allowed_methods": schema.ListAttribute{
@@ -34969,6 +36623,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of HTTP methods accepted by this input. Wildcards are supported (such as P*, GET). Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"auth_tokens_ext": schema.ListNestedAttribute{
@@ -35136,30 +36793,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -35197,6 +36869,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time interval in minutes between consecutive service calls`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 5),
+						},
 					},
 					"shard_expr": schema.StringAttribute{
 						Required:    false,
@@ -35221,12 +36896,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of records per getRecords call`,
+						Validators: []validator.Float64{
+							float64validator.Between(5000, 10000),
+						},
 					},
 					"get_records_limit_total": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of records, across all shards, to pull down at once per Worker Process`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(20000),
+						},
 					},
 					"load_balancing_algorithm": schema.StringAttribute{
 						Required:    false,
@@ -35280,6 +36961,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -35292,6 +36977,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"verify_kplcheck_sums": schema.BoolAttribute{
 						Required:    false,
@@ -35461,30 +37149,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -35667,30 +37370,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -35728,18 +37446,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter UDP port number to listen on. Not required if listening on TCP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tcp_port": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter TCP port number to listen on. Not required if listening on UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"max_buffer_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking. Only applies to UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -35851,6 +37578,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -35973,30 +37703,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -36088,30 +37833,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -36136,6 +37896,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36148,6 +37912,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -36220,12 +37987,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -36243,6 +38016,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -36251,6 +38027,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -36287,6 +38066,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36299,6 +38082,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -36445,30 +38231,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -36560,30 +38361,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -36608,6 +38424,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36620,6 +38440,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -36692,12 +38515,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -36715,6 +38544,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -36723,6 +38555,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"checksum_suffix": schema.StringAttribute{
 						Required:    false,
@@ -36735,6 +38570,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum download size (KB) of each manifest or checksum file. Manifest files larger than this size will not be read.        Defaults to 4096.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"validate_inventory_files": schema.BoolAttribute{
 						Required:    false,
@@ -36765,6 +38603,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36777,6 +38619,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -36927,30 +38772,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -36988,6 +38848,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `UDP port to receive SNMP traps on. Defaults to 162.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"snmp_v3_auth": schema.SingleNestedAttribute{
 						Required:    false,
@@ -37012,6 +38875,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `User credentials for receiving v3 traps`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								NestedObject: schema.NestedAttributeObject{
 									Attributes: map[string]schema.Attribute{
 										"name": schema.StringAttribute{
@@ -37019,6 +38885,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 											Optional:    false,
 											Computed:    false,
 											Description: `V3 name`,
+											Validators: []validator.String{
+												stringvalidator.UTF8LengthAtLeast(1),
+											},
 										},
 										"auth_protocol": schema.StringAttribute{
 											Required: false,
@@ -37052,6 +38921,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -37086,6 +38958,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"varbinds_with_types": schema.BoolAttribute{
 						Required:    false,
@@ -37221,30 +39096,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -37282,6 +39172,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -37359,30 +39252,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 sec.; maximum 600 sec. (10 min.).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -37437,6 +39345,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Shared secrets to authenticate clients. Supports Bearer tokens and Basic auth. If empty, unauthenticated access is permitted.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"auth_type": schema.StringAttribute{
@@ -37450,6 +39361,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Bearer token for Authorization header`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"description": schema.StringAttribute{
 									Required:    false,
@@ -37490,24 +39405,38 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Select or create a stored text secret`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"username": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Username`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"password": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Password`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"credentials_secret": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Select or create a secret that references your credentials`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -37539,6 +39468,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -37698,30 +39630,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -37759,6 +39706,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -37858,12 +39808,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"shutdown_timeout_ms": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time in milliseconds to allow the server to shutdown gracefully before forcing shutdown. Defaults to 5000.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -37986,30 +39942,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -38106,6 +40077,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -38118,18 +40093,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -38158,6 +40142,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -38182,6 +40169,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 				},
 			},
@@ -38298,30 +40288,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -38359,18 +40364,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter UDP port number to listen on. Not required if listening on TCP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tcp_port": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter TCP port number to listen on. Not required if listening on UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"max_buffer_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking. Only applies to UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -38401,6 +40415,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Wildcard list of fields to keep from source data; * = ALL (default)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						ElementType: types.StringType,
 					},
 					"octet_counting": schema.BoolAttribute{
@@ -38432,24 +40449,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process for TCP connections. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -38549,6 +40578,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"enable_load_balancing": schema.BoolAttribute{
 						Required:    false,
@@ -38684,30 +40716,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -38745,6 +40792,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between scanning for files`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"filenames": schema.ListAttribute{
 						Required:    false,
@@ -38770,6 +40820,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, before an idle file is closed`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"min_age_dur": schema.StringAttribute{
 						Required:    false,
@@ -38800,6 +40853,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Length of file header bytes to use in hash for unique file identification`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -38841,6 +40897,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -38859,6 +40918,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set how many subdirectories deep to search. Use 0 to search only files in the given path, 1 to also look in its immediate subdirectories, etc. Leave it empty for unlimited depth.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"suppress_missing_path_errors": schema.BoolAttribute{
 						Required:    false,
@@ -39006,30 +41068,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -39067,6 +41144,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -39150,24 +41230,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -39209,6 +41301,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"enable_header": schema.BoolAttribute{
 						Required:    false,
@@ -39381,30 +41476,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -39442,24 +41552,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -39501,6 +41623,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"enable_unix_path": schema.BoolAttribute{
 						Required:    false,
@@ -39572,12 +41697,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -39614,6 +41745,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -39826,30 +41960,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -39887,6 +42036,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_method": schema.StringAttribute{
 						Required:    false,
@@ -39983,12 +42135,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -40007,6 +42165,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -40031,6 +42192,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ca_fingerprint": schema.StringAttribute{
 						Required:    false,
@@ -40086,12 +42250,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    false,
 									Computed:    false,
 									Description: `Maximum time (in seconds) between endpoint checkins before considering it unavailable`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(1),
+									},
 								},
 								"batch_timeout": schema.Float64Attribute{
 									Required:    true,
 									Optional:    false,
 									Computed:    false,
 									Description: `Interval (in seconds) over which the endpoint should collect events before sending them to Stream`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 								"read_existing_events": schema.BoolAttribute{
 									Required:    false,
@@ -40116,6 +42286,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    false,
 									Computed:    false,
 									Description: `The DNS names of the endpoints that should forward these events. You may use wildcards, such as *.mydomain.com`,
+									Validators: []validator.List{
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"locale": schema.StringAttribute{
@@ -40333,30 +42506,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -40388,6 +42576,11 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Enter the event logs to collect. Run "Get-WinEvent -ListLog *" in PowerShell to see the available logs.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.UniqueValues(),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"suppress_missing_log_errors": schema.BoolAttribute{
@@ -40419,12 +42612,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between checking for new entries (Applicable for pre-4.8.0 nodes that use Windows Tools)`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"batch_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of events to read in one polling interval. A batch size higher than 500 can cause delays when pulling from multiple event logs. (Applicable for pre-4.8.0 nodes that use Windows Tools)`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -40453,6 +42652,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of bytes in an event before it is flushed to the pipelines`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 134217728),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -40588,30 +42790,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -40643,6 +42860,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `String to filter log entries, in NSPredicate format (e.g., subsystem == "com.apple.security" or process == "kernel"). See [Common Log Types and Predicates](https://docs.cribl.io/edge/sources-apple-unified-logs/#examples) for more information.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"read_mode": schema.StringAttribute{
 						Required:    false,
@@ -40794,30 +43014,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -40855,12 +43090,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"max_buffer_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -40885,6 +43126,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -41030,30 +43274,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -41091,6 +43350,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between scanning for journals. `,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"journals": schema.ListAttribute{
 						Required:    true,
@@ -41283,30 +43545,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -41338,6 +43615,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `The Wiz GraphQL API endpoint. Example: https://api.us1.app.wiz.io/graphql`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https:\/\/`), "must match pattern ^https:\\/\\/"),
+						},
 					},
 					"auth_url": schema.StringAttribute{
 						Required:    true,
@@ -41369,6 +43649,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    false,
 									Computed:    false,
 									Description: `The name of the Wiz query`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_\-\s]+$`), "must match pattern ^[a-zA-Z0-9_\\-\\s]+$"),
+									},
 								},
 								"content_description": schema.StringAttribute{
 									Required:    false,
@@ -41435,6 +43718,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Units default to seconds if not specified. Enter 0 for unlimited time.`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required: false,
@@ -41446,6 +43732,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum number of pages to retrieve per collection task. Defaults to 0. Set to 0 to retrieve all pages.`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -41455,24 +43744,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -41514,6 +43815,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"retry_rules": schema.SingleNestedAttribute{
 						Required: false,
@@ -41530,24 +43834,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -41709,30 +44025,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -41878,6 +44209,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum number of pages to retrieve per collection task. Set to 0 only when unlimited pagination is required.`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 								"pagination_next_relation_attribute": schema.StringAttribute{
 									Required:    false,
@@ -41914,6 +44248,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required:    false,
@@ -41951,6 +44288,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"api_key": schema.StringAttribute{
 						Required:    false,
@@ -41969,18 +44309,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -42025,24 +44374,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -42187,30 +44548,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -42248,6 +44624,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -42332,12 +44711,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -42356,24 +44741,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -42405,6 +44802,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -42433,6 +44833,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of URI paths accepted by this input. Wildcards are supported (such as /api/v*/hook). Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"allowed_methods": schema.ListAttribute{
@@ -42440,6 +44843,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of HTTP methods accepted by this input. Wildcards are supported (such as P*, GET). Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"auth_tokens_ext": schema.ListNestedAttribute{
@@ -42607,30 +45013,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -42668,6 +45089,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"enable_pass_through": schema.BoolAttribute{
 						Required:    false,
@@ -42692,12 +45116,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"template_cache_minutes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies how many minutes NetFlow v9 templates are cached before being discarded if not refreshed. Adjust based on your network's template update frequency to optimize performance and memory usage.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"v5_enabled": schema.BoolAttribute{
 						Required:    false,
@@ -42860,30 +45290,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -42975,30 +45420,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -43023,6 +45483,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43035,6 +45499,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -43107,12 +45574,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -43130,6 +45603,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -43138,6 +45614,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -43168,6 +45647,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43180,6 +45663,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -43331,30 +45817,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -43446,30 +45947,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -43494,6 +46010,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43506,6 +46026,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -43578,12 +46101,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -43601,6 +46130,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -43609,6 +46141,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -43639,6 +46174,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43651,6 +46190,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -43802,30 +46344,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -43857,18 +46414,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `ServiceNow instance base URL for Table API requests. Enter a literal URL (http or https and the instance host, for example a hostname ending in .service-now.com) or a Cribl expression that resolves to a URL.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"table_name": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `ServiceNow table name to collect from.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"fields": schema.ListAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Field names to return from the Table API (sysparm_fields). Leave empty to return all fields.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.RegexMatches(regexp.MustCompile(`^[^*?\[\]]+$`), "must match pattern ^[^*?\\[\\]]+$")),
+						},
 						ElementType: types.StringType,
 					},
 					"order_by_field": schema.StringAttribute{
@@ -43894,12 +46460,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum records per Table API page request (sysparm_limit). Setting a higher value may increase the risk of timeouts.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"max_pages": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of pages to retrieve per collection task. Set to 0 to retrieve all pages.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required:    false,
@@ -43918,18 +46490,27 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Cron schedule on which to run this job`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"earliest": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `Earliest time, relative to now. Format supported: [+|-]<time_integer><time_unit>@<snap-to_time_unit> (ex: -1hr, -42m, -42m@h)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"latest": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `Latest time, relative to now. Format supported: [+|-]<time_integer><time_unit>@<snap-to_time_unit> (ex: -1hr, -42m, -42m@h)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"state_tracking": schema.BoolAttribute{
 						Required:    false,
@@ -43947,6 +46528,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -43959,24 +46543,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -44021,24 +46617,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -44084,6 +46692,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `ServiceNow username for the password grant type`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"text_secret": schema.StringAttribute{
 						Required:    false,
@@ -44146,6 +46757,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `ServiceNow OAuth client ID`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"client_text_secret": schema.StringAttribute{
 						Required:    false,
@@ -44287,30 +46901,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -44348,6 +46977,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -44390,6 +47022,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -44493,12 +47129,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -44517,24 +47159,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -44553,6 +47207,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Zscaler HTTP Event Collector API requests. This input supports the /event endpoint.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -44581,6 +47238,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -44588,6 +47249,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -44595,6 +47260,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -44731,30 +47400,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -44792,6 +47476,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -44834,6 +47521,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -44938,12 +47629,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -44962,24 +47659,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -44998,6 +47707,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Cloudflare HTTP Event Collector API requests. This input supports the /event endpoint.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -45026,6 +47738,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -45033,6 +47749,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -45040,6 +47760,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -45060,6 +47784,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -45183,30 +47910,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -45244,6 +47986,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -45286,6 +48031,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -45389,12 +48138,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -45413,24 +48168,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -45449,6 +48216,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Sysdig HTTP Event Collector API requests. This input supports the /event and /raw endpoints.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -45477,6 +48247,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -45484,6 +48258,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -45491,6 +48269,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -45621,30 +48403,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -45682,6 +48479,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -45724,6 +48524,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -45827,12 +48631,18 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -45851,24 +48661,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -45887,6 +48709,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Upwind HTTP Event Collector API requests. This input supports the /event endpoint.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -45915,6 +48740,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -45922,6 +48751,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -45929,6 +48762,10 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -46059,30 +48896,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -46150,6 +49002,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: false,
@@ -46161,6 +49016,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of log file listing pages to retrieve per run. Set to 0 to retrieve all pages.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"state_tracking": schema.BoolAttribute{
 						Required:    false,
@@ -46173,24 +49031,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -46232,6 +49102,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"retry_rules": schema.SingleNestedAttribute{
 						Required: false,
@@ -46248,24 +49121,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -46305,6 +49190,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `One or more compliance log categories to collect`,
+						Validators: []validator.List{
+							listvalidator.UniqueValues(),
+						},
 						ElementType: types.StringType,
 					},
 					"organization_id": schema.StringAttribute{
@@ -46318,6 +49206,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `One or more compliance log categories to collect`,
+						Validators: []validator.List{
+							listvalidator.UniqueValues(),
+						},
 						ElementType: types.StringType,
 					},
 					"state_update_expression": schema.StringAttribute{
@@ -46454,30 +49345,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -46551,6 +49457,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46613,6 +49522,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46675,6 +49587,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46737,6 +49652,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46799,6 +49717,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46849,6 +49770,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46875,6 +49799,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46901,6 +49828,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46927,6 +49857,9 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46935,24 +49868,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -46997,24 +49942,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -47159,30 +50116,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -47250,30 +50222,45 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -47318,24 +50305,36 @@ func (r *PackSourceResource) Schema(_ context.Context, _ resource.SchemaRequest,
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{

--- a/internal/provider/pack_vars_resource.go
+++ b/internal/provider/pack_vars_resource.go
@@ -6,17 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_listplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/listplanmodifier"
 	custom_objectplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/objectplanmodifier"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -102,6 +105,9 @@ func (r *PackVarsResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
 				},
 			},
 			"lib": schema.StringAttribute{

--- a/internal/provider/parquet_schema_resource.go
+++ b/internal/provider/parquet_schema_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -66,6 +69,9 @@ func (r *ParquetSchemaResource) Schema(_ context.Context, _ resource.SchemaReque
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
 				},
 			},
 			"schema": schema.StringAttribute{

--- a/internal/provider/parser_lib_entry_resource.go
+++ b/internal/provider/parser_lib_entry_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -66,6 +69,9 @@ func (r *ParserLibEntryResource) Schema(_ context.Context, _ resource.SchemaRequ
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
 				},
 			},
 			"lib": schema.StringAttribute{

--- a/internal/provider/pipeline_resource.go
+++ b/internal/provider/pipeline_resource.go
@@ -17,6 +17,7 @@ import (
 	custom_validators "github.com/criblio/terraform-provider-criblio/internal/validators"
 	custom_stringvalidators "github.com/criblio/terraform-provider-criblio/internal/validators/stringvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -65,6 +66,9 @@ func (r *PipelineResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 						Description: `Timeout (in milliseconds) for asynchronous Pipeline functions.`,
 						PlanModifiers: []planmodifier.Int64{
 							custom_int64planmodifier.SuppressDiff(custom_int64planmodifier.ExplicitSuppress),
+						},
+						Validators: []validator.Int64{
+							int64validator.Between(0, 10000),
 						},
 					},
 					"output": schema.StringAttribute{

--- a/internal/provider/project_pipeline_resource.go
+++ b/internal/provider/project_pipeline_resource.go
@@ -17,6 +17,7 @@ import (
 	custom_validators "github.com/criblio/terraform-provider-criblio/internal/validators"
 	custom_stringvalidators "github.com/criblio/terraform-provider-criblio/internal/validators/stringvalidators"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -65,6 +66,9 @@ func (r *ProjectPipelineResource) Schema(_ context.Context, _ resource.SchemaReq
 						Description: `Timeout (in milliseconds) for asynchronous Pipeline functions.`,
 						PlanModifiers: []planmodifier.Int64{
 							custom_int64planmodifier.SuppressDiff(custom_int64planmodifier.ExplicitSuppress),
+						},
+						Validators: []validator.Int64{
+							int64validator.Between(0, 10000),
 						},
 					},
 					"output": schema.StringAttribute{

--- a/internal/provider/regex_resource.go
+++ b/internal/provider/regex_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -67,6 +70,9 @@ func (r *RegexResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
 				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+				},
 			},
 			"lib": schema.StringAttribute{
 				Required:    false,
@@ -85,6 +91,9 @@ func (r *RegexResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 				Optional:    true,
 				Computed:    false,
 				Description: `Optionally, paste in sample data to match against this regex`,
+				Validators: []validator.String{
+					stringvalidator.UTF8LengthAtMost(4096),
+				},
 			},
 			"tags": schema.StringAttribute{
 				Required:    false,

--- a/internal/provider/schema_resource.go
+++ b/internal/provider/schema_resource.go
@@ -6,15 +6,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -66,6 +69,9 @@ func (r *SchemaResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 					custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
 				},
 			},
 			"schema": schema.StringAttribute{

--- a/internal/provider/search_dashboard_resource.go
+++ b/internal/provider/search_dashboard_resource.go
@@ -4,15 +4,18 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -834,6 +837,9 @@ func (r *SearchDashboardResource) Schema(_ context.Context, _ resource.SchemaReq
 												stringplanmodifier.RequiresReplaceIfConfigured(),
 												custom_stringplanmodifier.SuppressDiff(custom_stringplanmodifier.ExplicitSuppress),
 											},
+											Validators: []validator.String{
+												stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+											},
 										},
 										"disabled": schema.BoolAttribute{
 											Required:    false,
@@ -866,6 +872,9 @@ func (r *SearchDashboardResource) Schema(_ context.Context, _ resource.SchemaReq
 														Optional:    false,
 														Computed:    false,
 														Description: `The <code>id</code> of the Notification target.`,
+														Validators: []validator.String{
+															stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+														},
 													},
 												},
 											},

--- a/internal/provider/search_dataset_provider_resource.go
+++ b/internal/provider/search_dataset_provider_resource.go
@@ -4,15 +4,18 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -74,6 +77,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -160,6 +167,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -187,6 +198,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `IAM role ARN to assume when using automatic credentials.`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+										stringvalidator.UTF8LengthAtLeast(20),
+									},
 								},
 								"assume_role_external_id": schema.StringAttribute{
 									Required:    false,
@@ -218,6 +233,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -232,6 +250,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -259,6 +281,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `Azure AD application (client) ID for API access.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"client_secret": schema.StringAttribute{
 									Required:    false,
@@ -266,18 +291,27 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Computed:    true,
 									Sensitive:   true,
 									Description: `Azure AD application client secret.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"name": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"tenant_id": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Azure AD tenant ID that owns the application registration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -292,6 +326,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -319,12 +357,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"service_account_credentials": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `JSON key downloaded from Google Cloud Console for a service account that can call GCP APIs.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -339,6 +383,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -366,18 +414,27 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"service_account_credentials": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `JSON key material for a Google Workspace domain-wide delegated service account.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"subject": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Admin user email address that the service account impersonates for Reports API access.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -392,6 +449,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -419,6 +480,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `Application (client) ID registered in Entra ID.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"client_secret": schema.StringAttribute{
 									Required:    false,
@@ -426,18 +490,27 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Computed:    true,
 									Sensitive:   true,
 									Description: `Client secret for the registered application.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"name": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"tenant_id": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Microsoft Entra ID (Azure AD) tenant ID.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -452,6 +525,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -479,18 +556,27 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `API token used to authorize Okta API requests.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"domain_endpoint": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Hostname of the Okta org URL.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"name": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -505,6 +591,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -532,6 +622,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `OAuth client ID from the Tailscale API credentials.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"client_secret": schema.StringAttribute{
 									Required:    false,
@@ -539,12 +632,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Computed:    true,
 									Sensitive:   true,
 									Description: `OAuth client secret from the Tailscale API credentials.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"name": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -559,6 +658,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -586,12 +689,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Optional:    true,
 									Computed:    true,
 									Description: `Zoom account identifier tied to these credentials.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"client_id": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `OAuth client ID from the Zoom Marketplace app.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"client_secret": schema.StringAttribute{
 									Required:    false,
@@ -599,12 +708,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 									Computed:    true,
 									Sensitive:   true,
 									Description: `OAuth client secret from the Zoom Marketplace app.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"name": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    true,
 									Description: `Display name that identifies the account configuration.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -619,6 +734,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -639,12 +758,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `The Tenant ID of the authorized application`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"client_id": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The Client ID (also known as Secret ID) of the authorized application`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"client_secret": schema.StringAttribute{
 						Required:    false,
@@ -652,6 +777,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Computed:    true,
 						Sensitive:   true,
 						Description: `The Client Secret of the authorized application`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 				},
 			},
@@ -663,6 +791,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -683,18 +815,27 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `The Snowflake account identifier, in the format <orgname>-<account_name>`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"username": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The Snowflake user for key pair authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"priv_key": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `The private key string out of the key file, from the pair of keys generated for authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"passphrase": schema.StringAttribute{
 						Required:    false,
@@ -725,6 +866,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -745,6 +890,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `The ClickHouse username for authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"password": schema.StringAttribute{
 						Required:    false,
@@ -752,12 +900,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Computed:    true,
 						Sensitive:   true,
 						Description: `The ClickHouse user password for authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"endpoint": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `URL to ClickHouse server with HTTP interface enabled. Ideally should be HTTPS over port 8443.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 				},
 			},
@@ -769,6 +923,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -789,6 +947,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Prometheus API endpoint URL. Example: https://prometheus.goats.biz`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://.+`), "must match pattern ^https?://.+"),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -831,6 +992,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -851,6 +1016,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `OpenSearch username for authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"password": schema.StringAttribute{
 						Required:    false,
@@ -858,12 +1026,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Computed:    true,
 						Sensitive:   true,
 						Description: `OpenSearch password for authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"endpoint": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `OpenSearch API endpoint URL. Example: https://opensearch.mycompany.com`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 				},
 			},
@@ -875,6 +1049,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -895,6 +1073,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Elasticsearch username for authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"password": schema.StringAttribute{
 						Required:    false,
@@ -902,12 +1083,18 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Computed:    true,
 						Sensitive:   true,
 						Description: `Elasticsearch password for authentication`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"endpoint": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Elasticsearch API endpoint URL`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 				},
 			},
@@ -919,6 +1106,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -941,6 +1132,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -1057,6 +1252,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -1082,6 +1281,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -1107,6 +1310,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -1132,6 +1339,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -1157,6 +1368,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -1189,6 +1404,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Storage account connection string`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"sas_configs": schema.ListNestedAttribute{
 						Required:    false,
@@ -1236,6 +1454,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Computed:    true,
 						Sensitive:   true,
 						Description: `Azure AD application client secret`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 				},
 			},
@@ -1247,6 +1468,10 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Unique identifier for the provider`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_-]+$`), "must match pattern ^[a-zA-Z0-9_-]+$"),
+							stringvalidator.UTF8LengthAtMost(512),
+						},
 					},
 					"type": schema.StringAttribute{
 						Required: false,
@@ -1267,6 +1492,9 @@ func (r *SearchDatasetProviderResource) Schema(_ context.Context, _ resource.Sch
 						Optional:    true,
 						Computed:    true,
 						Description: `Contents of Google Cloud service account credentials (JSON keys) file`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"endpoint": schema.StringAttribute{
 						Required:    false,

--- a/internal/provider/search_dataset_resource.go
+++ b/internal/provider/search_dataset_resource.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -269,6 +271,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `AWS inventory or API endpoints to include when querying this Dataset.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"regions": schema.ListAttribute{
@@ -276,6 +281,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `AWS regions to query for the enabled endpoints.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"breaker_rulesets": schema.ListAttribute{
@@ -463,6 +471,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Azure Dataset endpoints to include.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"subscription_ids": schema.ListAttribute{
@@ -470,6 +481,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Azure subscription identifiers scoped to the Dataset.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"breaker_rulesets": schema.ListAttribute{
@@ -657,30 +671,45 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Azure Data Explorer cluster hostname or name.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"database": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Database name.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"location": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Azure region code for the cluster.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"table": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Table name.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Column holding event time.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field_contents": schema.StringAttribute{
 						Required: false,
@@ -872,12 +901,18 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Index name.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Field that contains the event timestamp.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"breaker_rulesets": schema.ListAttribute{
 						Required:    false,
@@ -1064,6 +1099,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Configurations for all endpoints included in the dataset.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"endpoint_name": schema.StringAttribute{
@@ -1640,12 +1678,18 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Table name or KQL query to use as the data source.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Column holding event time.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field_contents": schema.StringAttribute{
 						Required: false,
@@ -2211,12 +2255,18 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Index name.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Field that contains the event timestamp.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"breaker_rulesets": schema.ListAttribute{
 						Required:    false,
@@ -2957,18 +3007,27 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `ClickHouse database that contains the table or view.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"table": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Table name, view name, or SQL query to use as the data source for the Dataset.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Column that contains the event timestamp.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"breaker_rulesets": schema.ListAttribute{
 						Required:    false,
@@ -4398,6 +4457,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Google Cloud Storage (GCS) bucket name. Supports templating.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"extra_paths": schema.ListNestedAttribute{
 						Required:    false,
@@ -4411,6 +4473,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 									Optional:    true,
 									Computed:    true,
 									Description: `Google Cloud Storage (GCS) bucket name. Supports templating.`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"filter": schema.StringAttribute{
 									Required:    false,
@@ -4462,6 +4527,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Storage classes to include when listing objects.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"breaker_rulesets": schema.ListAttribute{
@@ -4643,6 +4711,9 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Target number of samples per series.`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 11000),
+						},
 					},
 					"metric_name_pattern": schema.StringAttribute{
 						Required:    false,
@@ -5165,36 +5236,54 @@ func (r *SearchDatasetResource) Schema(_ context.Context, _ resource.SchemaReque
 						Optional:    true,
 						Computed:    true,
 						Description: `Database name in Snowflake.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"role": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Snowflake role assumed when executing queries for the Dataset.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"schema": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Schema name in Snowflake.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"table": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Table, view or SQL query for Snowflake statement.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"timestamp_field": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Column that contains the event timestamp.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"warehouse": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    true,
 						Description: `Warehouse name in Snowflake.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"breaker_rulesets": schema.ListAttribute{
 						Required:    false,

--- a/internal/provider/search_saved_query_resource.go
+++ b/internal/provider/search_saved_query_resource.go
@@ -8,11 +8,14 @@ import (
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -393,6 +396,9 @@ func (r *SearchSavedQueryResource) Schema(_ context.Context, _ resource.SchemaRe
 											Optional:    true,
 											Computed:    false,
 											Description: `Opacity of the area fill, from 0 (transparent) to 1 (opaque).`,
+											Validators: []validator.Float64{
+												float64validator.Between(0, 1),
+											},
 										},
 										"shadow_blur": schema.Int64Attribute{
 											Required:    false,
@@ -754,12 +760,18 @@ func (r *SearchSavedQueryResource) Schema(_ context.Context, _ resource.SchemaRe
 						Optional:    true,
 						Computed:    false,
 						Description: `Percentage of the scheduling interval to use as a random jitter window. Spreads scheduled search execution times to reduce load spikes. Valid range is 0-50. Set to 0 to disable jitter. If not set, uses the global scheduled search jitter configuration.`,
+						Validators: []validator.Int64{
+							int64validator.Between(0, 50),
+						},
 					},
 					"keep_last_n": schema.Int64Attribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `Minimum number of past execution artifacts to retain. Older artifacts are purged periodically. Default is <code>2</code>.`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 1000),
+						},
 					},
 					"notifications": schema.SingleNestedAttribute{
 						Required:    false,

--- a/internal/provider/search_source_resource.go
+++ b/internal/provider/search_source_resource.go
@@ -4,15 +4,21 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	custom_stringplanmodifier "github.com/criblio/terraform-provider-criblio/internal/tfplanmodifiers/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -74,6 +80,9 @@ func (r *SearchSourceResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Computed:    false,
 				Description: `Absolute path for Cribl HTTP API requests. Used when type is cribl_http.`,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+				},
 			},
 			"description": schema.StringAttribute{
 				Required:    false,
@@ -92,6 +101,9 @@ func (r *SearchSourceResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Computed:    false,
 				Description: `Absolute path for Elasticsearch bulk API requests. Used when type is elastic.`,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+				},
 			},
 			"host": schema.StringAttribute{
 				Required:    true,
@@ -139,6 +151,9 @@ func (r *SearchSourceResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Computed:    false,
 				Description: `Absolute path for Prometheus remote write requests. Used when type is prometheus_rw.`,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+				},
 			},
 			"splunk_hec_acks": schema.BoolAttribute{
 				Required:    false,
@@ -151,6 +166,9 @@ func (r *SearchSourceResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Computed:    false,
 				Description: `Absolute path for Splunk HTTP Event Collector (HEC) API requests. Required when type is splunk_hec.`,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+				},
 			},
 			"subscriptions": schema.ListNestedAttribute{
 				Required:    false,
@@ -182,18 +200,27 @@ func (r *SearchSourceResource) Schema(_ context.Context, _ resource.SchemaReques
 							Optional:    false,
 							Computed:    false,
 							Description: `Maximum seconds between endpoint check-ins before marking unavailable.`,
+							Validators: []validator.Float64{
+								float64validator.AtLeast(1),
+							},
 						},
 						"batch_timeout": schema.Float64Attribute{
 							Required:    true,
 							Optional:    false,
 							Computed:    false,
 							Description: `Seconds to collect events before sending to Cribl.`,
+							Validators: []validator.Float64{
+								float64validator.AtLeast(0),
+							},
 						},
 						"targets": schema.ListAttribute{
 							Required:    true,
 							Optional:    false,
 							Computed:    false,
 							Description: `DNS names of endpoints that forward these events.`,
+							Validators: []validator.List{
+								listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+							},
 							ElementType: types.StringType,
 						},
 						"id": schema.StringAttribute{
@@ -241,6 +268,9 @@ func (r *SearchSourceResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Computed:    false,
 				Description: `TCP listen port when the source type uses a dedicated TCP port.`,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 65535),
+				},
 			},
 			"tls": schema.SingleNestedAttribute{
 				Required:    false,
@@ -285,6 +315,9 @@ func (r *SearchSourceResource) Schema(_ context.Context, _ resource.SchemaReques
 				Optional:    true,
 				Computed:    false,
 				Description: `UDP listen port when applicable.`,
+				Validators: []validator.Int64{
+					int64validator.Between(0, 65535),
+				},
 			},
 		},
 	}

--- a/internal/provider/source_resource.go
+++ b/internal/provider/source_resource.go
@@ -6,14 +6,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -19372,30 +19378,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -19434,6 +19455,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"preprocess": schema.SingleNestedAttribute{
 						Required: false,
@@ -19466,6 +19490,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Rate (in bytes per second) to throttle while writing to an output. Accepts values with multiple-byte units, such as KB, MB, and GB. (Example: 42 MB) Default value of 0 specifies no throttling.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^[\d.]+(\s[KMGTPEZYkmgtpezy][Bb])?$`), "must match pattern ^[\\d.]+(\\s[KMGTPEZYkmgtpezy][Bb])?$"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -19610,30 +19637,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -19665,6 +19707,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify the hostname and port (such as mykafkabroker:9092) or just the hostname (in which case @{product} will assign port 9092).`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topics": schema.ListAttribute{
@@ -19672,6 +19718,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Topic to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Kafka Source to a single topic only.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -19708,18 +19758,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -19876,48 +19935,72 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -20127,6 +20210,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       the broker will remove the client from the group and initiate a rebalance.
       Value must be between the broker's configured group.min.session.timeout.ms and group.max.session.timeout.ms.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_session.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -20136,6 +20222,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Maximum allowed time for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#connectconfigs_rebalance.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -20145,36 +20234,54 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Expected time between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_heartbeat.interval.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_interval": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -20319,30 +20426,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -20374,6 +20496,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Enter each Kafka bootstrap server you want to use. Specify the hostname and port (such as mykafkabroker:9092) or just the hostname (in which case @{product} will assign port 9092).`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topics": schema.ListAttribute{
@@ -20381,6 +20507,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Topic to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Kafka Source to a single topic only.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -20405,6 +20535,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       the broker will remove the client from the group and initiate a rebalance.
       Value must be between the broker's configured group.min.session.timeout.ms and group.max.session.timeout.ms.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_session.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -20414,6 +20547,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Maximum allowed time for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#connectconfigs_rebalance.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -20423,6 +20559,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Expected time between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_heartbeat.interval.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -20468,18 +20607,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -20636,48 +20784,72 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: true,
@@ -20725,6 +20897,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -20737,6 +20913,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -20809,30 +20988,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -20968,30 +21162,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -21029,6 +21238,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -21113,12 +21325,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -21137,24 +21355,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -21179,18 +21409,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Cribl HTTP API requests. Only _bulk (default /cribl/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"elastic_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Elasticsearch API requests. Only _bulk (default /elastic/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which listen for the Splunk HTTP Event Collector API requests. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_acks": schema.BoolAttribute{
 						Required:    false,
@@ -21385,30 +21624,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -21446,6 +21700,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -21529,24 +21786,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -21588,6 +21857,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -21763,30 +22035,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -21909,6 +22196,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 for no timeout.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -21933,24 +22223,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -21995,24 +22297,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -22047,6 +22361,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required:    true,
@@ -22206,30 +22523,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -22267,6 +22599,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -22309,6 +22644,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -22412,12 +22751,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -22436,24 +22781,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -22472,6 +22829,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Splunk HTTP Event Collector API requests. This input supports the /event, /raw and /s2s endpoints.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -22500,6 +22860,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"splunk_hec_acks": schema.BoolAttribute{
@@ -22520,6 +22884,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"use_fwd_timezone": schema.BoolAttribute{
 						Required:    false,
@@ -22544,6 +22911,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, list HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -22551,6 +22922,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, list HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -22680,30 +23055,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -22747,24 +23137,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `The duration (in seconds) that the received messages are hidden from subsequent retrieve requests after being retrieved by a ReceiveMessage request.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 604800),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages to return in a poll request. Azure storage queues never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 32.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 32),
+						},
 					},
 					"service_period_secs": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The duration (in seconds) which pollers should be validated and restarted if exited`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -22806,18 +23208,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"parquet_chunk_size_mb": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -23007,30 +23418,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -23068,6 +23494,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -23145,12 +23574,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -23169,24 +23604,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -23211,6 +23658,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Elasticsearch API requests. Defaults to /. _bulk will be appended automatically. For example, /myPath becomes /myPath/_bulk. Requests can then be made to either /myPath/_bulk or /myPath/<myIndexName>/_bulk. Other entries are faked as success.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required:    false,
@@ -23320,6 +23770,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `List of headers to remove from the request to proxy`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(0),
+									listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+								},
 								ElementType: types.StringType,
 							},
 							"timeout_sec": schema.Float64Attribute{
@@ -23327,6 +23781,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Amount of time, in seconds, to wait for a proxy request to complete before canceling it`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 9007199254740991),
+								},
 							},
 						},
 					},
@@ -23482,30 +23939,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -23537,6 +24009,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `List of Confluent Cloud bootstrap servers to use, such as yourAccount.confluent.cloud:9092`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"tls": schema.SingleNestedAttribute{
@@ -23610,6 +24086,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Topic to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Kafka Source to a single topic only.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -23646,18 +24126,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for a Schema Registry connection to complete successfully`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"request_timeout": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time to wait for the Schema Registry to respond to a request`,
+								Validators: []validator.Float64{
+									float64validator.Between(1000, 60000),
+								},
 							},
 							"max_retries": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of times to try fetching schemas from the Schema Registry`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 							"auth": schema.SingleNestedAttribute{
 								Required: false,
@@ -23814,48 +24303,72 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -23999,6 +24512,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       the broker will remove the client from the group and initiate a rebalance.
       Value must be between the broker's configured group.min.session.timeout.ms and group.max.session.timeout.ms.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_session.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -24008,6 +24524,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Maximum allowed time for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#connectconfigs_rebalance.timeout.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -24017,36 +24536,54 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Expected time between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Kafka's documentation](https://kafka.apache.org/documentation/#consumerconfigs_heartbeat.interval.ms) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_interval": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -24192,30 +24729,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -24253,6 +24805,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -24330,12 +24885,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -24354,24 +24915,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for additional data, after the last response was sent, before closing a socket connection. This can be very useful when Grafana Agent remote write's request frequency is high so, reusing connections, would help mitigating the cost of creating a new connection per request. Note that Grafana Agent's embedded Prometheus would attempt to keep connections open for up to 5 minutes.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -24396,12 +24969,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Grafana Agent's Remote Write requests. Defaults to /api/prom/push, which will expand as: 'http://<your‑upstream‑URL>:<your‑port>/api/prom/push'. Either this field or 'Logs API endpoint' must be configured.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"loki_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Loki logs requests. Defaults to /loki/api/v1/push, which will (in this example) expand as: 'http://<your‑upstream‑URL>:<your‑port>/loki/api/v1/push'. Either this field or 'Remote Write API endpoint' must be configured.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"prometheus_auth": schema.SingleNestedAttribute{
 						Required: false,
@@ -24631,30 +25210,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -24692,6 +25286,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -24769,12 +25366,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -24793,24 +25396,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -24835,6 +25450,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Loki logs requests. Defaults to /loki/api/v1/push, which will (in this example) expand as: 'http://<your‑upstream‑URL>:<your‑port>/loki/api/v1/push'.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -25015,30 +25633,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -25076,6 +25709,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -25153,12 +25789,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -25177,24 +25819,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -25219,6 +25873,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for Prometheus requests. Defaults to /write, which will expand as: http://<your‑upstream‑URL>:<your‑port>/write.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required: false,
@@ -25398,30 +26055,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -25453,6 +26125,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Other dimensions to include in events`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						ElementType: types.StringType,
 					},
 					"field_per_metric": schema.BoolAttribute{
@@ -25472,6 +26147,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `How often, in minutes, to scrape targets for metrics. Maximum of 60 minutes. 60 must be evenly divisible by the value you enter.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 60),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: true,
@@ -25489,30 +26167,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, before aborting HTTP connection attempts; use 0 for no timeout`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -25558,6 +26251,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List of Prometheus targets to pull metrics from. Values can be in URL or host[:port] format. For example: http://localhost:9090/metrics, localhost:9090, or localhost. In cases where just host[:port] is specified, the endpoint will resolve to 'http://host[:port]/metrics'.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"record_type": schema.StringAttribute{
@@ -25570,12 +26266,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `The port number in the metrics URL for discovered targets`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"name_list": schema.ListAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of DNS names to resolve`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"scrape_protocol": schema.StringAttribute{
@@ -25589,6 +26291,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Path to use when collecting metrics from discovered targets`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/.*`), "must match pattern ^/.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -25631,6 +26336,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    false,
 									Computed:    false,
 									Description: `Values to match within this row's attribute. If empty, search will return only running EC2 instances.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 							},
@@ -25671,6 +26380,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -25683,12 +26396,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"http_discovery_url": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `URL to fetch target groups from (must be http or https)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"http_discovery_headers": schema.ListNestedAttribute{
 						Required:    false,
@@ -25858,30 +26577,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -25913,6 +26647,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Other dimensions to include in events`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						ElementType: types.StringType,
 					},
 					"field_per_metric": schema.BoolAttribute{
@@ -25932,12 +26669,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `How often in seconds to scrape targets for metrics.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Timeout, in milliseconds, before aborting HTTP connection attempts; 1-60000 or 0 to disable`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 60000),
+						},
 					},
 					"persistence": schema.SingleNestedAttribute{
 						Required: false,
@@ -25961,12 +26704,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space that can be consumed before older buckets are deleted. Examples: 420MB, 4GB. Default is 1GB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+(\.\d+)?\s*(?:[kmgKMG](b|B))?$`), "must match pattern ^\\d+(\\.\\d+)?\\s*(?:[kmgKMG](b|B))?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data before older buckets are deleted. Examples: 2h, 4d. Default is 24h.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -26014,6 +26763,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Targets`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"protocol": schema.StringAttribute{
@@ -26032,12 +26784,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `The port number in the metrics URL for discovered targets.`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 65535),
+									},
 								},
 								"path": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Path to use when collecting metrics from discovered targets`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^/.*`), "must match pattern ^/.*"),
+									},
 								},
 							},
 						},
@@ -26052,12 +26810,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `The port number in the metrics URL for discovered targets.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 65535),
+						},
 					},
 					"name_list": schema.ListAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `List of DNS names to resolve`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						ElementType: types.StringType,
 					},
 					"scrape_protocol": schema.StringAttribute{
@@ -26070,6 +26834,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Path to use when collecting metrics from discovered targets`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/.*`), "must match pattern ^/.*"),
+						},
 					},
 					"aws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -26112,6 +26879,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    false,
 									Computed:    false,
 									Description: `Values to match within this row's attribute. If empty, search will return only running EC2 instances.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 							},
@@ -26158,6 +26929,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -26170,6 +26945,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"service_monitor_namespace": schema.StringAttribute{
 						Required:    false,
@@ -26226,6 +27004,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `URL to fetch target groups from (must be http or https)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https?://`), "must match pattern ^https?://"),
+						},
 					},
 					"http_discovery_headers": schema.ListNestedAttribute{
 						Required:    false,
@@ -26395,30 +27176,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -26467,30 +27263,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout, use 0 to disable`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -26550,6 +27361,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Interval`,
+									Validators: []validator.Float64{
+										float64validator.Between(1, 60),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required: false,
@@ -26570,6 +27384,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Use this setting to account for ingestion lag. This is necessary because there can be a lag of 60 - 90 minutes (or longer) before Microsoft 365 events are available for retrieval.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 7200),
+						},
 					},
 					"retry_rules": schema.SingleNestedAttribute{
 						Required: false,
@@ -26586,24 +27403,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -26765,30 +27594,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -26837,30 +27681,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout, use 0 to disable`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -26914,6 +27773,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Interval`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 60),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required: false,
@@ -26944,24 +27806,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -27123,30 +27997,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -27184,6 +28073,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `How often (in minutes) to run the report. Must divide evenly into 60 minutes to create a predictable schedule, or Save will fail.`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 60),
+						},
 					},
 					"start_date": schema.StringAttribute{
 						Required:    false,
@@ -27202,6 +28094,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Maximum is 2400 (40 minutes); enter 0 to wait indefinitely.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"disable_time_filter": schema.BoolAttribute{
 						Required:    false,
@@ -27220,24 +28115,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -27278,6 +28185,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of times a task can be rescheduled`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: false,
@@ -27299,24 +28209,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -27545,30 +28467,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -27606,6 +28543,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `How often (in minutes) to run the report. Must divide evenly into 60 minutes to create a predictable schedule, or Save will fail.`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 60),
+						},
 					},
 					"start_date": schema.StringAttribute{
 						Required:    false,
@@ -27624,6 +28564,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Maximum is 2400 (40 minutes); enter 0 to wait indefinitely.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"disable_time_filter": schema.BoolAttribute{
 						Required:    false,
@@ -27636,6 +28579,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of pages to retrieve per collection task. Set to 0 to retrieve all pages.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"auth_type": schema.StringAttribute{
 						Required:    false,
@@ -27648,24 +28594,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run. Time unit defaults to seconds if not specified (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[sm]?$`), "must match pattern \\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -27706,6 +28664,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of times a task can be rescheduled`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: false,
@@ -27727,24 +28688,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of http codes that trigger a retry. Leave empty to use the default list of 429, 500, and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -27779,6 +28752,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -27969,30 +28945,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -28024,6 +29015,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `List of Event Hubs Kafka brokers to connect to (example: yourdomain.servicebus.windows.net:9093). The hostname can be found in the host portion of the primary or secondary connection string in Shared Access Policies.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"topics": schema.ListAttribute{
@@ -28031,6 +29026,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `The name of the Event Hub (Kafka topic) to subscribe to. Warning: To optimize performance, Cribl suggests subscribing each Event Hubs Source to only a single topic.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"group_id": schema.StringAttribute{
@@ -28050,48 +29049,72 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete successfully`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to a request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"max_retries": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `If messages are failing, you can set the maximum number of retries as high as 100 to prevent loss of data`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"max_back_off": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum wait time for a retry, in milliseconds. Default (and minimum) is 30,000 ms (30 seconds); maximum is 180,000 ms (180 seconds).`,
+						Validators: []validator.Float64{
+							float64validator.Between(30000, 180000),
+						},
 					},
 					"initial_backoff": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial value used to calculate the retry, in milliseconds. Maximum is 600,000 ms (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(300, 600000),
+						},
 					},
 					"backoff_rate": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Set the backoff multiplier (2-20) to control the retry frequency for failed messages. For faster retries, use a lower multiplier. For slower retries with more delay between attempts, use a higher multiplier. The multiplier is used in an exponential backoff formula; see the Kafka [documentation](https://kafka.js.org/docs/retry-detailed) for details.`,
+						Validators: []validator.Float64{
+							float64validator.Between(2, 20),
+						},
 					},
 					"authentication_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for Kafka to respond to an authentication request`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"reauthentication_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies a time window during which @{product} can reauthenticate if needed. Creates the window measuring backward from the moment when credentials are set to expire.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 1800000),
+						},
 					},
 					"sasl": schema.SingleNestedAttribute{
 						Required: false,
@@ -28223,6 +29246,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       If the client sends no heartbeats to the broker before the timeout expires, the broker will remove the client from the group and initiate a rebalance.
       Value must be lower than rebalanceTimeout.
       See details [here](https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/CONFIGURATION.md).`,
+						Validators: []validator.Float64{
+							float64validator.Between(6000, 300000),
+						},
 					},
 					"rebalance_timeout": schema.Float64Attribute{
 						Required: false,
@@ -28232,6 +29258,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Maximum allowed time (rebalance.timeout.ms in Kafka domain) for each worker to join the group after a rebalance begins.
       If the timeout is exceeded, the coordinator broker will remove the worker from the group.
       See [Recommended configurations](https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/CONFIGURATION.md).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"heartbeat_interval": schema.Float64Attribute{
 						Required: false,
@@ -28241,36 +29270,54 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
       Expected time (heartbeat.interval.ms in Kafka domain) between heartbeats to the consumer coordinator when using Kafka's group-management facilities.
       Value must be lower than sessionTimeout and typically should not exceed 1/3 of the sessionTimeout value.
       See [Recommended configurations](https://github.com/Azure/azure-event-hubs-for-kafka/blob/master/CONFIGURATION.md).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_interval": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often to commit offsets. If both this and Offset commit threshold are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1000, 3600000),
+						},
 					},
 					"auto_commit_threshold": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many events are needed to trigger an offset commit. If both this and Offset commit interval are set, @{product} commits offsets when either condition is met. If both are empty, @{product} commits offsets after each batch.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000),
+						},
 					},
 					"max_bytes_per_partition": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum amount of data that Kafka will return per partition, per fetch request. Must equal or exceed the maximum message size (maxBytesPerPartition) that Kafka is configured to allow. Otherwise, @{product} can get stuck trying to retrieve messages. Defaults to 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10000000),
+						},
 					},
 					"max_bytes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of bytes that Kafka will return per fetch request. Defaults to 10485760 (10 MB).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 1000000000),
+						},
 					},
 					"max_socket_errors": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of network errors before the consumer re-creates a socket`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 100),
+						},
 					},
 					"minimize_duplicates": schema.BoolAttribute{
 						Required:    false,
@@ -28422,30 +29469,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -28477,12 +29539,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `The name of the Event Hub to consume from`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"consumer_group": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `The consumer group this instance belongs to. Default is '$Default'.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"auth": schema.SingleNestedAttribute{
 						Required: false,
@@ -28584,6 +29652,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 										Optional:    false,
 										Computed:    false,
 										Description: `Azure Blob Storage container used to store checkpoints. Must be 3–63 lowercase alphanumeric characters or hyphens.`,
+										Validators: []validator.String{
+											stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z0-9](-?[a-z0-9])*$`), "must match pattern ^[a-z0-9](-?[a-z0-9])*$"),
+											stringvalidator.UTF8LengthBetween(3, 63),
+										},
 									},
 									"auth_type": schema.StringAttribute{
 										Required:    false,
@@ -28661,60 +29733,90 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events in each batch delivered to the consumer`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"max_wait_time_in_seconds": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a batch of events before delivering a partial batch`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"prefetch_count": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Number of events to prefetch from the service for processing`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"max_retries": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of retries per operation`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"initial_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial delay before the first retry, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(300),
+						},
 					},
 					"max_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum delay between retries, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(30000),
+						},
 					},
 					"timeout_in_ms": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a request to complete`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1000),
+						},
 					},
 					"connection_initial_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Initial delay before the first reconnection attempt, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"connection_max_backoff": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum delay between reconnection attempts, in milliseconds`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"connection_timeout_in_ms": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time to wait for a connection to complete`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -28860,30 +29962,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -28927,6 +30044,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of retry attempts in the event that the command fails`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"schedule_type": schema.StringAttribute{
 						Required:    false,
@@ -28946,6 +30066,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -28980,6 +30103,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Interval between command executions in seconds.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"cron_schedule": schema.StringAttribute{
 						Required:    false,
@@ -29103,30 +30229,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29164,6 +30305,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -29248,12 +30392,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -29272,24 +30422,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -29452,30 +30614,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29560,18 +30737,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `If Destination exerts backpressure, this setting limits how many inbound events Stream will queue for processing before it stops retrieving events`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"concurrency": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many streams to pull messages from at one time. Doubling the value doubles the number of messages this Source pulls from the topic (if available), while consuming more CPU and memory. Defaults to 5.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Pull request timeout, in milliseconds`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -29723,30 +30909,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29921,30 +31122,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -29982,6 +31198,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -30059,24 +31278,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -30262,30 +31493,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -30323,6 +31569,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -30428,12 +31677,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -30452,24 +31707,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -30633,30 +31900,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -30694,6 +31976,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -30778,12 +32063,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -30802,24 +32093,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -30844,18 +32147,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Cribl HTTP API requests. Only _bulk (default /cribl/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"elastic_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Elasticsearch API requests. Only _bulk (default /elastic/_bulk) is available. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_api": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Absolute path on which listen for the Splunk HTTP Event Collector API requests. Use empty string to disable.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/|^$`), "must match pattern ^/|^$"),
+						},
 					},
 					"splunk_hec_acks": schema.BoolAttribute{
 						Required:    false,
@@ -30942,9 +32254,13 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 											Computed: false,
 										},
 										"allowed_indexes_at_token": schema.ListAttribute{
-											Required:    false,
-											Optional:    true,
-											Computed:    false,
+											Required: false,
+											Optional: true,
+											Computed: false,
+											Validators: []validator.List{
+												listvalidator.SizeAtLeast(0),
+												listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+											},
 											ElementType: types.StringType,
 										},
 									},
@@ -31091,30 +32407,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -31152,6 +32483,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -31235,24 +32569,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -31427,30 +32773,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -31482,6 +32843,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive metric collections. Default is 10 seconds.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"host": schema.SingleNestedAttribute{
 						Required: false,
@@ -31719,6 +33083,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Timeout, in seconds, for the Docker API`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"filters": schema.ListNestedAttribute{
 								Required:    false,
@@ -31825,12 +33192,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -31967,30 +33340,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -32022,6 +33410,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive state collections. Default is 300 seconds (5 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -32228,12 +33619,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -32382,30 +33779,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -32437,6 +33849,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive metrics collections. Default is 15 secs.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"scrape_kubelet": schema.BoolAttribute{
 						Required:    false,
@@ -32517,12 +33932,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -32659,30 +34080,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -32714,6 +34150,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between checks for new containers. Default is 15 secs.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"rules": schema.ListNestedAttribute{
 						Required:    false,
@@ -32748,6 +34187,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum bytes to buffer while reassembling a single log line. A line that exceeds this size is flushed as-is, either whole or partially. The default is 1048576 (1 MB).`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1024),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -32793,12 +34235,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space that can be consumed before older buckets are deleted. Examples: 420MB, 4GB. Default is 1GB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+(\.\d+)?\s*(?:[kmgKMG](b|B))?$`), "must match pattern ^\\d+(\\.\\d+)?\\s*(?:[kmgKMG](b|B))?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data before older buckets are deleted. Examples: 2h, 4d. Default is 24h.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -32819,6 +34267,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"enable_load_balancing": schema.BoolAttribute{
 						Required:    false,
@@ -32948,30 +34399,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -33164,30 +34630,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -33219,6 +34700,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between consecutive metric collections. Default is 10 seconds.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"host": schema.SingleNestedAttribute{
 						Required: false,
@@ -33482,12 +34966,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -33630,30 +35120,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -33745,30 +35250,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -33793,6 +35313,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -33805,6 +35329,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -33888,6 +35415,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -33896,6 +35426,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -33926,6 +35459,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -33938,6 +35475,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -34089,30 +35629,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -34150,6 +35705,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -34227,12 +35785,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -34251,24 +35815,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -34299,12 +35875,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `The rate_by_service hint sent to connected tracers as the catch-all sampling rate. Applies to any service/environment not explicitly listed in Per-Service Sampling Rules. 1.0 = keep all traces (default); 0.0 = suggest dropping all.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 1),
+						},
 					},
 					"sampling_rules": schema.ListNestedAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Per-service sampling rate hints. Each row maps to a "service:<s>,env:<e>" key in the rate_by_service response sent to tracers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"service": schema.StringAttribute{
@@ -34312,18 +35894,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    false,
 									Computed:    false,
 									Description: `Datadog service name`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"environment": schema.StringAttribute{
 									Required:    true,
 									Optional:    false,
 									Computed:    false,
 									Description: `Datadog environment name (example: prod, staging)`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"rate": schema.Float64Attribute{
 									Required:    true,
 									Optional:    false,
 									Computed:    false,
 									Description: `Sampling rate for this service/environment combination (0.0–1.0)`,
+									Validators: []validator.Float64{
+										float64validator.Between(0, 1),
+									},
 								},
 							},
 						},
@@ -34491,30 +36082,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -34546,6 +36152,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Datagens`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"sample": schema.StringAttribute{
@@ -34559,6 +36168,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    false,
 									Computed:    false,
 									Description: `Maximum number of events to generate per second per Worker Node. Defaults to 10.`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(1),
+									},
 								},
 							},
 						},
@@ -34707,30 +36319,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -34768,6 +36395,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -34852,12 +36482,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -34876,24 +36512,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -34925,6 +36573,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -34953,6 +36604,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List of URI paths accepted by this input, wildcards are supported, e.g /api/v*/hook. Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"allowed_methods": schema.ListAttribute{
@@ -34960,6 +36614,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List of HTTP methods accepted by this input. Wildcards are supported (such as P*, GET). Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"auth_tokens_ext": schema.ListNestedAttribute{
@@ -35127,30 +36784,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -35188,6 +36860,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time interval in minutes between consecutive service calls`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 5),
+						},
 					},
 					"shard_expr": schema.StringAttribute{
 						Required:    false,
@@ -35212,12 +36887,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of records per getRecords call`,
+						Validators: []validator.Float64{
+							float64validator.Between(5000, 10000),
+						},
 					},
 					"get_records_limit_total": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of records, across all shards, to pull down at once per Worker Process`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(20000),
+						},
 					},
 					"load_balancing_algorithm": schema.StringAttribute{
 						Required:    false,
@@ -35271,6 +36952,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -35283,6 +36968,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"verify_kplcheck_sums": schema.BoolAttribute{
 						Required:    false,
@@ -35452,30 +37140,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -35658,30 +37361,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -35719,18 +37437,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter UDP port number to listen on. Not required if listening on TCP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tcp_port": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter TCP port number to listen on. Not required if listening on UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"max_buffer_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking. Only applies to UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -35842,6 +37569,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -35964,30 +37694,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -36079,30 +37824,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -36127,6 +37887,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36139,6 +37903,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -36211,12 +37978,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -36234,6 +38007,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -36242,6 +38018,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -36278,6 +38057,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36290,6 +38073,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -36436,30 +38222,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -36551,30 +38352,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -36599,6 +38415,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36611,6 +38431,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -36683,12 +38506,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -36706,6 +38535,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -36714,6 +38546,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"checksum_suffix": schema.StringAttribute{
 						Required:    false,
@@ -36726,6 +38561,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum download size (KB) of each manifest or checksum file. Manifest files larger than this size will not be read.        Defaults to 4096.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"validate_inventory_files": schema.BoolAttribute{
 						Required:    false,
@@ -36756,6 +38594,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -36768,6 +38610,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -36918,30 +38763,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -36979,6 +38839,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `UDP port to receive SNMP traps on. Defaults to 162.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"snmp_v3_auth": schema.SingleNestedAttribute{
 						Required:    false,
@@ -37003,6 +38866,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `User credentials for receiving v3 traps`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								NestedObject: schema.NestedAttributeObject{
 									Attributes: map[string]schema.Attribute{
 										"name": schema.StringAttribute{
@@ -37010,6 +38876,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 											Optional:    false,
 											Computed:    false,
 											Description: `V3 name`,
+											Validators: []validator.String{
+												stringvalidator.UTF8LengthAtLeast(1),
+											},
 										},
 										"auth_protocol": schema.StringAttribute{
 											Required: false,
@@ -37043,6 +38912,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -37077,6 +38949,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"varbinds_with_types": schema.BoolAttribute{
 						Required:    false,
@@ -37212,30 +39087,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -37273,6 +39163,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -37350,30 +39243,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 sec.; maximum 600 sec. (10 min.).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -37428,6 +39336,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Shared secrets to authenticate clients. Supports Bearer tokens and Basic auth. If empty, unauthenticated access is permitted.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						NestedObject: schema.NestedAttributeObject{
 							Attributes: map[string]schema.Attribute{
 								"auth_type": schema.StringAttribute{
@@ -37441,6 +39352,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Bearer token for Authorization header`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"description": schema.StringAttribute{
 									Required:    false,
@@ -37481,24 +39396,38 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Select or create a stored text secret`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"username": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Username`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"password": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Password`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 								"credentials_secret": schema.StringAttribute{
 									Required:    false,
 									Optional:    true,
 									Computed:    false,
 									Description: `Select or create a secret that references your credentials`,
+									Validators: []validator.String{
+										stringvalidator.UTF8LengthAtLeast(1),
+									},
 								},
 							},
 						},
@@ -37530,6 +39459,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -37689,30 +39621,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -37750,6 +39697,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -37849,12 +39799,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"shutdown_timeout_ms": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time in milliseconds to allow the server to shutdown gracefully before forcing shutdown. Defaults to 5000.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -37977,30 +39933,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -38097,6 +40068,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -38109,18 +40084,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -38149,6 +40133,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -38173,6 +40160,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 				},
 			},
@@ -38289,30 +40279,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -38350,18 +40355,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter UDP port number to listen on. Not required if listening on TCP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tcp_port": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Enter TCP port number to listen on. Not required if listening on UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"max_buffer_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking. Only applies to UDP.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -38392,6 +40406,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Wildcard list of fields to keep from source data; * = ALL (default)`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+						},
 						ElementType: types.StringType,
 					},
 					"octet_counting": schema.BoolAttribute{
@@ -38423,24 +40440,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process for TCP connections. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -38540,6 +40569,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"enable_load_balancing": schema.BoolAttribute{
 						Required:    false,
@@ -38675,30 +40707,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -38736,6 +40783,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between scanning for files`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"filenames": schema.ListAttribute{
 						Required:    false,
@@ -38761,6 +40811,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, before an idle file is closed`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"min_age_dur": schema.StringAttribute{
 						Required:    false,
@@ -38791,6 +40844,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Length of file header bytes to use in hash for unique file identification`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -38832,6 +40888,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -38850,6 +40909,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Set how many subdirectories deep to search. Use 0 to search only files in the given path, 1 to also look in its immediate subdirectories, etc. Leave it empty for unlimited depth.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"suppress_missing_path_errors": schema.BoolAttribute{
 						Required:    false,
@@ -38997,30 +41059,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -39058,6 +41135,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -39141,24 +41221,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -39200,6 +41292,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"enable_header": schema.BoolAttribute{
 						Required:    false,
@@ -39372,30 +41467,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -39433,24 +41543,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active connections allowed per Worker Process. Use 0 for unlimited.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_idle_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. After this time, the connection will be closed. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_ending_max_wait": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long the server will wait after initiating a closure for a client to close its end of the connection. If the client doesn't close the connection within this time, the server will forcefully terminate the socket to prevent resource leaks and ensure efficient connection cleanup and system stability. Leave at 0 for no inactive socket monitoring.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_max_lifespan": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum duration a socket can remain open, even if active. This helps manage resources and mitigate issues caused by TCP pinning. Set to 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -39492,6 +41614,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"enable_unix_path": schema.BoolAttribute{
 						Required:    false,
@@ -39563,12 +41688,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum disk space allowed to be consumed (examples: 420MB, 4GB). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_data_time": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum amount of time to retain data (examples: 2h, 4d). When limit is reached, older data will be deleted.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smhd]$`), "must match pattern \\d+[smhd]$"),
+								},
 							},
 							"compress": schema.StringAttribute{
 								Required: false,
@@ -39605,6 +41736,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"tls": schema.SingleNestedAttribute{
 						Required: false,
@@ -39817,30 +41951,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -39878,6 +42027,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_method": schema.StringAttribute{
 						Required:    false,
@@ -39974,12 +42126,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -39998,6 +42156,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -40022,6 +42183,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ca_fingerprint": schema.StringAttribute{
 						Required:    false,
@@ -40077,12 +42241,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    false,
 									Computed:    false,
 									Description: `Maximum time (in seconds) between endpoint checkins before considering it unavailable`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(1),
+									},
 								},
 								"batch_timeout": schema.Float64Attribute{
 									Required:    true,
 									Optional:    false,
 									Computed:    false,
 									Description: `Interval (in seconds) over which the endpoint should collect events before sending them to Stream`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 								"read_existing_events": schema.BoolAttribute{
 									Required:    false,
@@ -40107,6 +42277,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    false,
 									Computed:    false,
 									Description: `The DNS names of the endpoints that should forward these events. You may use wildcards, such as *.mydomain.com`,
+									Validators: []validator.List{
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"locale": schema.StringAttribute{
@@ -40324,30 +42497,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -40379,6 +42567,11 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Enter the event logs to collect. Run "Get-WinEvent -ListLog *" in PowerShell to see the available logs.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(1),
+							listvalidator.UniqueValues(),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"suppress_missing_log_errors": schema.BoolAttribute{
@@ -40410,12 +42603,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between checking for new entries (Applicable for pre-4.8.0 nodes that use Windows Tools)`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"batch_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of events to read in one polling interval. A batch size higher than 500 can cause delays when pulling from multiple event logs. (Applicable for pre-4.8.0 nodes that use Windows Tools)`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -40444,6 +42643,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of bytes in an event before it is flushed to the pipelines`,
+						Validators: []validator.Int64{
+							int64validator.Between(1, 134217728),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -40579,30 +42781,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -40634,6 +42851,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `String to filter log entries, in NSPredicate format (e.g., subsystem == "com.apple.security" or process == "kernel"). See [Common Log Types and Predicates](https://docs.cribl.io/edge/sources-apple-unified-logs/#examples) for more information.`,
+						Validators: []validator.String{
+							stringvalidator.UTF8LengthAtLeast(1),
+						},
 					},
 					"read_mode": schema.StringAttribute{
 						Required:    false,
@@ -40785,30 +43005,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -40846,12 +43081,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"max_buffer_size": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of events to buffer when downstream is blocking.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"ip_whitelist_regex": schema.StringAttribute{
 						Required:    false,
@@ -40876,6 +43117,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -41021,30 +43265,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -41082,6 +43341,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Time, in seconds, between scanning for journals. `,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"journals": schema.ListAttribute{
 						Required:    true,
@@ -41274,30 +43536,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -41329,6 +43606,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `The Wiz GraphQL API endpoint. Example: https://api.us1.app.wiz.io/graphql`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^https:\/\/`), "must match pattern ^https:\\/\\/"),
+						},
 					},
 					"auth_url": schema.StringAttribute{
 						Required:    true,
@@ -41360,6 +43640,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    false,
 									Computed:    false,
 									Description: `The name of the Wiz query`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^[a-zA-Z0-9_\-\s]+$`), "must match pattern ^[a-zA-Z0-9_\\-\\s]+$"),
+									},
 								},
 								"content_description": schema.StringAttribute{
 									Required:    false,
@@ -41426,6 +43709,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Units default to seconds if not specified. Enter 0 for unlimited time.`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required: false,
@@ -41437,6 +43723,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum number of pages to retrieve per collection task. Defaults to 0. Set to 0 to retrieve all pages.`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 							},
 						},
@@ -41446,24 +43735,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -41505,6 +43806,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"retry_rules": schema.SingleNestedAttribute{
 						Required: false,
@@ -41521,24 +43825,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -41700,30 +44016,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -41869,6 +44200,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum number of pages to retrieve per collection task. Set to 0 only when unlimited pagination is required.`,
+									Validators: []validator.Float64{
+										float64validator.AtLeast(0),
+									},
 								},
 								"pagination_next_relation_attribute": schema.StringAttribute{
 									Required:    false,
@@ -41905,6 +44239,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+									Validators: []validator.String{
+										stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+									},
 								},
 								"log_level": schema.StringAttribute{
 									Required:    false,
@@ -41942,6 +44279,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"api_key": schema.StringAttribute{
 						Required:    false,
@@ -41960,18 +44300,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -42016,24 +44365,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -42178,30 +44539,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -42239,6 +44615,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListAttribute{
 						Required:    false,
@@ -42323,12 +44702,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -42347,24 +44732,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"enable_health_check": schema.BoolAttribute{
 						Required:    false,
@@ -42396,6 +44793,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -42424,6 +44824,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List of URI paths accepted by this input. Wildcards are supported (such as /api/v*/hook). Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"allowed_methods": schema.ListAttribute{
@@ -42431,6 +44834,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List of HTTP methods accepted by this input. Wildcards are supported (such as P*, GET). Defaults to allow all.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"auth_tokens_ext": schema.ListNestedAttribute{
@@ -42598,30 +45004,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -42659,6 +45080,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"enable_pass_through": schema.BoolAttribute{
 						Required:    false,
@@ -42683,12 +45107,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Optionally, set the SO_RCVBUF socket option for the UDP socket. This value tells the operating system how many bytes can be buffered in the kernel before events are dropped. Leave blank to use the OS default. Caution: Increasing this value will affect OS memory utilization.`,
+						Validators: []validator.Float64{
+							float64validator.Between(256, 4294967295),
+						},
 					},
 					"template_cache_minutes": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Specifies how many minutes NetFlow v9 templates are cached before being discarded if not refreshed. Adjust based on your network's template update frequency to optimize performance and memory usage.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"v5_enabled": schema.BoolAttribute{
 						Required:    false,
@@ -42851,30 +45281,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -42966,30 +45411,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -43014,6 +45474,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43026,6 +45490,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -43098,12 +45565,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -43121,6 +45594,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -43129,6 +45605,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -43159,6 +45638,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43171,6 +45654,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -43322,30 +45808,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -43437,30 +45938,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"max_messages": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum number of messages SQS should return in a poll request. Amazon SQS never returns more messages than this value (however, fewer messages might be returned). Valid values: 1 to 10.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 10),
+						},
 					},
 					"visibility_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After messages are retrieved by a ReceiveMessage request, @{product} will hide them from subsequent retrieve requests for at least this duration. You can set this as high as 43200 sec. (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 43200),
+						},
 					},
 					"num_receivers": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How many receiver processes to run. The higher the number, the better the throughput - at the expense of CPU overhead.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Socket inactivity timeout (in seconds). Increase this value if timeouts occur due to backpressure.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 43200),
+						},
 					},
 					"skip_on_error": schema.BoolAttribute{
 						Required:    false,
@@ -43485,6 +46001,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"assume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43497,6 +46017,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"enable_sqsassume_role": schema.BoolAttribute{
 						Required:    false,
@@ -43569,12 +46092,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum file size for each Parquet chunk`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 100),
+						},
 					},
 					"parquet_chunk_download_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The maximum time allowed for downloading a Parquet chunk. Processing will stop if a chunk cannot be downloaded within the time specified.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 3600),
+						},
 					},
 					"checkpointing": schema.SingleNestedAttribute{
 						Required: false,
@@ -43592,6 +46121,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of times to retry processing when a processing error occurs. If Skip file on error is enabled, this setting is ignored.`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 100),
+								},
 							},
 						},
 					},
@@ -43600,6 +46132,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for events before trying polling again. The lower the number the higher the AWS bill. The higher the number the longer it will take for the source to react to configuration changes and system restarts.`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 20),
+						},
 					},
 					"encoding": schema.StringAttribute{
 						Required:    false,
@@ -43630,6 +46165,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Amazon Resource Name (ARN) of the role to assume`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^arn:`), "must match pattern ^arn:"),
+							stringvalidator.UTF8LengthAtLeast(20),
+						},
 					},
 					"sqsassume_role_external_id": schema.StringAttribute{
 						Required:    false,
@@ -43642,6 +46181,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Duration of the assumed role's session, in seconds. Minimum is 900 (15 minutes), default is 3600 (1 hour), and maximum is 43200 (12 hours).`,
+						Validators: []validator.Float64{
+							float64validator.Between(900, 43200),
+						},
 					},
 					"sqsaws_authentication_method": schema.StringAttribute{
 						Required: false,
@@ -43793,30 +46335,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -43848,18 +46405,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `ServiceNow instance base URL for Table API requests. Enter a literal URL (http or https and the instance host, for example a hostname ending in .service-now.com) or a Cribl expression that resolves to a URL.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"table_name": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `ServiceNow table name to collect from.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"fields": schema.ListAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Field names to return from the Table API (sysparm_fields). Leave empty to return all fields.`,
+						Validators: []validator.List{
+							listvalidator.ValueStringsAre(stringvalidator.RegexMatches(regexp.MustCompile(`^[^*?\[\]]+$`), "must match pattern ^[^*?\\[\\]]+$")),
+						},
 						ElementType: types.StringType,
 					},
 					"order_by_field": schema.StringAttribute{
@@ -43885,12 +46451,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum records per Table API page request (sysparm_limit). Setting a higher value may increase the risk of timeouts.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(1),
+						},
 					},
 					"max_pages": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of pages to retrieve per collection task. Set to 0 to retrieve all pages.`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"reject_unauthorized": schema.BoolAttribute{
 						Required:    false,
@@ -43909,18 +46481,27 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Cron schedule on which to run this job`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"earliest": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `Earliest time, relative to now. Format supported: [+|-]<time_integer><time_unit>@<snap-to_time_unit> (ex: -1hr, -42m, -42m@h)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"latest": schema.StringAttribute{
 						Required:    true,
 						Optional:    false,
 						Computed:    false,
 						Description: `Latest time, relative to now. Format supported: [+|-]<time_integer><time_unit>@<snap-to_time_unit> (ex: -1hr, -42m, -42m@h)`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"state_tracking": schema.BoolAttribute{
 						Required:    false,
@@ -43938,6 +46519,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"use_round_robin_dns": schema.BoolAttribute{
 						Required:    false,
@@ -43950,24 +46534,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"job_timeout": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -44012,24 +46608,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -44075,6 +46683,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `ServiceNow username for the password grant type`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"text_secret": schema.StringAttribute{
 						Required:    false,
@@ -44137,6 +46748,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `ServiceNow OAuth client ID`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`.*\S.*`), "must match pattern .*\\S.*"),
+						},
 					},
 					"client_text_secret": schema.StringAttribute{
 						Required:    false,
@@ -44278,30 +46892,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -44339,6 +46968,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -44381,6 +47013,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -44484,12 +47120,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -44508,24 +47150,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -44544,6 +47198,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Zscaler HTTP Event Collector API requests. This input supports the /event endpoint.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -44572,6 +47229,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -44579,6 +47240,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -44586,6 +47251,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -44722,30 +47391,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -44783,6 +47467,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -44825,6 +47512,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -44929,12 +47620,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -44953,24 +47650,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -44989,6 +47698,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Cloudflare HTTP Event Collector API requests. This input supports the /event endpoint.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -45017,6 +47729,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -45024,6 +47740,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -45031,6 +47751,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -45051,6 +47775,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"description": schema.StringAttribute{
 						Required:    false,
@@ -45174,30 +47901,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -45235,6 +47977,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -45277,6 +48022,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -45380,12 +48129,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -45404,24 +48159,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -45440,6 +48207,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Sysdig HTTP Event Collector API requests. This input supports the /event and /raw endpoints.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -45468,6 +48238,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -45475,6 +48249,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -45482,6 +48260,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -45612,30 +48394,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -45673,6 +48470,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Port to listen on`,
+						Validators: []validator.Float64{
+							float64validator.AtMost(65535),
+						},
 					},
 					"auth_tokens": schema.ListNestedAttribute{
 						Required:    false,
@@ -45715,6 +48515,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 									Optional:    true,
 									Computed:    false,
 									Description: `Enter the values you want to allow in the HEC event index field at the token level. Supports wildcards. To skip validation, leave blank.`,
+									Validators: []validator.List{
+										listvalidator.SizeAtLeast(0),
+										listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+									},
 									ElementType: types.StringType,
 								},
 								"metadata": schema.ListNestedAttribute{
@@ -45818,12 +48622,18 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of active requests allowed per Worker Process. Set to 0 for unlimited. Caution: Increasing the limit above the default value, or setting it to unlimited, may degrade performance and reduce throughput.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"max_requests_per_socket": schema.Int64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of requests per socket before @{product} instructs the client to close the connection. Default is 0 (unlimited).`,
+						Validators: []validator.Int64{
+							int64validator.AtLeast(0),
+						},
 					},
 					"enable_proxy_header": schema.BoolAttribute{
 						Required:    false,
@@ -45842,24 +48652,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: "How often request activity is logged at the `info` level. A value of 1 would log every request, 10 every 10th request, etc.",
+						Validators: []validator.Float64{
+							float64validator.AtLeast(1),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long to wait for an incoming request to complete before aborting it. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"socket_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How long @{product} should wait before assuming that an inactive socket has timed out. To wait forever, set to 0.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"keep_alive_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `After the last response is sent, @{product} will wait this long for additional data before closing the socket connection. Minimum 1 second, maximum 600 seconds (10 minutes).`,
+						Validators: []validator.Float64{
+							float64validator.Between(1, 600),
+						},
 					},
 					"ip_allowlist_regex": schema.StringAttribute{
 						Required:    false,
@@ -45878,6 +48700,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    false,
 						Computed:    false,
 						Description: `Absolute path on which to listen for the Upwind HTTP Event Collector API requests. This input supports the /event endpoint.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^/`), "must match pattern ^/"),
+						},
 					},
 					"metadata": schema.ListNestedAttribute{
 						Required:    false,
@@ -45906,6 +48731,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `List values allowed in HEC event index field. Leave blank to skip validation. Supports wildcards. The values here can expand index validation at the token level.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_origin": schema.ListAttribute{
@@ -45913,6 +48742,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP origins to which @{product} should send CORS (cross-origin resource sharing) Access-Control-Allow-* headers. Supports wildcards.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"access_control_allow_headers": schema.ListAttribute{
@@ -45920,6 +48753,10 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP headers that @{product} will send to allowed origins as "Access-Control-Allow-Headers" in a CORS preflight response. Use "*" to allow all headers.`,
+						Validators: []validator.List{
+							listvalidator.SizeAtLeast(0),
+							listvalidator.ValueStringsAre(stringvalidator.UTF8LengthAtLeast(1)),
+						},
 						ElementType: types.StringType,
 					},
 					"emit_token_metrics": schema.BoolAttribute{
@@ -46050,30 +48887,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -46141,6 +48993,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"log_level": schema.StringAttribute{
 						Required: false,
@@ -46152,6 +49007,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum number of log file listing pages to retrieve per run. Set to 0 to retrieve all pages.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(0),
+						},
 					},
 					"state_tracking": schema.BoolAttribute{
 						Required:    false,
@@ -46164,24 +49022,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -46223,6 +49093,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `How long (in milliseconds) the Event Breaker will wait for new data to be sent to a specific channel before flushing the data stream out, as is, to the Pipelines`,
+						Validators: []validator.Float64{
+							float64validator.Between(10, 43200000),
+						},
 					},
 					"retry_rules": schema.SingleNestedAttribute{
 						Required: false,
@@ -46239,24 +49112,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -46296,6 +49181,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `One or more compliance log categories to collect`,
+						Validators: []validator.List{
+							listvalidator.UniqueValues(),
+						},
 						ElementType: types.StringType,
 					},
 					"organization_id": schema.StringAttribute{
@@ -46309,6 +49197,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `One or more compliance log categories to collect`,
+						Validators: []validator.List{
+							listvalidator.UniqueValues(),
+						},
 						ElementType: types.StringType,
 					},
 					"state_update_expression": schema.StringAttribute{
@@ -46445,30 +49336,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -46542,6 +49448,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46604,6 +49513,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46666,6 +49578,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46728,6 +49643,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46790,6 +49708,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 							"state_tracking": schema.BoolAttribute{
 								Required:    false,
@@ -46840,6 +49761,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46866,6 +49790,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46892,6 +49819,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46918,6 +49848,9 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum time the job is allowed to run (examples: 30, 45s, 15m). Enter 0 for unlimited time.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+								},
 							},
 						},
 					},
@@ -46926,24 +49859,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -46988,24 +49933,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{
@@ -47150,30 +50107,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to hold in memory before writing events to disk. Enter a numeral with units of KB, MB, etc. The minimum value is 64KB and the maximum value is 10MB.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_buffer_size": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Maximum number of events to hold in memory before writing the events to disk. Deprecated and only supported in workers < v4.17.0. Use maxBufferSizeBytes instead.`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(42),
+								},
 							},
 							"commit_frequency": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The number of events to send downstream before committing that Stream has read them`,
+								Validators: []validator.Float64{
+									float64validator.AtLeast(1),
+								},
 							},
 							"max_file_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum size to store in each queue file before closing and optionally compressing. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"max_size": schema.StringAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum disk space that the queue can consume (as an average per Worker Process) before queueing stops. Enter a numeral with units of KB, MB, etc.`,
+								Validators: []validator.String{
+									stringvalidator.RegexMatches(regexp.MustCompile(`^\d+\s*(?:\w{2})?$`), "must match pattern ^\\d+\\s*(?:\\w{2})?$"),
+								},
 							},
 							"path": schema.StringAttribute{
 								Required:    false,
@@ -47241,30 +50213,45 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 						Optional:    true,
 						Computed:    false,
 						Description: `Maximum time the job is allowed to run (e.g., 30, 45s or 15m). Units are seconds, if not specified. Enter 0 for unlimited time.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`^\d+[sm]?$`), "must match pattern ^\\d+[sm]?$"),
+						},
 					},
 					"request_timeout": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `HTTP request inactivity timeout. Use 0 to disable.`,
+						Validators: []validator.Float64{
+							float64validator.Between(0, 2400),
+						},
 					},
 					"keep_alive_time": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `How often workers should check in with the scheduler to keep job subscription alive`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(10),
+						},
 					},
 					"max_missed_keep_alives": schema.Float64Attribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `The number of Keep Alive Time periods before an inactive worker will have its job subscription revoked.`,
+						Validators: []validator.Float64{
+							float64validator.AtLeast(2),
+						},
 					},
 					"ttl": schema.StringAttribute{
 						Required:    false,
 						Optional:    true,
 						Computed:    false,
 						Description: `Time to keep the job's artifacts on disk after job completion. This also affects how long a job is listed in the Job Inspector.`,
+						Validators: []validator.String{
+							stringvalidator.RegexMatches(regexp.MustCompile(`\d+[smh]$`), "must match pattern \\d+[smh]$"),
+						},
 					},
 					"ignore_group_jobs_limit": schema.BoolAttribute{
 						Required:    false,
@@ -47309,24 +50296,36 @@ func (r *SourceResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 								Optional:    true,
 								Computed:    false,
 								Description: `Time interval between failed request and first retry (kickoff). Maximum allowed value is 20,000 ms (1/3 minute).`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20000),
+								},
 							},
 							"limit": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `The maximum number of times to retry a failed HTTP request`,
+								Validators: []validator.Float64{
+									float64validator.Between(0, 20),
+								},
 							},
 							"multiplier": schema.Float64Attribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `Base for exponential backoff, e.g., base 2 means that retries will occur after 2, then 4, then 8 seconds, and so on`,
+								Validators: []validator.Float64{
+									float64validator.Between(1, 20),
+								},
 							},
 							"codes": schema.ListAttribute{
 								Required:    false,
 								Optional:    true,
 								Computed:    false,
 								Description: `List of HTTP codes that trigger a retry. Leave empty to use the default list of 429 and 503.`,
+								Validators: []validator.List{
+									listvalidator.SizeAtLeast(1),
+								},
 								ElementType: types.Float64Type,
 							},
 							"enable_header": schema.BoolAttribute{

--- a/internal/provider/workspace_resource.go
+++ b/internal/provider/workspace_resource.go
@@ -6,14 +6,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/criblio/terraform-provider-criblio/internal/restclient"
 	"github.com/hashicorp/terraform-plugin-framework-jsontypes/jsontypes"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 )
@@ -95,6 +98,10 @@ func (r *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Description: `Unique identifier for the workspace`,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
+				},
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z0-9]*$`), "must match pattern ^[a-z0-9]*$"),
+					stringvalidator.UTF8LengthBetween(4, 41),
 				},
 			},
 		},

--- a/terraform-overlay.yml
+++ b/terraform-overlay.yml
@@ -151,6 +151,18 @@ actions:
         x-terraform-optional-computed: true
         x-terraform-sensitive: true
         x-terraform-prefer-state: true
+  - target: "$.components.schemas.InputCollectorBase.properties.schedule.properties.run.properties"
+    update:
+      earliest:
+        type: string
+        title: Earliest
+        description: Earliest absolute or relative time to collect data for the selected timezone.
+        example: -10m@m
+      latest:
+        type: string
+        title: Latest
+        description: Latest absolute or relative time to collect data for the selected timezone.
+        example: -9m@m
   - target: "$.components.schemas"
     update:
       InputCollectorFilesystem:

--- a/terraform-overlay.yml
+++ b/terraform-overlay.yml
@@ -16,6 +16,21 @@ schema_imports:
       - SmtpTarget
 
 actions:
+  # Go's RE2 engine does not support the negative lookahead used by these
+  # OpenAPI array-element patterns. Keep the upstream constraint without
+  # generating a weaker Terraform validator.
+  - target: "$.components.schemas.FunctionConfSchemaFlatten.properties.fields.items"
+    update:
+      x-terraform-pattern-validator: false
+  - target: "$.components.schemas.FunctionConfSchemaMask.properties.fields.items"
+    update:
+      x-terraform-pattern-validator: false
+  - target: "$.components.schemas.FunctionConfSchemaSensitiveDataScanner.properties.fields.items"
+    update:
+      x-terraform-pattern-validator: false
+  - target: "$.components.schemas.FunctionConfSchemaSensitiveDataScanner.properties.excludeFields.items"
+    update:
+      x-terraform-pattern-validator: false
   - target: "$.paths./m/{groupId}/lib/jobs.post"
     update:
       x-terraform-resource: true
@@ -2962,7 +2977,6 @@ actions:
   - target: "$.components.schemas.SlackTarget.properties.url"
     update:
       pattern: '^https?://[a-zA-Z0-9-.]+'
-      x-terraform-pattern-validator: true
   - target: "$.components.schemas.WebhookTarget.properties.systemFields"
     update:
       x-terraform-suppress-diff: explicit

--- a/tests/acceptance/database_connection_test.go
+++ b/tests/acceptance/database_connection_test.go
@@ -21,7 +21,7 @@ func TestDatabaseConnection(t *testing.T) {
 			PreventPostDestroyRefresh: true,
 			Steps: []resource.TestStep{
 				{
-					Config: databaseConnectionConfig("MySQL database connection example", "test", 60),
+					Config: databaseConnectionConfig("MySQL database connection example", "test", 30000),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "id", "my_databaseconnection"),
 						resource.TestCheckResourceAttr(resourceName, "description", "MySQL database connection example"),
@@ -33,15 +33,15 @@ func TestDatabaseConnection(t *testing.T) {
 					),
 				},
 				{
-					Config: databaseConnectionConfig("Updated MySQL database connection example", "updated", 90),
+					Config: databaseConnectionConfig("Updated MySQL database connection example", "updated", 45000),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr(resourceName, "description", "Updated MySQL database connection example"),
 						resource.TestCheckResourceAttr(resourceName, "tags", "updated"),
-						resource.TestCheckResourceAttr(resourceName, "request_timeout", "90"),
+						resource.TestCheckResourceAttr(resourceName, "request_timeout", "45000"),
 					),
 				},
 				{
-					Config:   databaseConnectionConfig("Updated MySQL database connection example", "updated", 90),
+					Config:   databaseConnectionConfig("Updated MySQL database connection example", "updated", 45000),
 					PlanOnly: true,
 				},
 				{

--- a/tools/codegen/parser/parser.go
+++ b/tools/codegen/parser/parser.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -763,6 +765,38 @@ func fieldDef(modelName, apiName string, property, schemas *yaml.Node) (FieldDef
 			}
 		}
 	}
+	pattern, err := patternValidator(property, schemaForType)
+	if err != nil {
+		return FieldDef{}, fmt.Errorf("%s.%s: %v", modelName, apiName, err)
+	}
+	fieldConstraintValues, err := fieldConstraints(fieldType, property, schemaForType)
+	if err != nil {
+		return FieldDef{}, fmt.Errorf("%s.%s: %v", modelName, apiName, err)
+	}
+	var elementPattern string
+	var elementConstraints constraints
+	if fieldType == "array" && fieldElementType == "string" {
+		items, ok := mappingValue(schemaForType, "items")
+		if !ok {
+			return FieldDef{}, fmt.Errorf("%s.%s array field missing items schema", modelName, apiName)
+		}
+		resolvedItems := items
+		if schemaName := directSchemaRefName(items); schemaName != "" {
+			resolved, found := mappingValue(schemas, schemaName)
+			if !found {
+				return FieldDef{}, fmt.Errorf("array item schema %q not found", schemaName)
+			}
+			resolvedItems = resolved
+		}
+		elementPattern, err = patternValidator(items, resolvedItems)
+		if err != nil {
+			return FieldDef{}, fmt.Errorf("%s.%s items: %v", modelName, apiName, err)
+		}
+		elementConstraints, err = fieldConstraints("string", items, resolvedItems)
+		if err != nil {
+			return FieldDef{}, fmt.Errorf("%s.%s items: %v", modelName, apiName, err)
+		}
+	}
 	field := FieldDef{
 		APIName:       apiName,
 		TerraformName: snake(tfName),
@@ -793,7 +827,17 @@ func fieldDef(modelName, apiName string, property, schemas *yaml.Node) (FieldDef
 			property,
 			"x-terraform-enum-validator",
 		),
-		Pattern: patternValidator(property),
+		Pattern:          pattern,
+		MinLength:        fieldConstraintValues.minLength,
+		MaxLength:        fieldConstraintValues.maxLength,
+		Minimum:          fieldConstraintValues.minimum,
+		Maximum:          fieldConstraintValues.maximum,
+		MinItems:         fieldConstraintValues.minItems,
+		MaxItems:         fieldConstraintValues.maxItems,
+		UniqueItems:      fieldConstraintValues.uniqueItems,
+		ElementPattern:   elementPattern,
+		ElementMinLength: elementConstraints.minLength,
+		ElementMaxLength: elementConstraints.maxLength,
 	}
 	if field.Type == "array" && field.ElementType == "object" {
 		items, ok := mappingValue(schemaForType, "items")
@@ -865,11 +909,125 @@ func fieldDef(modelName, apiName string, property, schemas *yaml.Node) (FieldDef
 	return field, nil
 }
 
-func patternValidator(property *yaml.Node) string {
-	if !boolAnnotation(property, "x-terraform-pattern-validator") {
-		return ""
+type constraints struct {
+	minLength   *int
+	maxLength   *int
+	minimum     string
+	maximum     string
+	minItems    *int
+	maxItems    *int
+	uniqueItems bool
+}
+
+func fieldConstraints(fieldType string, property, resolvedSchema *yaml.Node) (constraints, error) {
+	var output constraints
+	var err error
+	switch fieldType {
+	case "string":
+		output.minLength, err = integerKeyword(property, resolvedSchema, "minLength")
+		if err != nil {
+			return constraints{}, err
+		}
+		output.maxLength, err = integerKeyword(property, resolvedSchema, "maxLength")
+	case "integer":
+		output.minimum, err = numericKeyword(property, resolvedSchema, "minimum", true)
+		if err != nil {
+			return constraints{}, err
+		}
+		output.maximum, err = numericKeyword(property, resolvedSchema, "maximum", true)
+	case "number":
+		output.minimum, err = numericKeyword(property, resolvedSchema, "minimum", false)
+		if err != nil {
+			return constraints{}, err
+		}
+		output.maximum, err = numericKeyword(property, resolvedSchema, "maximum", false)
+	case "array":
+		output.minItems, err = integerKeyword(property, resolvedSchema, "minItems")
+		if err != nil {
+			return constraints{}, err
+		}
+		output.maxItems, err = integerKeyword(property, resolvedSchema, "maxItems")
+		output.uniqueItems = boolKeyword(property, resolvedSchema, "uniqueItems")
 	}
-	return scalarValue(property, "pattern")
+	if err != nil {
+		return constraints{}, err
+	}
+	return output, nil
+}
+
+func integerKeyword(property, resolvedSchema *yaml.Node, key string) (*int, error) {
+	value, ok := constraintValue(property, resolvedSchema, key)
+	if !ok {
+		return nil, nil
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed < 0 {
+		return nil, fmt.Errorf("OpenAPI %s must be a non-negative integer, got %q", key, value)
+	}
+	return &parsed, nil
+}
+
+func numericKeyword(property, resolvedSchema *yaml.Node, key string, integer bool) (string, error) {
+	value, ok := constraintValue(property, resolvedSchema, key)
+	if !ok {
+		return "", nil
+	}
+	if integer {
+		if _, err := strconv.ParseInt(value, 10, 64); err != nil {
+			return "", fmt.Errorf("OpenAPI %s must be an int64, got %q", key, value)
+		}
+		return value, nil
+	}
+	if _, err := strconv.ParseFloat(value, 64); err != nil {
+		return "", fmt.Errorf("OpenAPI %s must be a float64, got %q", key, value)
+	}
+	return value, nil
+}
+
+func boolKeyword(property, resolvedSchema *yaml.Node, key string) bool {
+	if value, ok := boolValue(property, key); ok {
+		return value
+	}
+	if property != resolvedSchema {
+		value, _ := boolValue(resolvedSchema, key)
+		return value
+	}
+	return false
+}
+
+func constraintValue(property, resolvedSchema *yaml.Node, key string) (string, bool) {
+	if value, ok := mappingValue(property, key); ok && value.Kind == yaml.ScalarNode {
+		return value.Value, true
+	}
+	if property != resolvedSchema {
+		if value, ok := mappingValue(resolvedSchema, key); ok && value.Kind == yaml.ScalarNode {
+			return value.Value, true
+		}
+	}
+	return "", false
+}
+
+func patternValidator(property, resolvedSchema *yaml.Node) (string, error) {
+	if enabled, ok := boolValue(property, "x-terraform-pattern-validator"); ok && !enabled {
+		return "", nil
+	}
+	if property != resolvedSchema {
+		if enabled, ok := boolValue(resolvedSchema, "x-terraform-pattern-validator"); ok && !enabled {
+			return "", nil
+		}
+	}
+
+	pattern := scalarValue(property, "pattern")
+	if pattern == "" && property != resolvedSchema {
+		pattern = scalarValue(resolvedSchema, "pattern")
+	}
+	if pattern == "" {
+		return "", nil
+	}
+	if _, err := regexp.Compile(pattern); err != nil {
+		return "", fmt.Errorf("compile OpenAPI pattern %q: %v", pattern, err)
+	}
+	return pattern, nil
 }
 
 func ignoredAPIProperty(apiName string, property *yaml.Node) bool {
@@ -1406,8 +1564,23 @@ func scalarValue(node *yaml.Node, key string) string {
 }
 
 func boolAnnotation(node *yaml.Node, key string) bool {
+	value, ok := boolValue(node, key)
+	return ok && value
+}
+
+func boolValue(node *yaml.Node, key string) (bool, bool) {
 	value, ok := mappingValue(node, key)
-	return ok && value.Kind == yaml.ScalarNode && value.Value == "true"
+	if !ok || value.Kind != yaml.ScalarNode {
+		return false, false
+	}
+	switch value.Value {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
 }
 
 func suppressDiffAnnotation(node *yaml.Node) bool {

--- a/tools/codegen/parser/parser_test.go
+++ b/tools/codegen/parser/parser_test.go
@@ -420,20 +420,123 @@ func TestParseTerraformConflictsWith(t *testing.T) {
 	}
 }
 
-func TestPatternValidatorRequiresOptIn(t *testing.T) {
+func TestPatternValidator(t *testing.T) {
 	var property yaml.Node
-	if err := yaml.Unmarshal([]byte("pattern: '^https?://example\\.com'\nx-terraform-pattern-validator: true\n"), &property); err != nil {
+	if err := yaml.Unmarshal([]byte("pattern: '^https?://example\\.com'\n"), &property); err != nil {
 		t.Fatalf("parse property: %v", err)
 	}
-	if got := patternValidator(property.Content[0]); got != `^https?://example\.com` {
+	got, err := patternValidator(property.Content[0], property.Content[0])
+	if err != nil {
+		t.Fatalf("pattern validator: %v", err)
+	}
+	if got != `^https?://example\.com` {
 		t.Fatalf("pattern validator = %q, want %q", got, `^https?://example\.com`)
 	}
 
-	if err := yaml.Unmarshal([]byte("pattern: '^https?://'\n"), &property); err != nil {
-		t.Fatalf("parse property without opt-in: %v", err)
+	if err := yaml.Unmarshal([]byte("pattern: '^https?://'\nx-terraform-pattern-validator: false\n"), &property); err != nil {
+		t.Fatalf("parse opted-out property: %v", err)
 	}
-	if got := patternValidator(property.Content[0]); got != "" {
-		t.Fatalf("pattern validator without opt-in = %q, want empty", got)
+	got, err = patternValidator(property.Content[0], property.Content[0])
+	if err != nil {
+		t.Fatalf("opted-out pattern validator: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("opted-out pattern validator = %q, want empty", got)
+	}
+}
+
+func TestPatternValidatorResolvesReferencedSchema(t *testing.T) {
+	var property yaml.Node
+	if err := yaml.Unmarshal([]byte("$ref: '#/components/schemas/Identifier'\n"), &property); err != nil {
+		t.Fatalf("parse property: %v", err)
+	}
+	var schema yaml.Node
+	if err := yaml.Unmarshal([]byte("type: string\npattern: '^[a-z0-9_-]+$'\n"), &schema); err != nil {
+		t.Fatalf("parse schema: %v", err)
+	}
+
+	got, err := patternValidator(property.Content[0], schema.Content[0])
+	if err != nil {
+		t.Fatalf("pattern validator: %v", err)
+	}
+	if got != `^[a-z0-9_-]+$` {
+		t.Fatalf("pattern validator = %q, want %q", got, `^[a-z0-9_-]+$`)
+	}
+}
+
+func TestPatternValidatorRejectsUnsupportedPattern(t *testing.T) {
+	var property yaml.Node
+	if err := yaml.Unmarshal([]byte("pattern: '^(?!internal).+$'\n"), &property); err != nil {
+		t.Fatalf("parse property: %v", err)
+	}
+
+	_, err := patternValidator(property.Content[0], property.Content[0])
+	if err == nil {
+		t.Fatal("pattern validator accepted unsupported lookahead")
+	}
+}
+
+func TestFieldConstraints(t *testing.T) {
+	tests := []struct {
+		name      string
+		fieldType string
+		schema    string
+		check     func(t *testing.T, got constraints)
+	}{
+		{
+			name:      "string length",
+			fieldType: "string",
+			schema:    "type: string\nminLength: 2\nmaxLength: 12\n",
+			check: func(t *testing.T, got constraints) {
+				if got.minLength == nil || *got.minLength != 2 || got.maxLength == nil || *got.maxLength != 12 {
+					t.Fatalf("length constraints = %#v", got)
+				}
+			},
+		},
+		{
+			name:      "integer range",
+			fieldType: "integer",
+			schema:    "type: integer\nminimum: -1\nmaximum: 42\n",
+			check: func(t *testing.T, got constraints) {
+				if got.minimum != "-1" || got.maximum != "42" {
+					t.Fatalf("integer constraints = %#v", got)
+				}
+			},
+		},
+		{
+			name:      "number range",
+			fieldType: "number",
+			schema:    "type: number\nminimum: 0.5\nmaximum: 9.5\n",
+			check: func(t *testing.T, got constraints) {
+				if got.minimum != "0.5" || got.maximum != "9.5" {
+					t.Fatalf("number constraints = %#v", got)
+				}
+			},
+		},
+		{
+			name:      "array cardinality",
+			fieldType: "array",
+			schema:    "type: array\nminItems: 1\nmaxItems: 3\nuniqueItems: true\n",
+			check: func(t *testing.T, got constraints) {
+				if got.minItems == nil || *got.minItems != 1 || got.maxItems == nil || *got.maxItems != 3 || !got.uniqueItems {
+					t.Fatalf("array constraints = %#v", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var schema yaml.Node
+			if err := yaml.Unmarshal([]byte(tt.schema), &schema); err != nil {
+				t.Fatalf("parse schema: %v", err)
+			}
+			got, err := fieldConstraints(tt.fieldType, schema.Content[0], schema.Content[0])
+			if err != nil {
+				t.Fatalf("field constraints: %v", err)
+			}
+			tt.check(t, got)
+		})
 	}
 }
 

--- a/tools/codegen/parser/types.go
+++ b/tools/codegen/parser/types.go
@@ -86,6 +86,16 @@ type FieldDef struct {
 	Enum               []string
 	ValidateEnum       bool
 	Pattern            string
+	MinLength          *int
+	MaxLength          *int
+	Minimum            string
+	Maximum            string
+	MinItems           *int
+	MaxItems           *int
+	UniqueItems        bool
+	ElementPattern     string
+	ElementMinLength   *int
+	ElementMaxLength   *int
 	ConflictsWith      string
 	Fields             []FieldDef
 	ObjectAsJSON       bool

--- a/tools/codegen/render.go
+++ b/tools/codegen/render.go
@@ -208,12 +208,18 @@ func executeTemplate(kind string, resource parser.ResourceDef) ([]byte, error) {
 		"needsCustomPlanModifier":          needsCustomPlanModifier,
 		"needsValidator":                   needsValidator,
 		"needsStringValidator":             needsStringValidator,
+		"needsInt64Validator":              needsInt64Validator,
+		"needsFloat64Validator":            needsFloat64Validator,
+		"needsListValidator":               needsListValidator,
 		"needsRegexp":                      needsRegexp,
 		"needsCustomStringValidator":       needsCustomStringValidator,
 		"needsCustomJSONValidator":         needsCustomJSONValidator,
 		"planModifierType":                 planModifierType,
 		"planModifierCalls":                planModifierCalls,
 		"stringValidatorCalls":             stringValidatorCalls,
+		"int64ValidatorCalls":              int64ValidatorCalls,
+		"float64ValidatorCalls":            float64ValidatorCalls,
+		"listValidatorCalls":               listValidatorCalls,
 		"nestedObjectPlanModifierCalls":    nestedObjectPlanModifierCalls,
 		"schemaAttributes":                 schemaAttributes,
 		"oneOfSchemaAttributes":            oneOfSchemaAttributes,
@@ -709,6 +715,15 @@ func writeSchemaAttribute(output *strings.Builder, field parser.FieldDef, indent
 		}
 		fmt.Fprintf(output, "%s\t},\n", indent)
 	}
+	if calls := int64ValidatorCalls(field); len(calls) > 0 {
+		writeValidatorCalls(output, indent, "Int64", calls)
+	}
+	if calls := float64ValidatorCalls(field); len(calls) > 0 {
+		writeValidatorCalls(output, indent, "Float64", calls)
+	}
+	if calls := listValidatorCalls(field); len(calls) > 0 {
+		writeValidatorCalls(output, indent, "List", calls)
+	}
 	if nestedObjectList(field) {
 		fmt.Fprintf(output, "%s\tNestedObject: schema.NestedAttributeObject{\n", indent)
 		if calls := nestedObjectPlanModifierCalls(field); len(calls) > 0 {
@@ -743,6 +758,14 @@ func writeSchemaAttribute(output *strings.Builder, field parser.FieldDef, indent
 		fmt.Fprintf(output, "%s\tElementType: %s,\n", indent, listElementAttrType(field))
 	}
 	fmt.Fprintf(output, "%s},\n", indent)
+}
+
+func writeValidatorCalls(output *strings.Builder, indent, kind string, calls []string) {
+	fmt.Fprintf(output, "%s\tValidators: []validator.%s{\n", indent, kind)
+	for _, call := range calls {
+		fmt.Fprintf(output, "%s\t\t%s,\n", indent, call)
+	}
+	fmt.Fprintf(output, "%s\t},\n", indent)
 }
 
 func writeOneOfSchemaAttribute(output *strings.Builder, variant parser.OneOfVariantDef, indent string, optional bool) {
@@ -966,7 +989,34 @@ func needsResourceAttr(resource parser.ResourceDef) bool {
 
 func needsValidator(resource parser.ResourceDef) bool {
 	for _, field := range resourceFields(resource) {
-		if len(stringValidatorCalls(field)) > 0 {
+		if len(stringValidatorCalls(field)) > 0 || len(int64ValidatorCalls(field)) > 0 || len(float64ValidatorCalls(field)) > 0 || len(listValidatorCalls(field)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func needsInt64Validator(resource parser.ResourceDef) bool {
+	for _, field := range resourceFields(resource) {
+		if len(int64ValidatorCalls(field)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func needsFloat64Validator(resource parser.ResourceDef) bool {
+	for _, field := range resourceFields(resource) {
+		if len(float64ValidatorCalls(field)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func needsListValidator(resource parser.ResourceDef) bool {
+	for _, field := range resourceFields(resource) {
+		if len(listValidatorCalls(field)) > 0 {
 			return true
 		}
 	}
@@ -975,7 +1025,7 @@ func needsValidator(resource parser.ResourceDef) bool {
 
 func needsStringValidator(resource parser.ResourceDef) bool {
 	for _, field := range resourceFields(resource) {
-		if (field.FixedValue != "" || field.ValidateEnum && len(field.Enum) > 0 || field.Pattern != "" || field.ConflictsWith != "") && field.Type == "string" {
+		if len(stringValidatorCalls(field)) > 0 || len(elementStringValidatorCalls(field)) > 0 {
 			return true
 		}
 	}
@@ -984,7 +1034,7 @@ func needsStringValidator(resource parser.ResourceDef) bool {
 
 func needsRegexp(resource parser.ResourceDef) bool {
 	for _, field := range resourceFields(resource) {
-		if field.Pattern != "" && field.Type == "string" {
+		if field.Pattern != "" && field.Type == "string" || field.ElementPattern != "" && field.Type == "array" {
 			return true
 		}
 	}
@@ -1449,11 +1499,84 @@ func stringValidatorCalls(field parser.FieldDef) []string {
 	if field.Pattern != "" {
 		calls = append(calls, fmt.Sprintf("stringvalidator.RegexMatches(regexp.MustCompile(%s), %q)", goStringLiteral(field.Pattern), "must match pattern "+field.Pattern))
 	}
+	if field.MinLength != nil && field.MaxLength != nil {
+		calls = append(calls, fmt.Sprintf("stringvalidator.UTF8LengthBetween(%d, %d)", *field.MinLength, *field.MaxLength))
+	} else if field.MinLength != nil {
+		calls = append(calls, fmt.Sprintf("stringvalidator.UTF8LengthAtLeast(%d)", *field.MinLength))
+	} else if field.MaxLength != nil {
+		calls = append(calls, fmt.Sprintf("stringvalidator.UTF8LengthAtMost(%d)", *field.MaxLength))
+	}
 	if field.ValidJSON {
 		calls = append(calls, "custom_validators.IsValidJSON()")
 	}
 	if field.ConflictsWith != "" {
 		calls = append(calls, fmt.Sprintf("stringvalidator.ConflictsWith(path.MatchRoot(%q))", field.ConflictsWith))
+	}
+	return calls
+}
+
+func int64ValidatorCalls(field parser.FieldDef) []string {
+	if field.Type != "integer" {
+		return nil
+	}
+	return rangeValidatorCalls("int64validator", field.Minimum, field.Maximum)
+}
+
+func float64ValidatorCalls(field parser.FieldDef) []string {
+	if field.Type != "number" {
+		return nil
+	}
+	return rangeValidatorCalls("float64validator", field.Minimum, field.Maximum)
+}
+
+func rangeValidatorCalls(packageName, minimum, maximum string) []string {
+	if minimum != "" && maximum != "" {
+		return []string{fmt.Sprintf("%s.Between(%s, %s)", packageName, minimum, maximum)}
+	}
+	if minimum != "" {
+		return []string{fmt.Sprintf("%s.AtLeast(%s)", packageName, minimum)}
+	}
+	if maximum != "" {
+		return []string{fmt.Sprintf("%s.AtMost(%s)", packageName, maximum)}
+	}
+	return nil
+}
+
+func listValidatorCalls(field parser.FieldDef) []string {
+	if field.Type != "array" {
+		return nil
+	}
+	var calls []string
+	if field.MinItems != nil && field.MaxItems != nil {
+		calls = append(calls, fmt.Sprintf("listvalidator.SizeBetween(%d, %d)", *field.MinItems, *field.MaxItems))
+	} else if field.MinItems != nil {
+		calls = append(calls, fmt.Sprintf("listvalidator.SizeAtLeast(%d)", *field.MinItems))
+	} else if field.MaxItems != nil {
+		calls = append(calls, fmt.Sprintf("listvalidator.SizeAtMost(%d)", *field.MaxItems))
+	}
+	if field.UniqueItems {
+		calls = append(calls, "listvalidator.UniqueValues()")
+	}
+	if elementCalls := elementStringValidatorCalls(field); len(elementCalls) > 0 {
+		calls = append(calls, fmt.Sprintf("listvalidator.ValueStringsAre(%s)", strings.Join(elementCalls, ", ")))
+	}
+	return calls
+}
+
+func elementStringValidatorCalls(field parser.FieldDef) []string {
+	if field.Type != "array" || field.ElementType != "string" {
+		return nil
+	}
+	var calls []string
+	if field.ElementPattern != "" {
+		calls = append(calls, fmt.Sprintf("stringvalidator.RegexMatches(regexp.MustCompile(%s), %q)", goStringLiteral(field.ElementPattern), "must match pattern "+field.ElementPattern))
+	}
+	if field.ElementMinLength != nil && field.ElementMaxLength != nil {
+		calls = append(calls, fmt.Sprintf("stringvalidator.UTF8LengthBetween(%d, %d)", *field.ElementMinLength, *field.ElementMaxLength))
+	} else if field.ElementMinLength != nil {
+		calls = append(calls, fmt.Sprintf("stringvalidator.UTF8LengthAtLeast(%d)", *field.ElementMinLength))
+	} else if field.ElementMaxLength != nil {
+		calls = append(calls, fmt.Sprintf("stringvalidator.UTF8LengthAtMost(%d)", *field.ElementMaxLength))
 	}
 	return calls
 }

--- a/tools/codegen/render_test.go
+++ b/tools/codegen/render_test.go
@@ -1238,6 +1238,37 @@ func TestPatternValidator(t *testing.T) {
 	assertContains(t, content, "stringvalidator.RegexMatches(regexp.MustCompile(`^https?://[a-zA-Z0-9-.]+`), \"must match pattern ^https?://[a-zA-Z0-9-.]+\")")
 }
 
+func TestOpenAPIConstraintValidators(t *testing.T) {
+	minLength, maxLength := 2, 12
+	minItems, maxItems := 1, 3
+	elementMinLength := 1
+	resource := parser.ResourceDef{
+		Name:       "constraints",
+		FileStem:   "constraints",
+		TypeName:   "criblio_constraints",
+		StructName: "Constraints",
+		Fields: []parser.FieldDef{
+			{TerraformName: "name", GoName: "Name", Type: "string", Optional: true, MinLength: &minLength, MaxLength: &maxLength},
+			{TerraformName: "count", GoName: "Count", Type: "integer", Optional: true, Minimum: "1", Maximum: "10"},
+			{TerraformName: "ratio", GoName: "Ratio", Type: "number", Optional: true, Minimum: "0.25"},
+			{TerraformName: "items", GoName: "Items", Type: "array", ElementType: "string", Optional: true, MinItems: &minItems, MaxItems: &maxItems, UniqueItems: true, ElementPattern: `^[a-z]+$`, ElementMinLength: &elementMinLength},
+		},
+	}
+
+	content := renderTemplate(t, "resource", resource)
+	assertContains(t, content, `"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"`)
+	assertContains(t, content, `"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"`)
+	assertContains(t, content, `"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"`)
+	assertContains(t, content, `"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"`)
+	assertContains(t, content, "stringvalidator.UTF8LengthBetween(2, 12)")
+	assertContains(t, content, "int64validator.Between(1, 10)")
+	assertContains(t, content, "float64validator.AtLeast(0.25)")
+	assertContains(t, content, "listvalidator.SizeBetween(1, 3)")
+	assertContains(t, content, "listvalidator.UniqueValues()")
+	assertContains(t, content, "listvalidator.ValueStringsAre(stringvalidator.RegexMatches(regexp.MustCompile(`^[a-z]+$`)")
+	assertContains(t, content, "stringvalidator.UTF8LengthAtLeast(1)")
+}
+
 func TestRestWriteCall(t *testing.T) {
 	tests := []struct {
 		method string

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -1757,6 +1757,15 @@ import (
 {{- if needsStringValidator . }}
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 {{- end }}
+{{- if needsInt64Validator . }}
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+{{- end }}
+{{- if needsFloat64Validator . }}
+	"github.com/hashicorp/terraform-plugin-framework-validators/float64validator"
+{{- end }}
+{{- if needsListValidator . }}
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+{{- end }}
 {{- if needsResourceAttr . }}
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 {{- end }}

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -882,6 +882,13 @@ func (m *{{ .StructName }}Model) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
+{{- if eq .StructName "Collector" }}
+	normalizeCollectorUnionValues(raw)
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return err
+	}
+{{- end }}
 {{- if or (eq .StructName "Source") (eq .StructName "PackSource") }}
 	set{{ .StructName }}LegacyItemsFromRaw(m, raw)
 {{- end }}
@@ -1020,6 +1027,28 @@ func (m *{{ .StructName }}Model) UnmarshalJSON(data []byte) error {
 {{- end }}
 	return nil
 }
+
+{{- if eq .StructName "Collector" }}
+func normalizeCollectorUnionValues(raw map[string]any) {
+	if input, ok := raw["input"].(map[string]any); ok {
+		if value, ok := input["throttleRatePerSec"].(float64); ok {
+			input["throttleRatePerSec"] = fmt.Sprintf("%v", value)
+		}
+	}
+	if schedule, ok := raw["schedule"].(map[string]any); ok {
+		if run, ok := schedule["run"].(map[string]any); ok {
+			for _, field := range []string{"earliest", "latest"} {
+				if value, ok := run[field].(float64); ok {
+					run[field] = fmt.Sprintf("%v", value)
+				}
+			}
+		}
+	}
+	if savedState, ok := raw["savedState"].([]any); ok && len(savedState) == 0 {
+		raw["savedState"] = map[string]any{}
+	}
+}
+{{- end }}
 {{- if not (or (eq .StructName "PackDestination") (eq .StructName "PackSource")) }}
 {{ range .OneOfVariants }}
 type {{ .ModelName }} struct {
@@ -1814,6 +1843,9 @@ var _ = types.String{}
 var _ resource.Resource = &{{ .StructName }}Resource{}
 var _ resource.ResourceWithConfigure = &{{ .StructName }}Resource{}
 var _ resource.ResourceWithImportState = &{{ .StructName }}Resource{}
+{{- if eq .StructName "Collector" }}
+var _ resource.ResourceWithUpgradeState = &{{ .StructName }}Resource{}
+{{- end }}
 
 type {{ .StructName }}Resource struct {
 	client *restclient.Client
@@ -1830,6 +1862,9 @@ func (r *{{ .StructName }}Resource) Metadata(_ context.Context, req resource.Met
 
 func (r *{{ .StructName }}Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
+		{{- if eq .StructName "Collector" }}
+		Version: 1,
+		{{- end }}
 		MarkdownDescription: "{{ .StructName }} Resource",
 		Attributes: map[string]schema.Attribute{
 {{ schemaAttributes .Fields "\t\t\t" -}}

--- a/tools/import-cli/internal/export/export_test.go
+++ b/tools/import-cli/internal/export/export_test.go
@@ -2,6 +2,7 @@ package export
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -599,6 +600,43 @@ func TestAddOneOfBlockFromFirstItem_nestedDiscriminator(t *testing.T) {
 		err := addOneOfBlockFromFirstItem(model, attrs, cfg)
 		assert.ErrorIs(t, err, ErrUnsupportedOneOfType)
 	})
+}
+
+func TestAddCollectorOneOfFromGeneratedModel(t *testing.T) {
+	cfg := &registry.OneOfConfig{
+		DiscriminatorField:       "type",
+		NestedDiscriminatorField: "collector.type",
+		BlockNamePrefix:          "input_collector_",
+		SupportedBlockNames:      []string{"input_collector_rest"},
+	}
+	raw := json.RawMessage(`{
+		"id":"test_collect",
+		"type":"collection",
+		"ttl":"15h",
+		"collector":{"type":"rest","conf":{"collectUrl":"https://example.com"}},
+		"input":{"type":"collection","throttleRatePerSec":0},
+		"schedule":{"run":{"earliest":"-10m@m","latest":"-9m@m","maxTaskReschedule":60}},
+		"removeFields":[],
+		"savedState":[]
+	}`)
+	entry := registry.Entry{TypeName: "criblio_collector", ModelTypeName: "CollectorResourceModel", OneOf: cfg}
+	model, err := converter.ConvertRawItemWithIdentifiers(entry, raw, map[string]string{"GroupID": "worker-group", "ID": "test_collect"})
+	require.NoError(t, err)
+	attrs := map[string]hcl.Value{}
+
+	err = addOneOfBlockFromFirstItem(model, attrs, cfg)
+	require.NoError(t, err)
+	rest := attrs["input_collector_rest"]
+	require.Equal(t, hcl.KindMap, rest.Kind)
+	assert.NotContains(t, rest.Map, "type")
+	assert.Equal(t, "0", rest.Map["input"].Map["throttle_rate_per_sec"].String)
+	assert.Equal(t, "https://example.com", rest.Map["collector"].Map["conf"].Map["collect_url"].String)
+	run := rest.Map["schedule"].Map["run"]
+	assert.Equal(t, "-10m@m", run.Map["earliest"].String)
+	assert.Equal(t, "-9m@m", run.Map["latest"].String)
+	assert.Equal(t, float64(60), run.Map["max_task_reschedule"].Number)
+	assert.Equal(t, hcl.KindList, rest.Map["remove_fields"].Kind)
+	assert.Empty(t, rest.Map["remove_fields"].List)
 }
 
 func TestAddOneOfBlockFromFirstItem_generatedSourceInputBlock(t *testing.T) {

--- a/tools/import-cli/internal/export/oneof.go
+++ b/tools/import-cli/internal/export/oneof.go
@@ -23,11 +23,16 @@ func addOneOfBlockFromFirstItem(model interface{}, attrs map[string]hcl.Value, o
 	itemMap := firstItemMapFromModel(model, oneOf.ReadOnlyAttr)
 	if len(itemMap) == 0 {
 		switch model.(type) {
-		case *provider.SourceResourceModel, *provider.SourceModel, *provider.PackSourceResourceModel, *provider.PackSourceModel:
+		case *provider.SourceResourceModel, *provider.SourceModel, *provider.PackSourceResourceModel, *provider.PackSourceModel,
+			*provider.CollectorResourceModel, *provider.CollectorModel:
 			return addOneOfFromGeneratedInputBlocks(model, attrs, oneOf)
 		}
 		return nil
 	}
+	return addOneOfBlockFromItemMap(itemMap, attrs, oneOf)
+}
+
+func addOneOfBlockFromItemMap(itemMap map[string]string, attrs map[string]hcl.Value, oneOf *registry.OneOfConfig) error {
 	raw := itemMap[oneOf.DiscriminatorField]
 	var discStr string
 	if err := json.Unmarshal([]byte(raw), &discStr); err != nil {
@@ -172,6 +177,14 @@ func addOneOfFromGeneratedInputBlocks(model interface{}, attrs map[string]hcl.Va
 			return nil
 		}
 		raw := itemMap[oneOf.DiscriminatorField]
+		keysToSkip := oneOf.KeysToSkip
+		if raw == "" && oneOf.NestedDiscriminatorField != "" {
+			raw = resolveNestedDiscriminator(itemMap, oneOf.NestedDiscriminatorField)
+			if raw != "" {
+				itemMap[oneOf.DiscriminatorField] = raw
+				keysToSkip = append(append([]string(nil), keysToSkip...), oneOf.DiscriminatorField)
+			}
+		}
 		if raw == "" {
 			return fmt.Errorf("generated input branch missing discriminator %q", oneOf.DiscriminatorField)
 		}
@@ -194,9 +207,12 @@ func addOneOfFromGeneratedInputBlocks(model interface{}, attrs map[string]hcl.Va
 		} else {
 			alias = oneOf.DiscriminatorAlias
 		}
-		blockName, blockValue, err := hcl.ItemMapToBlock(itemMap, oneOf.DiscriminatorField, oneOf.BlockNamePrefix, oneOf.BlockNameSuffix, oneOf.KeysToSkip, alias)
+		blockName, blockValue, err := hcl.ItemMapToBlock(itemMap, oneOf.DiscriminatorField, oneOf.BlockNamePrefix, oneOf.BlockNameSuffix, keysToSkip, alias)
 		if err != nil {
 			return err
+		}
+		if removeFields, ok := blockMap["remove_fields"]; ok && removeFields.Kind == hcl.KindList && len(removeFields.List) == 0 {
+			blockValue.Map["remove_fields"] = removeFields
 		}
 		if blockName != "" && !blockValue.IsNull() {
 			attrs[blockName] = blockValue

--- a/tools/merge-spec/main.go
+++ b/tools/merge-spec/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"go/format"
 	"os"
 	"slices"
 	"sort"
@@ -444,7 +445,11 @@ func writeAvailabilityPaths(filename string, cloudOnlyPaths, onPremOnlyPaths []s
 	output.WriteString("\t}\n")
 	output.WriteString("}\n")
 
-	if err := os.WriteFile(filename, output.Bytes(), 0644); err != nil {
+	formatted, err := format.Source(output.Bytes())
+	if err != nil {
+		return fmt.Errorf("format cloud-only paths: %v", err)
+	}
+	if err := os.WriteFile(filename, formatted, 0644); err != nil {
 		return fmt.Errorf("write cloud-only paths: %v", err)
 	}
 	return nil

--- a/tools/merge-spec/main_test.go
+++ b/tools/merge-spec/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"go/format"
 	"os"
 	"path/filepath"
 	"strings"
@@ -158,10 +159,29 @@ components:
 	assertArrayItemsType(t, outputNode, "$.paths./m/{groupId}/system/strings.get.responses.200.content.application/json.schema", "string")
 
 	cloudOnlyPaths := readFile(t, cloudOnlyOutput)
-	assertContains(t, cloudOnlyPaths, `"/search/datasets": true`)
-	assertContains(t, cloudOnlyPaths, `"/search/jobs": true`)
-	assertContains(t, cloudOnlyPaths, `"/system/scripts": true`)
-	assertNotContains(t, cloudOnlyPaths, `"/system/certificates": true`)
+	assertContains(t, cloudOnlyPaths, `"/search/datasets"`)
+	assertContains(t, cloudOnlyPaths, `"/search/jobs"`)
+	assertContains(t, cloudOnlyPaths, `"/system/scripts"`)
+	assertNotContains(t, cloudOnlyPaths, `"/system/certificates"`)
+}
+
+func TestWriteAvailabilityPathsFormatsGeneratedGo(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "cloud_only_paths.go")
+	if err := writeAvailabilityPaths(filename, []string{"/short", "/a/much/longer/path"}, []string{"/onprem"}); err != nil {
+		t.Fatalf("write availability paths: %v", err)
+	}
+
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("read availability paths: %v", err)
+	}
+	formatted, err := format.Source(content)
+	if err != nil {
+		t.Fatalf("format generated source: %v", err)
+	}
+	if string(content) != string(formatted) {
+		t.Fatal("generated availability paths are not gofmt-formatted")
+	}
 }
 
 func TestLookupTargetSupportsSequenceIndexes(t *testing.T) {


### PR DESCRIPTION
- Generate Terraform validators from OpenAPI patterns, ranges, lengths, and collection constraints.
- Fix collector export to preserve type-specific configuration and remove_fields = [].
- Support numeric and relative-string collector schedule ranges.
- Add automatic state migration for existing numeric collector schedule values.