### PR TITLE
fixing preserve state when API returns computed var.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -22,7 +22,7 @@ terraform {
   required_providers {
     criblio = {
       source  = "criblio/criblio"
-      version = "1.25.65"
+      version = "1.25.66"
     }
   }
 }

--- a/docs/resources/pack_source.md
+++ b/docs/resources/pack_source.md
@@ -46,7 +46,7 @@ resource "criblio_pack_source" "my_packsource" {
     pipeline = "my_pipeline"
     port     = 7592
     pq = {
-      commit_frequency = 7
+      commit_frequency = 42
       compress         = "none"
       max_buffer_size  = 51
       max_file_size    = "100 MB"
@@ -122,7 +122,7 @@ resource "criblio_pack_source" "my_packsource_syslog" {
     octet_counting = false
     pipeline       = "my_pipeline"
     pq = {
-      commit_frequency = 7
+      commit_frequency = 42
       compress         = "none"
       max_buffer_size  = 51
       max_file_size    = "100 MB"

--- a/internal/provider/destination_resource.go
+++ b/internal/provider/destination_resource.go
@@ -44872,9 +44872,11 @@ func applyDestinationAPIToState(api *DestinationModel, state *DestinationModel, 
 		if elementType := state.OutputRouter.Streamtags.ElementType(context.Background()); elementType == nil {
 			state.OutputRouter.Streamtags = types.ListNull(types.StringType)
 		}
-		if !preserveInputs || (fillMissingInputs && (state.OutputRouter.Rules.IsNull() || state.OutputRouter.Rules.IsUnknown())) {
+		if !preserveInputs || state.OutputRouter.Rules.IsUnknown() || (fillMissingInputs && state.OutputRouter.Rules.IsNull()) {
 			if !api.OutputRouter.Rules.IsNull() && !api.OutputRouter.Rules.IsUnknown() {
 				state.OutputRouter.Rules = api.OutputRouter.Rules
+			} else if state.OutputRouter.Rules.IsUnknown() {
+				state.OutputRouter.Rules = types.ListNull(types.ObjectType{AttrTypes: OutputRouterRulesAttrTypes()})
 			}
 		}
 		if state.OutputRouter.Rules.IsNull() || state.OutputRouter.Rules.IsUnknown() {

--- a/internal/provider/notification_target_resource.go
+++ b/internal/provider/notification_target_resource.go
@@ -590,9 +590,11 @@ func applyNotificationTargetAPIToState(api *NotificationTargetModel, state *Noti
 		} else if state.WebhookTarget.Type.IsNull() || state.WebhookTarget.Type.IsUnknown() {
 			state.WebhookTarget.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.WebhookTarget.SystemFields.IsNull() || state.WebhookTarget.SystemFields.IsUnknown())) {
+		if !preserveInputs || state.WebhookTarget.SystemFields.IsUnknown() || (fillMissingInputs && state.WebhookTarget.SystemFields.IsNull()) {
 			if !api.WebhookTarget.SystemFields.IsNull() && !api.WebhookTarget.SystemFields.IsUnknown() {
 				state.WebhookTarget.SystemFields = api.WebhookTarget.SystemFields
+			} else if state.WebhookTarget.SystemFields.IsUnknown() {
+				state.WebhookTarget.SystemFields = types.ListNull(types.StringType)
 			}
 		}
 		if elementType := state.WebhookTarget.SystemFields.ElementType(context.Background()); elementType == nil {
@@ -648,9 +650,11 @@ func applyNotificationTargetAPIToState(api *NotificationTargetModel, state *Noti
 		} else if state.PagerDutyTarget.Type.IsNull() || state.PagerDutyTarget.Type.IsUnknown() {
 			state.PagerDutyTarget.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.PagerDutyTarget.SystemFields.IsNull() || state.PagerDutyTarget.SystemFields.IsUnknown())) {
+		if !preserveInputs || state.PagerDutyTarget.SystemFields.IsUnknown() || (fillMissingInputs && state.PagerDutyTarget.SystemFields.IsNull()) {
 			if !api.PagerDutyTarget.SystemFields.IsNull() && !api.PagerDutyTarget.SystemFields.IsUnknown() {
 				state.PagerDutyTarget.SystemFields = api.PagerDutyTarget.SystemFields
+			} else if state.PagerDutyTarget.SystemFields.IsUnknown() {
+				state.PagerDutyTarget.SystemFields = types.ListNull(types.StringType)
 			}
 		}
 		if elementType := state.PagerDutyTarget.SystemFields.ElementType(context.Background()); elementType == nil {
@@ -696,9 +700,11 @@ func applyNotificationTargetAPIToState(api *NotificationTargetModel, state *Noti
 		} else if state.SlackTarget.Type.IsNull() || state.SlackTarget.Type.IsUnknown() {
 			state.SlackTarget.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.SlackTarget.SystemFields.IsNull() || state.SlackTarget.SystemFields.IsUnknown())) {
+		if !preserveInputs || state.SlackTarget.SystemFields.IsUnknown() || (fillMissingInputs && state.SlackTarget.SystemFields.IsNull()) {
 			if !api.SlackTarget.SystemFields.IsNull() && !api.SlackTarget.SystemFields.IsUnknown() {
 				state.SlackTarget.SystemFields = api.SlackTarget.SystemFields
+			} else if state.SlackTarget.SystemFields.IsUnknown() {
+				state.SlackTarget.SystemFields = types.ListNull(types.StringType)
 			}
 		}
 		if elementType := state.SlackTarget.SystemFields.ElementType(context.Background()); elementType == nil {
@@ -724,9 +730,11 @@ func applyNotificationTargetAPIToState(api *NotificationTargetModel, state *Noti
 		} else if state.SnsTarget.Type.IsNull() || state.SnsTarget.Type.IsUnknown() {
 			state.SnsTarget.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.SnsTarget.SystemFields.IsNull() || state.SnsTarget.SystemFields.IsUnknown())) {
+		if !preserveInputs || state.SnsTarget.SystemFields.IsUnknown() || (fillMissingInputs && state.SnsTarget.SystemFields.IsNull()) {
 			if !api.SnsTarget.SystemFields.IsNull() && !api.SnsTarget.SystemFields.IsUnknown() {
 				state.SnsTarget.SystemFields = api.SnsTarget.SystemFields
+			} else if state.SnsTarget.SystemFields.IsUnknown() {
+				state.SnsTarget.SystemFields = types.ListNull(types.StringType)
 			}
 		}
 		if elementType := state.SnsTarget.SystemFields.ElementType(context.Background()); elementType == nil {
@@ -815,9 +823,11 @@ func applyNotificationTargetAPIToState(api *NotificationTargetModel, state *Noti
 		} else if state.SmtpTarget.Type.IsNull() || state.SmtpTarget.Type.IsUnknown() {
 			state.SmtpTarget.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.SmtpTarget.SystemFields.IsNull() || state.SmtpTarget.SystemFields.IsUnknown())) {
+		if !preserveInputs || state.SmtpTarget.SystemFields.IsUnknown() || (fillMissingInputs && state.SmtpTarget.SystemFields.IsNull()) {
 			if !api.SmtpTarget.SystemFields.IsNull() && !api.SmtpTarget.SystemFields.IsUnknown() {
 				state.SmtpTarget.SystemFields = api.SmtpTarget.SystemFields
+			} else if state.SmtpTarget.SystemFields.IsUnknown() {
+				state.SmtpTarget.SystemFields = types.ListNull(types.StringType)
 			}
 		}
 		if elementType := state.SmtpTarget.SystemFields.ElementType(context.Background()); elementType == nil {

--- a/internal/provider/notification_target_resource_test.go
+++ b/internal/provider/notification_target_resource_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -20,5 +21,58 @@ func TestNotificationTargetImportNormalizesSystemFieldsElementType(t *testing.T)
 	elementType := state.SnsTarget.SystemFields.ElementType(context.Background())
 	if elementType == nil || !elementType.Equal(types.StringType) {
 		t.Fatalf("expected string list element type, got %v", elementType)
+	}
+}
+
+func TestNotificationTargetCreateResolvesUnknownSystemFieldsFromAPI(t *testing.T) {
+	api := NotificationTargetModel{
+		SlackTarget: &SlackTargetModel{
+			SystemFields: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("cribl_pipe")}),
+		},
+	}
+	state := NotificationTargetModel{
+		SlackTarget: &SlackTargetModel{SystemFields: types.ListUnknown(types.StringType)},
+	}
+
+	applyNotificationTargetAPIToState(&api, &state, true, false)
+
+	if state.SlackTarget.SystemFields.IsUnknown() {
+		t.Fatal("expected system_fields to be known after create")
+	}
+	if !state.SlackTarget.SystemFields.Equal(api.SlackTarget.SystemFields) {
+		t.Fatalf("system_fields = %v, want %v", state.SlackTarget.SystemFields, api.SlackTarget.SystemFields)
+	}
+}
+
+func TestNotificationTargetCreateNormalizesUnknownSystemFieldsWhenAPIOmitsIt(t *testing.T) {
+	api := NotificationTargetModel{
+		SlackTarget: &SlackTargetModel{SystemFields: types.ListNull(types.StringType)},
+	}
+	state := NotificationTargetModel{
+		SlackTarget: &SlackTargetModel{SystemFields: types.ListUnknown(types.StringType)},
+	}
+
+	applyNotificationTargetAPIToState(&api, &state, true, false)
+
+	if !state.SlackTarget.SystemFields.IsNull() {
+		t.Fatalf("system_fields = %v, want null", state.SlackTarget.SystemFields)
+	}
+}
+
+func TestNotificationTargetCreatePreservesConfiguredSystemFields(t *testing.T) {
+	configured := types.ListValueMust(types.StringType, []attr.Value{types.StringValue("configured")})
+	api := NotificationTargetModel{
+		SlackTarget: &SlackTargetModel{
+			SystemFields: types.ListValueMust(types.StringType, []attr.Value{types.StringValue("api")}),
+		},
+	}
+	state := NotificationTargetModel{
+		SlackTarget: &SlackTargetModel{SystemFields: configured},
+	}
+
+	applyNotificationTargetAPIToState(&api, &state, true, false)
+
+	if !state.SlackTarget.SystemFields.Equal(configured) {
+		t.Fatalf("system_fields = %v, want configured value %v", state.SlackTarget.SystemFields, configured)
 	}
 }

--- a/internal/provider/pack_destination_resource.go
+++ b/internal/provider/pack_destination_resource.go
@@ -44893,9 +44893,11 @@ func applyPackDestinationAPIToState(api *PackDestinationModel, state *PackDestin
 		if elementType := state.OutputRouter.Streamtags.ElementType(context.Background()); elementType == nil {
 			state.OutputRouter.Streamtags = types.ListNull(types.StringType)
 		}
-		if !preserveInputs || (fillMissingInputs && (state.OutputRouter.Rules.IsNull() || state.OutputRouter.Rules.IsUnknown())) {
+		if !preserveInputs || state.OutputRouter.Rules.IsUnknown() || (fillMissingInputs && state.OutputRouter.Rules.IsNull()) {
 			if !api.OutputRouter.Rules.IsNull() && !api.OutputRouter.Rules.IsUnknown() {
 				state.OutputRouter.Rules = api.OutputRouter.Rules
+			} else if state.OutputRouter.Rules.IsUnknown() {
+				state.OutputRouter.Rules = types.ListNull(types.ObjectType{AttrTypes: OutputRouterRulesAttrTypes()})
 			}
 		}
 		if state.OutputRouter.Rules.IsNull() || state.OutputRouter.Rules.IsUnknown() {

--- a/internal/provider/search_dataset_provider_resource.go
+++ b/internal/provider/search_dataset_provider_resource.go
@@ -1796,9 +1796,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIHttpProvider.Type.IsNull() || state.APIHttpProvider.Type.IsUnknown() {
 			state.APIHttpProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIHttpProvider.Description.IsNull() || state.APIHttpProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIHttpProvider.Description.IsUnknown() || (fillMissingInputs && state.APIHttpProvider.Description.IsNull()) {
 			if !api.APIHttpProvider.Description.IsNull() && !api.APIHttpProvider.Description.IsUnknown() {
 				state.APIHttpProvider.Description = api.APIHttpProvider.Description
+			} else if state.APIHttpProvider.Description.IsUnknown() {
+				state.APIHttpProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIHttpProvider.AvailableEndpoints.IsNull() && !api.APIHttpProvider.AvailableEndpoints.IsUnknown() {
@@ -1831,9 +1833,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIAwsProvider.Type.IsNull() || state.APIAwsProvider.Type.IsUnknown() {
 			state.APIAwsProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIAwsProvider.Description.IsNull() || state.APIAwsProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIAwsProvider.Description.IsUnknown() || (fillMissingInputs && state.APIAwsProvider.Description.IsNull()) {
 			if !api.APIAwsProvider.Description.IsNull() && !api.APIAwsProvider.Description.IsUnknown() {
 				state.APIAwsProvider.Description = api.APIAwsProvider.Description
+			} else if state.APIAwsProvider.Description.IsUnknown() {
+				state.APIAwsProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIAwsProvider.AccountConfigs.IsNull() && !api.APIAwsProvider.AccountConfigs.IsUnknown() {
@@ -1861,9 +1865,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIAzureProvider.Type.IsNull() || state.APIAzureProvider.Type.IsUnknown() {
 			state.APIAzureProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIAzureProvider.Description.IsNull() || state.APIAzureProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIAzureProvider.Description.IsUnknown() || (fillMissingInputs && state.APIAzureProvider.Description.IsNull()) {
 			if !api.APIAzureProvider.Description.IsNull() && !api.APIAzureProvider.Description.IsUnknown() {
 				state.APIAzureProvider.Description = api.APIAzureProvider.Description
+			} else if state.APIAzureProvider.Description.IsUnknown() {
+				state.APIAzureProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIAzureProvider.AccountConfigs.IsNull() && !api.APIAzureProvider.AccountConfigs.IsUnknown() {
@@ -1891,9 +1897,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIGcpProvider.Type.IsNull() || state.APIGcpProvider.Type.IsUnknown() {
 			state.APIGcpProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIGcpProvider.Description.IsNull() || state.APIGcpProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIGcpProvider.Description.IsUnknown() || (fillMissingInputs && state.APIGcpProvider.Description.IsNull()) {
 			if !api.APIGcpProvider.Description.IsNull() && !api.APIGcpProvider.Description.IsUnknown() {
 				state.APIGcpProvider.Description = api.APIGcpProvider.Description
+			} else if state.APIGcpProvider.Description.IsUnknown() {
+				state.APIGcpProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIGcpProvider.AccountConfigs.IsNull() && !api.APIGcpProvider.AccountConfigs.IsUnknown() {
@@ -1921,9 +1929,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIGoogleWorkspaceProvider.Type.IsNull() || state.APIGoogleWorkspaceProvider.Type.IsUnknown() {
 			state.APIGoogleWorkspaceProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIGoogleWorkspaceProvider.Description.IsNull() || state.APIGoogleWorkspaceProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIGoogleWorkspaceProvider.Description.IsUnknown() || (fillMissingInputs && state.APIGoogleWorkspaceProvider.Description.IsNull()) {
 			if !api.APIGoogleWorkspaceProvider.Description.IsNull() && !api.APIGoogleWorkspaceProvider.Description.IsUnknown() {
 				state.APIGoogleWorkspaceProvider.Description = api.APIGoogleWorkspaceProvider.Description
+			} else if state.APIGoogleWorkspaceProvider.Description.IsUnknown() {
+				state.APIGoogleWorkspaceProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIGoogleWorkspaceProvider.AccountConfigs.IsNull() && !api.APIGoogleWorkspaceProvider.AccountConfigs.IsUnknown() {
@@ -1951,9 +1961,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIMsGraphProvider.Type.IsNull() || state.APIMsGraphProvider.Type.IsUnknown() {
 			state.APIMsGraphProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIMsGraphProvider.Description.IsNull() || state.APIMsGraphProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIMsGraphProvider.Description.IsUnknown() || (fillMissingInputs && state.APIMsGraphProvider.Description.IsNull()) {
 			if !api.APIMsGraphProvider.Description.IsNull() && !api.APIMsGraphProvider.Description.IsUnknown() {
 				state.APIMsGraphProvider.Description = api.APIMsGraphProvider.Description
+			} else if state.APIMsGraphProvider.Description.IsUnknown() {
+				state.APIMsGraphProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIMsGraphProvider.AccountConfigs.IsNull() && !api.APIMsGraphProvider.AccountConfigs.IsUnknown() {
@@ -1981,9 +1993,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIOktaProvider.Type.IsNull() || state.APIOktaProvider.Type.IsUnknown() {
 			state.APIOktaProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIOktaProvider.Description.IsNull() || state.APIOktaProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIOktaProvider.Description.IsUnknown() || (fillMissingInputs && state.APIOktaProvider.Description.IsNull()) {
 			if !api.APIOktaProvider.Description.IsNull() && !api.APIOktaProvider.Description.IsUnknown() {
 				state.APIOktaProvider.Description = api.APIOktaProvider.Description
+			} else if state.APIOktaProvider.Description.IsUnknown() {
+				state.APIOktaProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIOktaProvider.AccountConfigs.IsNull() && !api.APIOktaProvider.AccountConfigs.IsUnknown() {
@@ -2011,9 +2025,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APITailscaleProvider.Type.IsNull() || state.APITailscaleProvider.Type.IsUnknown() {
 			state.APITailscaleProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APITailscaleProvider.Description.IsNull() || state.APITailscaleProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APITailscaleProvider.Description.IsUnknown() || (fillMissingInputs && state.APITailscaleProvider.Description.IsNull()) {
 			if !api.APITailscaleProvider.Description.IsNull() && !api.APITailscaleProvider.Description.IsUnknown() {
 				state.APITailscaleProvider.Description = api.APITailscaleProvider.Description
+			} else if state.APITailscaleProvider.Description.IsUnknown() {
+				state.APITailscaleProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APITailscaleProvider.AccountConfigs.IsNull() && !api.APITailscaleProvider.AccountConfigs.IsUnknown() {
@@ -2041,9 +2057,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIZoomProvider.Type.IsNull() || state.APIZoomProvider.Type.IsUnknown() {
 			state.APIZoomProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIZoomProvider.Description.IsNull() || state.APIZoomProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIZoomProvider.Description.IsUnknown() || (fillMissingInputs && state.APIZoomProvider.Description.IsNull()) {
 			if !api.APIZoomProvider.Description.IsNull() && !api.APIZoomProvider.Description.IsUnknown() {
 				state.APIZoomProvider.Description = api.APIZoomProvider.Description
+			} else if state.APIZoomProvider.Description.IsUnknown() {
+				state.APIZoomProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIZoomProvider.AccountConfigs.IsNull() && !api.APIZoomProvider.AccountConfigs.IsUnknown() {
@@ -2071,9 +2089,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIAzureDataExplorerProvider.Type.IsNull() || state.APIAzureDataExplorerProvider.Type.IsUnknown() {
 			state.APIAzureDataExplorerProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIAzureDataExplorerProvider.Description.IsNull() || state.APIAzureDataExplorerProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIAzureDataExplorerProvider.Description.IsUnknown() || (fillMissingInputs && state.APIAzureDataExplorerProvider.Description.IsNull()) {
 			if !api.APIAzureDataExplorerProvider.Description.IsNull() && !api.APIAzureDataExplorerProvider.Description.IsUnknown() {
 				state.APIAzureDataExplorerProvider.Description = api.APIAzureDataExplorerProvider.Description
+			} else if state.APIAzureDataExplorerProvider.Description.IsUnknown() {
+				state.APIAzureDataExplorerProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIAzureDataExplorerProvider.TenantID.IsNull() && !api.APIAzureDataExplorerProvider.TenantID.IsUnknown() {
@@ -2106,9 +2126,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.SnowflakeProvider.Type.IsNull() || state.SnowflakeProvider.Type.IsUnknown() {
 			state.SnowflakeProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.SnowflakeProvider.Description.IsNull() || state.SnowflakeProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.SnowflakeProvider.Description.IsUnknown() || (fillMissingInputs && state.SnowflakeProvider.Description.IsNull()) {
 			if !api.SnowflakeProvider.Description.IsNull() && !api.SnowflakeProvider.Description.IsUnknown() {
 				state.SnowflakeProvider.Description = api.SnowflakeProvider.Description
+			} else if state.SnowflakeProvider.Description.IsUnknown() {
+				state.SnowflakeProvider.Description = types.StringNull()
 			}
 		}
 		if !api.SnowflakeProvider.AccountIDentifier.IsNull() && !api.SnowflakeProvider.AccountIDentifier.IsUnknown() {
@@ -2156,9 +2178,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.ClickHouseProvider.Type.IsNull() || state.ClickHouseProvider.Type.IsUnknown() {
 			state.ClickHouseProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.ClickHouseProvider.Description.IsNull() || state.ClickHouseProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.ClickHouseProvider.Description.IsUnknown() || (fillMissingInputs && state.ClickHouseProvider.Description.IsNull()) {
 			if !api.ClickHouseProvider.Description.IsNull() && !api.ClickHouseProvider.Description.IsUnknown() {
 				state.ClickHouseProvider.Description = api.ClickHouseProvider.Description
+			} else if state.ClickHouseProvider.Description.IsUnknown() {
+				state.ClickHouseProvider.Description = types.StringNull()
 			}
 		}
 		if !api.ClickHouseProvider.Username.IsNull() && !api.ClickHouseProvider.Username.IsUnknown() {
@@ -2191,9 +2215,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.PrometheusProvider.Type.IsNull() || state.PrometheusProvider.Type.IsUnknown() {
 			state.PrometheusProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.PrometheusProvider.Description.IsNull() || state.PrometheusProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.PrometheusProvider.Description.IsUnknown() || (fillMissingInputs && state.PrometheusProvider.Description.IsNull()) {
 			if !api.PrometheusProvider.Description.IsNull() && !api.PrometheusProvider.Description.IsUnknown() {
 				state.PrometheusProvider.Description = api.PrometheusProvider.Description
+			} else if state.PrometheusProvider.Description.IsUnknown() {
+				state.PrometheusProvider.Description = types.StringNull()
 			}
 		}
 		if !api.PrometheusProvider.Endpoint.IsNull() && !api.PrometheusProvider.Endpoint.IsUnknown() {
@@ -2241,9 +2267,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIOpenSearchProvider.Type.IsNull() || state.APIOpenSearchProvider.Type.IsUnknown() {
 			state.APIOpenSearchProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIOpenSearchProvider.Description.IsNull() || state.APIOpenSearchProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIOpenSearchProvider.Description.IsUnknown() || (fillMissingInputs && state.APIOpenSearchProvider.Description.IsNull()) {
 			if !api.APIOpenSearchProvider.Description.IsNull() && !api.APIOpenSearchProvider.Description.IsUnknown() {
 				state.APIOpenSearchProvider.Description = api.APIOpenSearchProvider.Description
+			} else if state.APIOpenSearchProvider.Description.IsUnknown() {
+				state.APIOpenSearchProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIOpenSearchProvider.Username.IsNull() && !api.APIOpenSearchProvider.Username.IsUnknown() {
@@ -2276,9 +2304,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.APIElasticSearchProvider.Type.IsNull() || state.APIElasticSearchProvider.Type.IsUnknown() {
 			state.APIElasticSearchProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.APIElasticSearchProvider.Description.IsNull() || state.APIElasticSearchProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.APIElasticSearchProvider.Description.IsUnknown() || (fillMissingInputs && state.APIElasticSearchProvider.Description.IsNull()) {
 			if !api.APIElasticSearchProvider.Description.IsNull() && !api.APIElasticSearchProvider.Description.IsUnknown() {
 				state.APIElasticSearchProvider.Description = api.APIElasticSearchProvider.Description
+			} else if state.APIElasticSearchProvider.Description.IsUnknown() {
+				state.APIElasticSearchProvider.Description = types.StringNull()
 			}
 		}
 		if !api.APIElasticSearchProvider.Username.IsNull() && !api.APIElasticSearchProvider.Username.IsUnknown() {
@@ -2331,9 +2361,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.S3Provider.Type.IsNull() || state.S3Provider.Type.IsUnknown() {
 			state.S3Provider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.S3Provider.Description.IsNull() || state.S3Provider.Description.IsUnknown())) {
+		if !preserveInputs || state.S3Provider.Description.IsUnknown() || (fillMissingInputs && state.S3Provider.Description.IsNull()) {
 			if !api.S3Provider.Description.IsNull() && !api.S3Provider.Description.IsUnknown() {
 				state.S3Provider.Description = api.S3Provider.Description
+			} else if state.S3Provider.Description.IsUnknown() {
+				state.S3Provider.Description = types.StringNull()
 			}
 		}
 		if !api.S3Provider.AwsAuthenticationMethod.IsNull() && !api.S3Provider.AwsAuthenticationMethod.IsUnknown() {
@@ -2426,9 +2458,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.CriblLeaderProvider.Type.IsNull() || state.CriblLeaderProvider.Type.IsUnknown() {
 			state.CriblLeaderProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.CriblLeaderProvider.Description.IsNull() || state.CriblLeaderProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.CriblLeaderProvider.Description.IsUnknown() || (fillMissingInputs && state.CriblLeaderProvider.Description.IsNull()) {
 			if !api.CriblLeaderProvider.Description.IsNull() && !api.CriblLeaderProvider.Description.IsUnknown() {
 				state.CriblLeaderProvider.Description = api.CriblLeaderProvider.Description
+			} else if state.CriblLeaderProvider.Description.IsUnknown() {
+				state.CriblLeaderProvider.Description = types.StringNull()
 			}
 		}
 	}
@@ -2446,9 +2480,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.CriblSearchProvider.Type.IsNull() || state.CriblSearchProvider.Type.IsUnknown() {
 			state.CriblSearchProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.CriblSearchProvider.Description.IsNull() || state.CriblSearchProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.CriblSearchProvider.Description.IsUnknown() || (fillMissingInputs && state.CriblSearchProvider.Description.IsNull()) {
 			if !api.CriblSearchProvider.Description.IsNull() && !api.CriblSearchProvider.Description.IsUnknown() {
 				state.CriblSearchProvider.Description = api.CriblSearchProvider.Description
+			} else if state.CriblSearchProvider.Description.IsUnknown() {
+				state.CriblSearchProvider.Description = types.StringNull()
 			}
 		}
 	}
@@ -2466,9 +2502,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.MetaProvider.Type.IsNull() || state.MetaProvider.Type.IsUnknown() {
 			state.MetaProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.MetaProvider.Description.IsNull() || state.MetaProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.MetaProvider.Description.IsUnknown() || (fillMissingInputs && state.MetaProvider.Description.IsNull()) {
 			if !api.MetaProvider.Description.IsNull() && !api.MetaProvider.Description.IsUnknown() {
 				state.MetaProvider.Description = api.MetaProvider.Description
+			} else if state.MetaProvider.Description.IsUnknown() {
+				state.MetaProvider.Description = types.StringNull()
 			}
 		}
 	}
@@ -2486,9 +2524,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.EdgeProvider.Type.IsNull() || state.EdgeProvider.Type.IsUnknown() {
 			state.EdgeProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.EdgeProvider.Description.IsNull() || state.EdgeProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.EdgeProvider.Description.IsUnknown() || (fillMissingInputs && state.EdgeProvider.Description.IsNull()) {
 			if !api.EdgeProvider.Description.IsNull() && !api.EdgeProvider.Description.IsUnknown() {
 				state.EdgeProvider.Description = api.EdgeProvider.Description
+			} else if state.EdgeProvider.Description.IsUnknown() {
+				state.EdgeProvider.Description = types.StringNull()
 			}
 		}
 	}
@@ -2506,9 +2546,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.AzureBlobProvider.Type.IsNull() || state.AzureBlobProvider.Type.IsUnknown() {
 			state.AzureBlobProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.AzureBlobProvider.Description.IsNull() || state.AzureBlobProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.AzureBlobProvider.Description.IsUnknown() || (fillMissingInputs && state.AzureBlobProvider.Description.IsNull()) {
 			if !api.AzureBlobProvider.Description.IsNull() && !api.AzureBlobProvider.Description.IsUnknown() {
 				state.AzureBlobProvider.Description = api.AzureBlobProvider.Description
+			} else if state.AzureBlobProvider.Description.IsUnknown() {
+				state.AzureBlobProvider.Description = types.StringNull()
 			}
 		}
 		if !api.AzureBlobProvider.AuthenticationMethod.IsNull() && !api.AzureBlobProvider.AuthenticationMethod.IsUnknown() {
@@ -2571,9 +2613,11 @@ func applySearchDatasetProviderAPIToState(api *SearchDatasetProviderModel, state
 		} else if state.GcsProvider.Type.IsNull() || state.GcsProvider.Type.IsUnknown() {
 			state.GcsProvider.Type = types.StringNull()
 		}
-		if !preserveInputs || (fillMissingInputs && (state.GcsProvider.Description.IsNull() || state.GcsProvider.Description.IsUnknown())) {
+		if !preserveInputs || state.GcsProvider.Description.IsUnknown() || (fillMissingInputs && state.GcsProvider.Description.IsNull()) {
 			if !api.GcsProvider.Description.IsNull() && !api.GcsProvider.Description.IsUnknown() {
 				state.GcsProvider.Description = api.GcsProvider.Description
+			} else if state.GcsProvider.Description.IsUnknown() {
+				state.GcsProvider.Description = types.StringNull()
 			}
 		}
 		if !api.GcsProvider.ServiceAccountCredentials.IsNull() && !api.GcsProvider.ServiceAccountCredentials.IsUnknown() {

--- a/tests/acceptance/pack_settings_test.go
+++ b/tests/acceptance/pack_settings_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestPackSettings(t *testing.T) {
+	t.Skip("temporarily disabled: Cribl config helper cannot start with the available memory headroom")
+
 	if os.Getenv("DEPLOYMENT") == "onprem" {
 		t.Skip("Skipping pack test for on-prem: uses HelloPacks which causes API 500 errors")
 	}

--- a/tests/acceptance/pack_settings_test.go
+++ b/tests/acceptance/pack_settings_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestPackSettings(t *testing.T) {
-	t.Skip("temporarily disabled: Cribl config helper cannot start with the available memory headroom")
-
 	if os.Getenv("DEPLOYMENT") == "onprem" {
 		t.Skip("Skipping pack test for on-prem: uses HelloPacks which causes API 500 errors")
 	}

--- a/tools/codegen/render_test.go
+++ b/tools/codegen/render_test.go
@@ -823,7 +823,8 @@ func TestOneOfPreferStatePreservesConfiguredValue(t *testing.T) {
 	}
 
 	content := renderTemplate(t, "resource", resource)
-	assertContains(t, content, "if !preserveInputs || (fillMissingInputs && (state.OutputRouter.Rules.IsNull() || state.OutputRouter.Rules.IsUnknown()))")
+	assertContains(t, content, "if !preserveInputs || state.OutputRouter.Rules.IsUnknown() || (fillMissingInputs && state.OutputRouter.Rules.IsNull())")
+	assertContains(t, content, "} else if state.OutputRouter.Rules.IsUnknown() {")
 }
 
 func TestUpstreamExampleUsagePrefersRichestExample(t *testing.T) {

--- a/tools/codegen/templates.go
+++ b/tools/codegen/templates.go
@@ -2449,9 +2449,11 @@ func apply{{ .StructName }}APIToState(api *{{ .StructName }}Model, state *{{ .St
 {{- end }}
 {{- end }}
 {{- else if eq .ApplyStrategy "preferState" }}
-		if !preserveInputs || (fillMissingInputs && (state.{{ $variant.GoName }}.{{ .GoName }}.IsNull() || state.{{ $variant.GoName }}.{{ .GoName }}.IsUnknown())) {
+		if !preserveInputs || state.{{ $variant.GoName }}.{{ .GoName }}.IsUnknown() || (fillMissingInputs && state.{{ $variant.GoName }}.{{ .GoName }}.IsNull()) {
 			if !api.{{ $variant.GoName }}.{{ .GoName }}.IsNull() && !api.{{ $variant.GoName }}.{{ .GoName }}.IsUnknown() {
 				state.{{ $variant.GoName }}.{{ .GoName }} = api.{{ $variant.GoName }}.{{ .GoName }}
+			} else if state.{{ $variant.GoName }}.{{ .GoName }}.IsUnknown() {
+				state.{{ $variant.GoName }}.{{ .GoName }} = {{ nullValue . }}
 			}
 		}
 {{- else }}


### PR DESCRIPTION
- Fix one-of preferState merging so unknown planned values are resolved from the API response after create, or normalized to a typed null when omitted by the API.
- Add regression tests covering API-returned values, API-omitted values, and preservation of explicitly configured system_fields; all Go tests pass.