### PR TITLE
fixing import-cli null preservance issue and adding input for all col…

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.61"
+      version = "1.25.65"
     }
   }
 }

--- a/docs/resources/collector.md
+++ b/docs/resources/collector.md
@@ -980,7 +980,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_splunk--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_splunk--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_splunk--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_splunk--collector))
 
 <a id="nestedatt--input_collector_rest"></a>
@@ -998,7 +998,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_rest--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_rest--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_rest--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_rest--collector))
 
 <a id="nestedatt--input_collector_s3"></a>
@@ -1016,7 +1016,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_s3--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_s3--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_s3--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_s3--collector))
 
 <a id="nestedatt--input_collector_azure_blob"></a>
@@ -1034,7 +1034,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_azure_blob--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_azure_blob--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_azure_blob--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_azure_blob--collector))
 
 <a id="nestedatt--input_collector_cribl_lake"></a>
@@ -1052,7 +1052,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_cribl_lake--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_cribl_lake--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_cribl_lake--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_cribl_lake--collector))
 
 <a id="nestedatt--input_collector_database"></a>
@@ -1070,7 +1070,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_database--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_database--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_database--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_database--collector))
 
 <a id="nestedatt--input_collector_gcs"></a>
@@ -1088,7 +1088,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_gcs--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_gcs--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_gcs--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_gcs--collector))
 
 <a id="nestedatt--input_collector_health_check"></a>
@@ -1106,7 +1106,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_health_check--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_health_check--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_health_check--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_health_check--collector))
 
 <a id="nestedatt--input_collector_script"></a>
@@ -1124,7 +1124,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_script--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_script--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_script--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_script--collector))
 
 <a id="nestedatt--input_collector_filesystem"></a>
@@ -1142,7 +1142,7 @@ Optional:
 - `schedule` (Attributes) Configuration for a scheduled job (see [below for nested schema](#nestedatt--input_collector_filesystem--schedule))
 - `streamtags` (List of String) Tags for filtering and grouping
 - `worker_affinity` (Boolean) If enabled, tasks are created and run by the same Worker Node
-- `input` (Attributes) (see [below for nested schema](#nestedatt--input_collector_filesystem--input))
+- `input` (Attributes) Input configuration for a collection job. Set type to "collection". (see [below for nested schema](#nestedatt--input_collector_filesystem--input))
 - `collector` (Attributes) (see [below for nested schema](#nestedatt--input_collector_filesystem--collector))
 
 <a id="nestedatt--input_collector_splunk--schedule"></a>

--- a/examples/collector/main.tf
+++ b/examples/collector/main.tf
@@ -263,6 +263,30 @@ resource "criblio_collector" "rest_api_collector_discovery_http" {
   }
 }
 
+resource "criblio_collector" "s3" {
+  id       = "TestS3Collector"
+  group_id = "default"
+  input_collector_s3 = {
+    id         = "TestS3Collector"
+    streamtags = ["terraform"]
+    input = {
+      type = "collection"
+    }
+    collector = {
+      type = "s3"
+      conf = {
+        aws_authentication_method = "auto"
+        bucket                    = "test-bucket"
+        recurse                   = true
+        max_batch_size            = 10
+        verify_permissions        = true
+        reuse_connections         = true
+        enable_assume_role        = false
+      }
+    }
+  }
+}
+
 /*
 resource "criblio_collector" "rest_conf_update_test" {
   group_id = "default"

--- a/examples/pack-with-source/main.tf
+++ b/examples/pack-with-source/main.tf
@@ -31,7 +31,7 @@ resource "criblio_pack_source" "my_packsource" {
     pipeline = "my_pipeline"
     port     = 7592
     pq = {
-      commit_frequency = 7
+      commit_frequency = 42
       compress         = "none"
       max_buffer_size  = 51
       max_file_size    = "100 MB"
@@ -107,7 +107,7 @@ resource "criblio_pack_source" "my_packsource_syslog" {
     octet_counting = false
     pipeline       = "my_pipeline"
     pq = {
-      commit_frequency = 7
+      commit_frequency = 42
       compress         = "none"
       max_buffer_size  = 51
       max_file_size    = "100 MB"

--- a/internal/provider/collector_data_source.go
+++ b/internal/provider/collector_data_source.go
@@ -190,7 +190,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -456,7 +457,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -1019,7 +1021,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -1278,7 +1281,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -1559,7 +1563,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -1773,7 +1778,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -1994,7 +2000,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -2243,7 +2250,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -2478,7 +2486,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,
@@ -2697,7 +2706,8 @@ func (d *CollectorDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 						Description: `If enabled, tasks are created and run by the same Worker Node`,
 					},
 					"input": schema.SingleNestedAttribute{
-						Computed: true,
+						Computed:    true,
+						Description: `Input configuration for a collection job. Set type to "collection".`,
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Computed: true,

--- a/internal/provider/collector_resource.go
+++ b/internal/provider/collector_resource.go
@@ -312,12 +312,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -739,12 +743,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -1625,12 +1633,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -2037,12 +2049,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -2481,12 +2497,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -2821,12 +2841,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -3172,12 +3196,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -3568,12 +3596,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -3946,12 +3978,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,
@@ -4295,12 +4331,16 @@ func (r *CollectorResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Required:      false,
 						Optional:      true,
 						Computed:      true,
+						Description:   `Input configuration for a collection job. Set type to "collection".`,
 						PlanModifiers: collectorPreferConfigOrStatePlanModifiers(),
 						Attributes: map[string]schema.Attribute{
 							"type": schema.StringAttribute{
 								Required: false,
 								Optional: true,
 								Computed: true,
+								Validators: []validator.String{
+									stringvalidator.OneOf("collection"),
+								},
 							},
 							"breaker_rulesets": schema.ListAttribute{
 								Required:    false,

--- a/internal/provider/collector_schema_test.go
+++ b/internal/provider/collector_schema_test.go
@@ -1,0 +1,43 @@
+package provider
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	resourceschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+)
+
+func TestCollectorSchemaKeepsInputOptionalForBackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	var response resource.SchemaResponse
+	(&CollectorResource{}).Schema(context.Background(), resource.SchemaRequest{}, &response)
+
+	for _, variantName := range []string{
+		"input_collector_splunk",
+		"input_collector_rest",
+		"input_collector_s3",
+		"input_collector_azure_blob",
+		"input_collector_cribl_lake",
+		"input_collector_database",
+		"input_collector_gcs",
+		"input_collector_health_check",
+		"input_collector_script",
+		"input_collector_filesystem",
+	} {
+		t.Run(variantName, func(t *testing.T) {
+			variant, ok := response.Schema.Attributes[variantName].(resourceschema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("%s is not a single nested attribute", variantName)
+			}
+			input, ok := variant.Attributes["input"].(resourceschema.SingleNestedAttribute)
+			if !ok {
+				t.Fatalf("%s.input is not a single nested attribute", variantName)
+			}
+			if input.Required || !input.Optional || !input.Computed {
+				t.Errorf("%s.input flags = required:%v optional:%v computed:%v", variantName, input.Required, input.Optional, input.Computed)
+			}
+		})
+	}
+}

--- a/internal/provider/collector_types.go
+++ b/internal/provider/collector_types.go
@@ -3385,6 +3385,12 @@ func (m InputCollectorSplunkModel) terraformPayload() (map[string]any, error) {
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -3618,6 +3624,12 @@ func (m InputCollectorRestModel) terraformPayload() (map[string]any, error) {
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -3851,6 +3863,12 @@ func (m InputCollectorS3Model) terraformPayload() (map[string]any, error) {
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -4084,6 +4102,12 @@ func (m InputCollectorAzureBlobModel) terraformPayload() (map[string]any, error)
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -4317,6 +4341,12 @@ func (m InputCollectorCriblLakeModel) terraformPayload() (map[string]any, error)
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -4550,6 +4580,12 @@ func (m InputCollectorDatabaseModel) terraformPayload() (map[string]any, error) 
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -4783,6 +4819,12 @@ func (m InputCollectorGCSModel) terraformPayload() (map[string]any, error) {
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -5016,6 +5058,12 @@ func (m InputCollectorHealthCheckModel) terraformPayload() (map[string]any, erro
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -5249,6 +5297,12 @@ func (m InputCollectorScriptModel) terraformPayload() (map[string]any, error) {
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 
@@ -5482,6 +5536,12 @@ func (m InputCollectorFilesystemModel) terraformPayload() (map[string]any, error
 		}
 		output["collector"] = value
 	}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
 	return output, nil
 }
 

--- a/internal/provider/collector_types_test.go
+++ b/internal/provider/collector_types_test.go
@@ -69,6 +69,97 @@ func TestCollectorMarshalJSONIncludesSavedJobType(t *testing.T) {
 	if got["id"] != "rest-api-demo-collector" {
 		t.Fatalf("expected collector id in body, got %#v in %s", got["id"], data)
 	}
+	input, ok := got["input"].(map[string]any)
+	if !ok || input["type"] != "collection" {
+		t.Fatalf("expected default collection input in body, got %#v in %s", got["input"], data)
+	}
+}
+
+func TestCollectorMarshalJSONDefaultsInputForEveryVariant(t *testing.T) {
+	tests := map[string]CollectorModel{
+		"splunk":       {InputCollectorSplunk: &InputCollectorSplunkModel{}},
+		"rest":         {InputCollectorRest: &InputCollectorRestModel{}},
+		"s3":           {InputCollectorS3: &InputCollectorS3Model{}},
+		"azure_blob":   {InputCollectorAzureBlob: &InputCollectorAzureBlobModel{}},
+		"cribl_lake":   {InputCollectorCriblLake: &InputCollectorCriblLakeModel{}},
+		"database":     {InputCollectorDatabase: &InputCollectorDatabaseModel{}},
+		"gcs":          {InputCollectorGCS: &InputCollectorGCSModel{}},
+		"health_check": {InputCollectorHealthCheck: &InputCollectorHealthCheckModel{}},
+		"script":       {InputCollectorScript: &InputCollectorScriptModel{}},
+		"filesystem":   {InputCollectorFilesystem: &InputCollectorFilesystemModel{}},
+	}
+
+	for name, model := range tests {
+		t.Run(name, func(t *testing.T) {
+			data, err := json.Marshal(model)
+			if err != nil {
+				t.Fatalf("json.Marshal returned error: %v", err)
+			}
+			var body map[string]any
+			if err := json.Unmarshal(data, &body); err != nil {
+				t.Fatalf("json.Unmarshal returned error: %v", err)
+			}
+			input, ok := body["input"].(map[string]any)
+			if !ok || input["type"] != "collection" {
+				t.Fatalf("expected default collection input, got %#v in %s", body["input"], data)
+			}
+		})
+	}
+}
+
+func TestCollectorMarshalJSONCompletesPartialInputAndPreservesFields(t *testing.T) {
+	inputValues := make(map[string]attr.Value, len(InputCollectorRestInputAttrTypes()))
+	for name, typ := range InputCollectorRestInputAttrTypes() {
+		value, err := CollectorTerraformNullValue(typ)
+		if err != nil {
+			t.Fatalf("null value for %s: %v", name, err)
+		}
+		inputValues[name] = value
+	}
+	inputValues["pipeline"] = types.StringValue("main")
+
+	model := CollectorModel{InputCollectorRest: &InputCollectorRestModel{
+		Input: types.ObjectValueMust(InputCollectorRestInputAttrTypes(), inputValues),
+	}}
+	data, err := json.Marshal(model)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	input := body["input"].(map[string]any)
+	if input["type"] != "collection" || input["pipeline"] != "main" {
+		t.Fatalf("expected completed input preserving pipeline, got %#v", input)
+	}
+}
+
+func TestCollectorMarshalJSONCompletesEmptyS3Input(t *testing.T) {
+	inputValues := make(map[string]attr.Value, len(InputCollectorS3InputAttrTypes()))
+	for name, typ := range InputCollectorS3InputAttrTypes() {
+		value, err := CollectorTerraformNullValue(typ)
+		if err != nil {
+			t.Fatalf("null value for %s: %v", name, err)
+		}
+		inputValues[name] = value
+	}
+
+	model := CollectorModel{InputCollectorS3: &InputCollectorS3Model{
+		Input: types.ObjectValueMust(InputCollectorS3InputAttrTypes(), inputValues),
+	}}
+	data, err := json.Marshal(model)
+	if err != nil {
+		t.Fatalf("json.Marshal returned error: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(data, &body); err != nil {
+		t.Fatalf("json.Unmarshal returned error: %v", err)
+	}
+	input := body["input"].(map[string]any)
+	if len(input) != 1 || input["type"] != "collection" {
+		t.Fatalf("expected minimal collection input, got %#v", input)
+	}
 }
 
 func TestCollectorModelUnmarshalGoogleCloudStorageAlias(t *testing.T) {

--- a/internal/provider/collectors_data_source.go
+++ b/internal/provider/collectors_data_source.go
@@ -196,7 +196,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -462,7 +463,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -1025,7 +1027,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -1284,7 +1287,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -1565,7 +1569,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -1779,7 +1784,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -2000,7 +2006,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -2249,7 +2256,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -2484,7 +2492,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,
@@ -2703,7 +2712,8 @@ func (d *CollectorsDataSource) Schema(_ context.Context, _ datasource.SchemaRequ
 									Description: `If enabled, tasks are created and run by the same Worker Node`,
 								},
 								"input": schema.SingleNestedAttribute{
-									Computed: true,
+									Computed:    true,
+									Description: `Input configuration for a collection job. Set type to "collection".`,
 									Attributes: map[string]schema.Attribute{
 										"type": schema.StringAttribute{
 											Computed: true,

--- a/terraform-overlay.yml
+++ b/terraform-overlay.yml
@@ -116,6 +116,12 @@ actions:
   - target: "$.components.schemas.InputCollectorBase.properties.type"
     update:
       x-terraform-ignore: true
+  - target: "$.components.schemas.InputCollectorBase.properties.input"
+    update:
+      description: 'Input configuration for a collection job. Set type to "collection".'
+  - target: "$.components.schemas.InputCollectorBase.properties.input.properties.type"
+    update:
+      x-terraform-enum-validator: true
   - target: "$.components.schemas.InputCollectorAzureBlob.allOf.1.properties.collector.properties"
     update:
       destructive:

--- a/tests/acceptance/collector_validation_test.go
+++ b/tests/acceptance/collector_validation_test.go
@@ -26,7 +26,8 @@ resource "criblio_collector" "s3" {
     }
   }
 }`,
-			PlanOnly: true,
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
 		}},
 	})
 }
@@ -53,7 +54,8 @@ resource "criblio_collector" "s3" {
     }
   }
 }`,
-			PlanOnly: true,
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
 		}},
 	})
 }
@@ -106,7 +108,8 @@ resource "criblio_collector" "rest" {
     }
   }
 }`,
-			PlanOnly: true,
+			PlanOnly:           true,
+			ExpectNonEmptyPlan: true,
 		}},
 	})
 }

--- a/tests/acceptance/collector_validation_test.go
+++ b/tests/acceptance/collector_validation_test.go
@@ -1,0 +1,112 @@
+package tests
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestCollectorS3InputRemainsOptional(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: providerFactory,
+		Steps: []resource.TestStep{{
+			Config: `
+resource "criblio_collector" "s3" {
+  id       = "collector-without-input"
+  group_id = "default"
+
+  input_collector_s3 = {
+    collector = {
+      type = "s3"
+      conf = {
+        aws_authentication_method = "auto"
+        bucket                    = "test-bucket"
+      }
+    }
+  }
+}`,
+			PlanOnly: true,
+		}},
+	})
+}
+
+func TestCollectorS3AcceptsValidInput(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: providerFactory,
+		Steps: []resource.TestStep{{
+			Config: `
+resource "criblio_collector" "s3" {
+  id       = "collector-with-input"
+  group_id = "default"
+
+  input_collector_s3 = {
+    input = {
+      type = "collection"
+    }
+    collector = {
+      type = "s3"
+      conf = {
+        aws_authentication_method = "auto"
+        bucket                    = "test-bucket"
+      }
+    }
+  }
+}`,
+			PlanOnly: true,
+		}},
+	})
+}
+
+func TestCollectorRejectsInvalidInputType(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: providerFactory,
+		Steps: []resource.TestStep{{
+			Config: `
+resource "criblio_collector" "s3" {
+  id       = "collector-invalid-input-type"
+  group_id = "default"
+
+  input_collector_s3 = {
+    input = {
+      type = "invalid"
+    }
+    collector = {
+      type = "s3"
+      conf = {
+        aws_authentication_method = "auto"
+        bucket                    = "test-bucket"
+      }
+    }
+  }
+}`,
+			PlanOnly:    true,
+			ExpectError: regexp.MustCompile(`input_collector_s3\.input\.type`),
+		}},
+	})
+}
+
+func TestCollectorRestInputRemainsOptional(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: providerFactory,
+		Steps: []resource.TestStep{{
+			Config: `
+resource "criblio_collector" "rest" {
+  id       = "legacy-rest-discovery"
+  group_id = "default"
+
+  input_collector_rest = {
+    collector = {
+      type = "rest"
+      conf = {
+        authentication = "none"
+        collect_method = "get"
+        collect_url    = "'https://example.com/data'"
+      }
+    }
+  }
+}`,
+			PlanOnly: true,
+		}},
+	})
+}

--- a/tools/codegen/parser/parser.go
+++ b/tools/codegen/parser/parser.go
@@ -504,7 +504,26 @@ func renameProviderField(fields []FieldDef) {
 
 func makeCollectorVariantsOptionalComputed(variants []OneOfVariantDef) {
 	for variantIndex := range variants {
+		inputRequired := false
+		for _, field := range variants[variantIndex].Fields {
+			if field.TerraformName == "input" && field.Required {
+				inputRequired = true
+				break
+			}
+		}
 		makeFieldsOptionalComputed(variants[variantIndex].Fields)
+		if inputRequired {
+			for fieldIndex := range variants[variantIndex].Fields {
+				field := &variants[variantIndex].Fields[fieldIndex]
+				if field.TerraformName == "input" {
+					field.Required = true
+					field.Optional = false
+					field.Computed = false
+					field.OptionalComputed = false
+					break
+				}
+			}
+		}
 		addCollectorPlanModifierHooks(variants[variantIndex].Fields)
 	}
 }

--- a/tools/codegen/parser/parser_test.go
+++ b/tools/codegen/parser/parser_test.go
@@ -37,6 +37,31 @@ discriminator:
 	}
 }
 
+func TestMakeCollectorVariantsOptionalComputedPreservesRequiredInput(t *testing.T) {
+	variants := []OneOfVariantDef{{
+		Fields: []FieldDef{
+			{TerraformName: "id", Required: true},
+			{TerraformName: "input", Type: "object", Required: true},
+			{TerraformName: "collector", Type: "object", Required: true},
+		},
+	}}
+
+	makeCollectorVariantsOptionalComputed(variants)
+
+	id := fieldByTFName(t, variants[0].Fields, "id")
+	if id.Required || !id.Optional || !id.Computed {
+		t.Fatalf("id flags = required:%v optional:%v computed:%v", id.Required, id.Optional, id.Computed)
+	}
+	input := fieldByTFName(t, variants[0].Fields, "input")
+	if !input.Required || input.Optional || input.Computed || input.OptionalComputed {
+		t.Fatalf("input flags = required:%v optional:%v computed:%v optionalComputed:%v", input.Required, input.Optional, input.Computed, input.OptionalComputed)
+	}
+	collector := fieldByTFName(t, variants[0].Fields, "collector")
+	if collector.Required || !collector.Optional || !collector.Computed {
+		t.Fatalf("collector flags = required:%v optional:%v computed:%v", collector.Required, collector.Optional, collector.Computed)
+	}
+}
+
 func TestParseCertificateResource(t *testing.T) {
 	resources, err := ParseFile(filepath.Join("..", "testdata", "fixture.yml"))
 	if err != nil {

--- a/tools/codegen/render_test.go
+++ b/tools/codegen/render_test.go
@@ -1103,6 +1103,11 @@ func TestCollectorMarshalIncludesSavedJobType(t *testing.T) {
 		FileStem:   "collector",
 		TypeName:   "criblio_collector",
 		StructName: "Collector",
+		OneOfVariants: []parser.OneOfVariantDef{{
+			GoName:        "InputCollectorRest",
+			TerraformName: "input_collector_rest",
+			ModelName:     "InputCollectorRestModel",
+		}},
 		Fields: []parser.FieldDef{
 			{
 				APIName:       "id",
@@ -1122,6 +1127,8 @@ func TestCollectorMarshalIncludesSavedJobType(t *testing.T) {
 	got := string(content)
 
 	assertContains(t, got, `output["type"] = "collection"`)
+	assertContains(t, got, `input, ok := output["input"].(map[string]any)`)
+	assertContains(t, got, `input["type"] = "collection"`)
 }
 
 func TestPrimitiveArrayFieldsPreserveElementTypes(t *testing.T) {

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -1088,6 +1088,14 @@ func (m {{ .ModelName }}) terraformPayload() (map[string]any, error) {
 		output["{{ .APIName }}"] = "{{ index .Enum 0 }}"
 	}
 {{- end }}
+{{- if eq $.StructName "Collector" }}
+	input, ok := output["input"].(map[string]any)
+	if !ok {
+		input = map[string]any{}
+	}
+	input["type"] = "collection"
+	output["input"] = input
+{{- end }}
 	return output, nil
 }
 

--- a/tools/import-cli/internal/hcl/cty.go
+++ b/tools/import-cli/internal/hcl/cty.go
@@ -37,6 +37,102 @@ func ValueToCty(v Value) (cty.Value, error) {
 	return ctyReplaceUnknownWithNullForHCL(out)
 }
 
+// pruneNullCollectionPlaceholders removes null values introduced while cty
+// homogenizes sibling objects. Null object attributes and null list elements
+// are omitted from generated Terraform configuration.
+func pruneNullCollectionPlaceholders(v cty.Value, pruneEmptyCollections bool) cty.Value {
+	if !v.IsKnown() {
+		return v
+	}
+	if v.IsNull() {
+		return v
+	}
+	if v.Type().IsObjectType() || v.Type().IsMapType() {
+		values := make(map[string]cty.Value)
+		iterator := v.ElementIterator()
+		for iterator.Next() {
+			key, child := iterator.Element()
+			child = pruneNullCollectionPlaceholders(child, pruneEmptyCollections)
+			if child.IsNull() || (pruneEmptyCollections && isEmptyCtySequence(child)) {
+				continue
+			}
+			values[key.AsString()] = child
+		}
+		if v.Type().IsMapType() {
+			if len(values) == 0 {
+				return cty.MapValEmpty(v.Type().ElementType())
+			}
+			if ctyMapValuesHaveSameType(values) {
+				return cty.MapVal(values)
+			}
+			return cty.ObjectVal(values)
+		}
+		return cty.ObjectVal(values)
+	}
+	if v.Type().IsListType() || v.Type().IsTupleType() || v.Type().IsSetType() {
+		values := make([]cty.Value, 0, v.LengthInt())
+		iterator := v.ElementIterator()
+		for iterator.Next() {
+			_, child := iterator.Element()
+			child = pruneNullCollectionPlaceholders(child, pruneEmptyCollections)
+			if child.IsNull() {
+				continue
+			}
+			values = append(values, child)
+		}
+		if len(values) == 0 {
+			if v.Type().IsListType() {
+				return cty.ListValEmpty(v.Type().ElementType())
+			}
+			if v.Type().IsSetType() {
+				return cty.SetValEmpty(v.Type().ElementType())
+			}
+			return cty.EmptyTupleVal
+		}
+		if v.Type().IsSetType() {
+			if allSameType(values) {
+				return cty.SetVal(values)
+			}
+			return cty.TupleVal(values)
+		}
+		if v.Type().IsTupleType() {
+			return cty.TupleVal(values)
+		}
+		if cty.CanListVal(values) {
+			return cty.ListVal(values)
+		}
+		return cty.TupleVal(values)
+	}
+	return v
+}
+
+func ctyMapValuesHaveSameType(values map[string]cty.Value) bool {
+	var firstType cty.Type
+	first := true
+	for _, value := range values {
+		if first {
+			firstType = value.Type()
+			first = false
+			continue
+		}
+		if !value.Type().Equals(firstType) {
+			return false
+		}
+	}
+	return true
+}
+
+func isEmptyCtySequence(v cty.Value) bool {
+	if !v.IsKnown() || v.IsNull() {
+		return false
+	}
+	typeOfValue := v.Type()
+	if !typeOfValue.IsListType() && !typeOfValue.IsSetType() && !typeOfValue.IsTupleType() {
+		return false
+	}
+	return v.LengthInt() == 0
+}
+
 func valueToCtyInner(v Value) (cty.Value, error) {
 	switch v.Kind {
 	case KindNull:
@@ -600,18 +696,15 @@ func pruneDefaultValueTimerangeEarliestLatest(inner cty.Value) (cty.Value, error
 	return out, nil
 }
 
-// normalizeAndPruneList normalizes list-of-maps (union keys), prunes nulls, and re-normalizes.
+// normalizeAndPruneList normalizes list-of-maps without changing null values.
 // cty requires all list elements to have the same type; optional/omitted attributes cause object types to differ.
 func normalizeAndPruneList(v Value) Value {
-	v = normalizeListOfMaps(v)
-	v = PruneNulls(v)
-	v = normalizeListOfMaps(v)
-	return v
+	return normalizeListOfMaps(v)
 }
 
-// listToCtyElems converts each list element to cty.Value. Do not call PruneNulls here:
-// normalizeAndPruneList already aligned keys across elements with explicit nulls; pruning
-// again drops union branches and yields inconsistent object types per element (cty.ListVal panics).
+// listToCtyElems converts each list element to cty.Value. Do not prune nulls here:
+// normalizeAndPruneList aligned keys across elements with explicit nulls; pruning them
+// drops union branches and yields inconsistent object types per element.
 func listToCtyElems(list []Value) ([]cty.Value, error) {
 	elems := make([]cty.Value, 0, len(list))
 	for i, el := range list {

--- a/tools/import-cli/internal/hcl/cty_test.go
+++ b/tools/import-cli/internal/hcl/cty_test.go
@@ -8,6 +8,69 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+func TestPruneNullCollectionPlaceholdersPreservesEmptyCollectionsAndTypes(t *testing.T) {
+	input := cty.ObjectVal(map[string]cty.Value{
+		"empty_list": cty.ListValEmpty(cty.String),
+		"empty_map":  cty.MapValEmpty(cty.String),
+		"null_value": cty.NullVal(cty.String),
+		"set": cty.SetVal([]cty.Value{
+			cty.StringVal("kept"),
+			cty.NullVal(cty.String),
+		}),
+	})
+
+	got := pruneNullCollectionPlaceholders(input, false)
+
+	require.True(t, got.Type().HasAttribute("empty_list"))
+	require.True(t, got.GetAttr("empty_list").Type().IsListType())
+	require.True(t, got.Type().HasAttribute("empty_map"))
+	require.True(t, got.GetAttr("empty_map").Type().IsMapType())
+	require.False(t, got.Type().HasAttribute("null_value"))
+	require.True(t, got.GetAttr("set").Type().IsSetType())
+	require.Equal(t, 1, got.GetAttr("set").LengthInt())
+}
+
+func TestPruneNullCollectionPlaceholdersHandlesHeterogeneousMapAndSet(t *testing.T) {
+	left := cty.ObjectVal(map[string]cty.Value{
+		"left":  cty.StringVal("value"),
+		"right": cty.NullVal(cty.String),
+	})
+	right := cty.ObjectVal(map[string]cty.Value{
+		"left":  cty.NullVal(cty.String),
+		"right": cty.StringVal("value"),
+	})
+	input := cty.ObjectVal(map[string]cty.Value{
+		"map": cty.MapVal(map[string]cty.Value{"a": left, "b": right}),
+		"set": cty.SetVal([]cty.Value{left, right}),
+	})
+
+	var got cty.Value
+	require.NotPanics(t, func() {
+		got = pruneNullCollectionPlaceholders(input, false)
+	})
+	require.True(t, got.GetAttr("map").Type().IsObjectType())
+	require.True(t, got.GetAttr("set").Type().IsTupleType())
+}
+
+func TestValueToCtyPreservesNullListElements(t *testing.T) {
+	got, err := ValueToCty(Value{Kind: KindList, List: []Value{
+		{Kind: KindString, String: "before"},
+		{Kind: KindNull},
+		{Kind: KindString, String: "after"},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, 3, got.LengthInt())
+	require.True(t, got.Index(cty.NumberIntVal(1)).IsNull())
+
+	objects, err := ValueToCty(Value{Kind: KindList, List: []Value{{
+		Kind: KindMap,
+		Map:  map[string]Value{"optional": {Kind: KindNull}},
+	}}})
+	require.NoError(t, err)
+	require.True(t, objects.Index(cty.NumberIntVal(0)).Type().HasAttribute("optional"))
+	require.True(t, objects.Index(cty.NumberIntVal(0)).GetAttr("optional").IsNull())
+}
+
 // Regression: search dashboard elements are a list of one-of maps (e.g. dashboard_element_input
 // vs dashboard_element_visualization). normalizeListOfMaps adds null for absent branches;
 // an extra PruneNulls on each element before ValueToCty removed those nulls and caused

--- a/tools/import-cli/internal/hcl/resource.go
+++ b/tools/import-cli/internal/hcl/resource.go
@@ -97,7 +97,7 @@ func ResourceBlock(typeName, name string, attrs map[string]Value, opts *Resource
 			v = PruneEmptyLists(v)
 		}
 		if skipNull {
-			v = PruneNulls(v)
+			v = PruneNullPlaceholders(v)
 		}
 		if skipNull && v.Kind == KindNull {
 			continue
@@ -113,6 +113,10 @@ func ResourceBlock(typeName, name string, attrs map[string]Value, opts *Resource
 		ctyVal, err := ValueToCty(v)
 		if err != nil {
 			return nil, fmt.Errorf("attribute %q: %w", k, err)
+		}
+		if skipNull {
+			pruneEmptyCollections := opts.SkipEmptyListAttributes && !attrInList(typeName, k, opts.SkipPruneEmptyListsFor)
+			ctyVal = pruneNullCollectionPlaceholders(ctyVal, pruneEmptyCollections)
 		}
 		if typeName == "criblio_search_dashboard" && k == "elements" {
 			ctyVal, err = PruneSearchDashboardElementsCty(ctyVal)

--- a/tools/import-cli/internal/hcl/resource_test.go
+++ b/tools/import-cli/internal/hcl/resource_test.go
@@ -80,6 +80,43 @@ func TestResourceBlock_list_and_null(t *testing.T) {
 	assert.Contains(t, string(bytes), "tags")
 }
 
+func TestResourceBlockPrunesNullElementsFromNestedSiblingLists(t *testing.T) {
+	validMetadata := Value{Kind: KindMap, Map: map[string]Value{
+		"name":  {Kind: KindString, String: "my"},
+		"value": {Kind: KindString, String: `"name"`},
+	}}
+	attrs := map[string]Value{
+		"input_splunk_hec": {Kind: KindMap, Map: map[string]Value{
+			"auth_tokens": {Kind: KindList, List: []Value{
+				{Kind: KindMap, Map: map[string]Value{
+					"metadata":                 {Kind: KindList, List: []Value{validMetadata}},
+					"allowed_indexes_at_token": {Kind: KindList, List: []Value{{Kind: KindString, String: "main"}}},
+				}},
+				{Kind: KindMap, Map: map[string]Value{
+					"metadata":                 {Kind: KindList, List: []Value{{Kind: KindNull}}},
+					"allowed_indexes_at_token": {Kind: KindList, List: []Value{{Kind: KindNull}}},
+					"description":              {Kind: KindString, String: "fve"},
+					"token_secret":             {Kind: KindNull},
+				}},
+				{Kind: KindMap, Map: map[string]Value{
+					"metadata":                 {Kind: KindList, List: []Value{{Kind: KindNull}}},
+					"allowed_indexes_at_token": {Kind: KindList, List: []Value{{Kind: KindString, String: "myindex"}, {Kind: KindString, String: "anotherindex"}}},
+					"description":              {Kind: KindNull},
+					"token_secret":             {Kind: KindNull},
+				}},
+			}},
+		}},
+	}
+
+	generated, err := ResourceBlockBytes("criblio_source", "hec", attrs, DefaultResourceBlockOptions())
+	require.NoError(t, err)
+	source := string(generated)
+	assert.NotContains(t, source, "null")
+	assert.Contains(t, source, `name  = "my"`)
+	assert.Equal(t, 1, strings.Count(source, "metadata"))
+	assert.Equal(t, 2, strings.Count(source, "allowed_indexes_at_token"))
+}
+
 func TestResourceBlock_skip_null_option(t *testing.T) {
 	attrs := map[string]Value{
 		"id":       {Kind: KindString, String: "x"},
@@ -252,4 +289,39 @@ func TestResourceBlock_preservesConfiguredEmptyMaps(t *testing.T) {
 	got, err := ResourceBlockBytes("criblio_mapping_ruleset", "test", attrs, opts)
 	require.NoError(t, err)
 	assert.Contains(t, string(got), "conf = {}")
+}
+
+func TestResourceBlockRendersPrunedHeterogeneousObjectsAsValidHCL(t *testing.T) {
+	attrs := map[string]Value{
+		"items": {Kind: KindList, List: []Value{
+			{Kind: KindMap, Map: map[string]Value{
+				"left":  {Kind: KindString, String: "value"},
+				"right": {Kind: KindNull},
+			}},
+			{Kind: KindMap, Map: map[string]Value{
+				"left":  {Kind: KindNull},
+				"right": {Kind: KindString, String: "value"},
+			}},
+		}},
+	}
+
+	got, err := ResourceBlockBytes("criblio_example", "test", attrs, DefaultResourceBlockOptions())
+	require.NoError(t, err)
+	require.NoError(t, ParseHCL(got, "test.tf"))
+	assert.NotContains(t, string(got), "null")
+	assert.Contains(t, string(got), `left = "value"`)
+	assert.Contains(t, string(got), `right = "value"`)
+}
+
+func TestResourceBlockAlwaysEmitsConfiguredEmptyLists(t *testing.T) {
+	attrs := map[string]Value{
+		"subscriptions": {Kind: KindList, List: []Value{}},
+		"destinations":  {Kind: KindList, List: []Value{}},
+	}
+
+	got, err := ResourceBlockBytes("criblio_project", "test", attrs, DefaultResourceBlockOptions())
+	require.NoError(t, err)
+	require.NoError(t, ParseHCL(got, "test.tf"))
+	assert.Contains(t, string(got), "subscriptions = []")
+	assert.Contains(t, string(got), "destinations  = []")
 }

--- a/tools/import-cli/internal/hcl/value.go
+++ b/tools/import-cli/internal/hcl/value.go
@@ -137,10 +137,42 @@ func PruneNulls(v Value) Value {
 		}
 		return Value{Kind: KindMap, Map: out}
 	}
-	// KindList: prune each element, keep list length (do not drop null elements).
 	list := make([]Value, len(v.List))
 	for i, el := range v.List {
 		list[i] = PruneNulls(el)
+	}
+	return Value{Kind: KindList, List: list}
+}
+
+// PruneNullPlaceholders removes null map entries, null list elements, and list
+// objects that become empty after their null fields are removed. It is intended
+// for exporter output where null placeholders are not valid configuration.
+func PruneNullPlaceholders(v Value) Value {
+	if v.Kind != KindMap && v.Kind != KindList {
+		return v
+	}
+	if v.Kind == KindMap {
+		out := make(map[string]Value, len(v.Map))
+		for key, child := range v.Map {
+			if child.Kind == KindNull {
+				continue
+			}
+			pruned := PruneNullPlaceholders(child)
+			if child.Kind == KindList && len(child.List) > 0 && pruned.Kind == KindList && len(pruned.List) == 0 {
+				continue
+			}
+			out[key] = pruned
+		}
+		return Value{Kind: KindMap, Map: out}
+	}
+	list := make([]Value, 0, len(v.List))
+	for _, child := range v.List {
+		wasNonEmptyMap := child.Kind == KindMap && len(child.Map) > 0
+		child = PruneNullPlaceholders(child)
+		if child.Kind == KindNull || (wasNonEmptyMap && child.Kind == KindMap && len(child.Map) == 0) {
+			continue
+		}
+		list = append(list, child)
 	}
 	return Value{Kind: KindList, List: list}
 }

--- a/tools/import-cli/internal/hcl/value_test.go
+++ b/tools/import-cli/internal/hcl/value_test.go
@@ -667,6 +667,55 @@ func TestReplaceSecretValuesWithVariableRefs_masks_all_extra_http_headers(t *tes
 	assert.Equal(t, "X-google-api-key", header0.Map["name"].String, "header name value should be unchanged")
 }
 
+func TestPruneNullPlaceholdersRemovesInvalidListPlaceholders(t *testing.T) {
+	value := Value{
+		Kind: KindMap,
+		Map: map[string]Value{
+			"metadata": {
+				Kind: KindList,
+				List: []Value{
+					{Kind: KindNull},
+					{Kind: KindMap, Map: map[string]Value{
+						"name":  {Kind: KindNull},
+						"value": {Kind: KindNull},
+					}},
+					{Kind: KindMap, Map: map[string]Value{
+						"name":  {Kind: KindString, String: "index"},
+						"value": {Kind: KindString, String: "'main'"},
+					}},
+				},
+			},
+			"allowed_indexes_at_token": {
+				Kind: KindList,
+				List: []Value{{Kind: KindNull}},
+			},
+		},
+	}
+
+	pruned := PruneNullPlaceholders(value)
+
+	metadata := pruned.Map["metadata"]
+	require.Len(t, metadata.List, 1)
+	assert.Equal(t, "index", metadata.List[0].Map["name"].String)
+	assert.Empty(t, pruned.Map["allowed_indexes_at_token"].List)
+}
+
+func TestPruneNullPlaceholdersPreservesGenuinelyEmptyCollections(t *testing.T) {
+	value := Value{Kind: KindMap, Map: map[string]Value{
+		"empty_list": {Kind: KindList, List: []Value{}},
+		"objects": {Kind: KindList, List: []Value{
+			{Kind: KindMap, Map: map[string]Value{}},
+		}},
+	}}
+
+	pruned := PruneNullPlaceholders(value)
+
+	require.Contains(t, pruned.Map, "empty_list")
+	assert.Empty(t, pruned.Map["empty_list"].List)
+	require.Len(t, pruned.Map["objects"].List, 1)
+	assert.Empty(t, pruned.Map["objects"].List[0].Map)
+}
+
 func TestPruneEmptyLists_filters_urls_with_empty_url(t *testing.T) {
 	// Simulate what ModelToValue produces for output_webhook with empty urls
 	// When loadBalanced=false, the model contains urls: [{url: "", weight: 1}]


### PR DESCRIPTION
- Automatically adds input = { type = "collection" } for all collectors while preserving backward compatibility.
- Validates explicit collector input types and preserves configured input fields.
- Removes invalid [null] values from Import CLI output while preserving valid empty collections.
- Adds schema, payload, HCL rendering, and acceptance regression tests.